### PR TITLE
Publish portable agent skills

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 scripts/validate.py
+      - run: python3 -m py_compile skills/spin-worktree/scripts/spin-worktree.py
+      - run: node --check skills/drive-local-webapp/scripts/driver.mjs
+      - run: node --check skills/drive-local-webapp/scripts/self-check.mjs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,11 +12,44 @@ jobs:
   skills:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - run: python3 scripts/validate.py
-      - run: python3 -m py_compile skills/spin-worktree/scripts/spin-worktree.py
-      - run: node --check skills/drive-local-webapp/scripts/driver.mjs
-      - run: node --check skills/drive-local-webapp/scripts/self-check.mjs
+      - name: Validate skill pack and reachable history
+        run: python3 scripts/validate.py
+      - name: Run public-interface behavior tests
+        run: python3 -m unittest -v tests.test_behavior
+      - name: Check DCO
+        if: github.event_name == 'pull_request'
+        run: >-
+          python3 scripts/check_dco.py
+          "${{ github.event.pull_request.base.sha }}"
+          "${{ github.event.pull_request.head.sha }}"
+      - name: Check Python, JavaScript, and shell syntax
+        run: |
+          python3 -m py_compile skills/spin-worktree/scripts/spin-worktree.py
+          node --check skills/drive-local-webapp/scripts/driver.mjs
+          node --check skills/drive-local-webapp/scripts/self-check.mjs
+          sh -n skills/cbm-onboard/scripts/cbm-onboard.sh
+          sh -n skills/cbm-onboard/scripts/cbm-reindex.sh
+      - name: Fresh-install through the standard skills CLI
+        run: >-
+          npx --yes skills@1.5.20 add . --skill '*'
+          --agent codex --copy --yes
+      - name: Verify installed skills
+        run: |
+          test -f .agents/skills/ui-mockups/SKILL.md
+          test -f .agents/skills/drive-local-webapp/SKILL.md
+          test -f .agents/skills/cbm-onboard/SKILL.md
+          test -f .agents/skills/spin-worktree/SKILL.md
+      - name: Install pinned browser driver dependencies
+        working-directory: skills/drive-local-webapp
+        run: |
+          npm ci
+          npx playwright install chromium
+      - name: Run browser driver self-check
+        working-directory: skills/drive-local-webapp
+        run: npm run self-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+*.png
+*.capture.json
+.DS_Store
+__pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Open an issue before making a large behavioral change. Small fixes can go
+directly to a pull request.
+
+Keep each skill self-contained, concise, and portable:
+
+- Put triggering context in `SKILL.md` frontmatter.
+- Keep machine-specific paths, personal data, credentials, generated files,
+  and copied third-party skills out of the repository.
+- Bundle deterministic helpers under the skill's `scripts/` directory.
+- Document optional upstream dependencies rather than copying them.
+- Run `python3 scripts/validate.py` before opening a pull request.
+
+## Developer Certificate of Origin
+
+Every commit must certify the
+[Developer Certificate of Origin 1.1](https://developercertificate.org/) by
+including a `Signed-off-by` trailer:
+
+```sh
+git commit -s -m "Describe the change"
+```
+
+By signing off, you certify that you have the right to submit the contribution
+under this repository's license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Connor Griffin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+Connor Griffin's agent skills
+Copyright 2026 Connor Griffin
+
+The ui-mockups workflow composes with, but does not redistribute, skills from
+Matt Pocock's public skills repository:
+https://github.com/mattpocock/skills
+
+The installation examples use the open source skills CLI:
+https://github.com/vercel-labs/skills
+
+Third-party product and project names are used only to identify compatible
+tools and remain the property of their respective owners.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# skills
-Portable skills for coding agents
+# Connor Griffin's agent skills
+
+Portable workflows for coding agents. Each skill is self-contained under
+[`skills/`](skills/) and works with clients that support the Agent Skills
+format.
+
+## Included skills
+
+| Skill | Purpose | Extra requirement |
+| --- | --- | --- |
+| [`ui-mockups`](skills/ui-mockups/SKILL.md) | Explore grounded UI directions and lock one visual spec before implementation | `drive-local-webapp` for rendered review; parallel-agent support is recommended |
+| [`drive-local-webapp`](skills/drive-local-webapp/SKILL.md) | Drive and screenshot a local web app with headless Chromium | Node.js 20+; installs Playwright locally |
+| [`cbm-onboard`](skills/cbm-onboard/SKILL.md) | Index a repository with codebase-memory-mcp and keep it current | `codebase-memory-mcp` on `PATH` |
+| [`spin-worktree`](skills/spin-worktree/SKILL.md) | Create isolated Git worktrees for issue and PR work | Git; GitHub CLI only for `--pr` discovery |
+
+## Install
+
+Install one skill with the standard [`skills` CLI](https://github.com/vercel-labs/skills):
+
+```sh
+npx skills add ConnorGriffin/skills --skill ui-mockups
+```
+
+Install the UI workflow and its browser driver together:
+
+```sh
+npx skills add ConnorGriffin/skills \
+  --skill ui-mockups \
+  --skill drive-local-webapp
+```
+
+Install every skill:
+
+```sh
+npx skills add ConnorGriffin/skills --all
+```
+
+The CLI prompts for the target agents and whether to install per-project or
+globally. Review skill instructions and scripts before running them; several
+skills intentionally start processes, modify repositories, or install Git
+hooks.
+
+## Optional upstream skills
+
+`ui-mockups` can use interviewing, design-system, and module-design skills when
+they are already installed. Those are optional enhancements, not hidden runtime
+requirements. Install them from their owners rather than from this repository:
+
+```sh
+npx skills add mattpocock/skills --skill grilling --skill codebase-design
+```
+
+The workflow also recognizes an installed `impeccable` skill for its final
+visual-quality gate.
+
+## Development
+
+Run the repository checks with:
+
+```sh
+python3 scripts/validate.py
+```
+
+Contributions require a Signed-off-by trailer under the
+[Developer Certificate of Origin](CONTRIBUTING.md#developer-certificate-of-origin).
+
+## License and support
+
+Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE). Security reports belong
+in the private channel described in [SECURITY.md](SECURITY.md); everything else
+uses GitHub issues.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Connor Griffin's agent skills
 
-Portable workflows for coding agents. Each skill is self-contained under
-[`skills/`](skills/) and works with clients that support the Agent Skills
-format.
+A portable skill pack for coding agents. Skills live under [`skills/`](skills/)
+and work with clients that support the Agent Skills format. Some skills compose:
+the UI workflow uses the bundled browser driver for rendered evidence.
 
 ## Included skills
 
@@ -15,18 +15,19 @@ format.
 
 ## Install
 
-Install one skill with the standard [`skills` CLI](https://github.com/vercel-labs/skills):
-
-```sh
-npx skills add ConnorGriffin/skills --skill ui-mockups
-```
-
-Install the UI workflow and its browser driver together:
+Install the primary UI workflow with its required browser driver using the
+standard [`skills` CLI](https://github.com/vercel-labs/skills):
 
 ```sh
 npx skills add ConnorGriffin/skills \
   --skill ui-mockups \
   --skill drive-local-webapp
+```
+
+Install another skill by itself:
+
+```sh
+npx skills add ConnorGriffin/skills --skill spin-worktree
 ```
 
 Install every skill:
@@ -42,16 +43,23 @@ hooks.
 
 ## Optional upstream skills
 
-`ui-mockups` can use interviewing, design-system, and module-design skills when
-they are already installed. Those are optional enhancements, not hidden runtime
-requirements. Install them from their owners rather than from this repository:
+Optional integrations are enhancements, not hidden runtime requirements:
+
+- **Codebase Memory:** accelerates structural exploration. Without it, use
+  ordinary repository search and file reads.
+- **`grilling`:** sharpens the UI brief. Without it, run the short inline
+  interview described by `ui-mockups`.
+- **`codebase-design`:** helps shape non-trivial render logic. Without it, keep
+  the shipping module shape and preserve locality.
+- **`impeccable`:** adds a final visual-quality audit. Without it, run the
+  explicit contrast, focus, overflow, and target-size checks.
+
+Install Matt Pocock's optional skills from their owner rather than copying them
+into this pack:
 
 ```sh
 npx skills add mattpocock/skills --skill grilling --skill codebase-design
 ```
-
-The workflow also recognizes an installed `impeccable` skill for its final
-visual-quality gate.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security
+
+Do not open a public issue for a vulnerability or accidentally published
+secret. Report it through
+[GitHub private vulnerability reporting](https://github.com/ConnorGriffin/skills/security/advisories/new).
+
+Include the affected skill, a minimal reproduction, and the practical impact.
+You should receive an acknowledgement within seven days. There is no guaranteed
+support window or compatibility promise for these beta skills.
+
+Each skill may run commands or modify a repository when explicitly invoked.
+Review its `SKILL.md` and bundled scripts before installation or use.

--- a/scripts/check_dco.py
+++ b/scripts/check_dco.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Require a valid Signed-off-by trailer on every commit in a revision range."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+
+SIGNOFF = re.compile(
+    r"^Signed-off-by:\s+.+\s+<[^<>\s@]+@[^<>\s@]+>$",
+    re.MULTILINE,
+)
+
+
+def git(*arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", *arguments],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip())
+    return completed.stdout
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: check_dco.py <base-sha> <head-sha>", file=sys.stderr)
+        return 2
+    base, head = sys.argv[1:]
+    try:
+        commits = git("rev-list", "--reverse", f"{base}..{head}").splitlines()
+        missing = [
+            revision
+            for revision in commits
+            if not SIGNOFF.search(git("show", "-s", "--format=%B", revision))
+        ]
+    except RuntimeError as error:
+        print(f"DCO check failed: {error}", file=sys.stderr)
+        return 2
+    if missing:
+        print(
+            "Missing valid Signed-off-by trailer: " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+    print(f"DCO_OK commits={len(commits)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate public skill structure and catch common disclosure mistakes."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = ROOT / "skills"
+EXPECTED = {"ui-mockups", "drive-local-webapp", "cbm-onboard", "spin-worktree"}
+FORBIDDEN = (
+    re.compile("/" + "Users/"),
+    re.compile("~/" + "Code/" + "ConnorGriffin"),
+    re.compile("Connor's " + r"(?:real browser|rule)"),
+    re.compile("t" + "connect", re.IGNORECASE),
+    re.compile(r"BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+)
+LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+
+
+def fail(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def validate_frontmatter(path: Path, errors: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not match:
+        fail(errors, f"{path.relative_to(ROOT)}: missing YAML frontmatter")
+        return
+    fields = {
+        line.split(":", 1)[0].strip()
+        for line in match.group(1).splitlines()
+        if ":" in line
+    }
+    if fields != {"name", "description"}:
+        fail(
+            errors,
+            f"{path.relative_to(ROOT)}: frontmatter must contain only name and description",
+        )
+    name_match = re.search(r"^name:\s*(.+)$", match.group(1), re.MULTILINE)
+    if not name_match or name_match.group(1).strip() != path.parent.name:
+        fail(errors, f"{path.relative_to(ROOT)}: name must match directory")
+    if len(text.splitlines()) > 500:
+        fail(errors, f"{path.relative_to(ROOT)}: exceeds 500 lines")
+
+
+def validate_links(path: Path, errors: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for target in LINK.findall(text):
+        target = target.split("#", 1)[0]
+        if not target or "://" in target or target.startswith("mailto:"):
+            continue
+        resolved = (path.parent / target).resolve()
+        if ROOT not in resolved.parents and resolved != ROOT:
+            fail(errors, f"{path.relative_to(ROOT)}: link escapes repository: {target}")
+        elif not resolved.exists():
+            fail(errors, f"{path.relative_to(ROOT)}: broken link: {target}")
+
+
+def main() -> int:
+    errors: list[str] = []
+    actual = {path.name for path in SKILLS.iterdir() if path.is_dir()}
+    if actual != EXPECTED:
+        fail(errors, f"skills: expected {sorted(EXPECTED)}, found {sorted(actual)}")
+
+    tracked_candidates = [
+        path
+        for path in ROOT.rglob("*")
+        if path.is_file() and ".git" not in path.parts and "node_modules" not in path.parts
+    ]
+    for path in tracked_candidates:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            fail(errors, f"{path.relative_to(ROOT)}: unexpected binary file")
+            continue
+        for pattern in FORBIDDEN:
+            if pattern.search(text):
+                fail(errors, f"{path.relative_to(ROOT)}: forbidden pattern {pattern.pattern!r}")
+        if path.suffix == ".md":
+            validate_links(path, errors)
+
+    for skill in sorted(EXPECTED):
+        skill_file = SKILLS / skill / "SKILL.md"
+        if not skill_file.exists():
+            fail(errors, f"skills/{skill}: missing SKILL.md")
+            continue
+        validate_frontmatter(skill_file, errors)
+        metadata = SKILLS / skill / "agents" / "openai.yaml"
+        if not metadata.exists():
+            fail(errors, f"skills/{skill}: missing agents/openai.yaml")
+
+    if errors:
+        print("\n".join(f"ERROR: {error}" for error in errors), file=sys.stderr)
+        return 1
+    print(f"validated {len(EXPECTED)} skills and {len(tracked_candidates)} files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -15,11 +16,29 @@ FORBIDDEN = (
     re.compile("/" + "Users/"),
     re.compile("~/" + "Code/" + "ConnorGriffin"),
     re.compile("Connor's " + r"(?:real browser|rule)"),
+    re.compile("nt" + "fy", re.IGNORECASE),
     re.compile("t" + "connect", re.IGNORECASE),
     re.compile(r"BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
 )
 LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+HISTORY_PATTERN = "|".join(
+    (
+        "/" + "Users/",
+        "~/" + "Code/" + "ConnorGriffin",
+        "Connor's " + "(real browser|rule)",
+        "nt" + "fy",
+        "t" + "connect",
+        "BEGIN (RSA |OPENSSH |EC )?PRIVATE KEY",
+        "gh[pousr]_[A-Za-z0-9_]{20,}",
+        "AKIA[0-9A-Z]{16}",
+        "sk-[A-Za-z0-9]{20,}",
+        "xox[baprs]-[A-Za-z0-9-]{10,}",
+    )
+)
 
 
 def fail(errors: list[str], message: str) -> None:
@@ -62,6 +81,51 @@ def validate_links(path: Path, errors: list[str]) -> None:
             fail(errors, f"{path.relative_to(ROOT)}: broken link: {target}")
 
 
+def validate_reachable_history(errors: list[str]) -> None:
+    commits = subprocess.run(
+        ["git", "rev-list", "--all"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if commits.returncode != 0:
+        fail(errors, f"history scan failed: {commits.stderr.strip()}")
+        return
+    for revision in commits.stdout.splitlines():
+        scan = subprocess.run(
+            ["git", "grep", "-I", "-q", "-E", HISTORY_PATTERN, revision, "--", "."],
+            cwd=ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if scan.returncode == 0:
+            fail(errors, f"reachable history contains a forbidden value at {revision}")
+        elif scan.returncode != 1:
+            fail(errors, f"history content scan failed at {revision}")
+
+    objects = subprocess.run(
+        ["git", "rev-list", "--objects", "--all"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if objects.returncode != 0:
+        fail(errors, f"history path scan failed: {objects.stderr.strip()}")
+        return
+    for line in objects.stdout.splitlines():
+        _, separator, object_path = line.partition(" ")
+        if not separator:
+            continue
+        for pattern in FORBIDDEN:
+            if pattern.search(object_path):
+                fail(errors, f"reachable history contains a forbidden path")
+
+
 def main() -> int:
     errors: list[str] = []
     actual = {path.name for path in SKILLS.iterdir() if path.is_dir()}
@@ -94,6 +158,8 @@ def main() -> int:
         metadata = SKILLS / skill / "agents" / "openai.yaml"
         if not metadata.exists():
             fail(errors, f"skills/{skill}: missing agents/openai.yaml")
+
+    validate_reachable_history(errors)
 
     if errors:
         print("\n".join(f"ERROR: {error}" for error in errors), file=sys.stderr)

--- a/skills/cbm-onboard/SKILL.md
+++ b/skills/cbm-onboard/SKILL.md
@@ -25,8 +25,10 @@ project. Never index a directory containing several repositories.
 
    The script resolves linked worktrees to the maintained checkout, reconciles
    a marked baseline inside `.cbmignore`, preserves custom exclusions, and adds
-   a managed reindex block to `.git/hooks/post-commit` without deleting an
-   existing hook.
+   a managed reindex block to Git's configured `post-commit` hook without
+   deleting an existing shell hook. It refuses symlink targets. A non-shell
+   foreign hook is left unchanged with a warning because composing it would be
+   unsafe.
 
 3. Verify the project through the available Codebase Memory MCP interface with
    `index_status` or `list_projects`.

--- a/skills/cbm-onboard/SKILL.md
+++ b/skills/cbm-onboard/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: cbm-onboard
+description: Register a Git repository with codebase-memory-mcp, create a managed .cbmignore baseline, install a non-clobbering post-commit reindex hook, and run the initial index. Use when asked to index, onboard, register, or keep a repository current in Codebase Memory.
+---
+
+# Onboard a repository to Codebase Memory
+
+Use the bundled script to make one maintained checkout one Codebase Memory
+project. Never index a directory containing several repositories.
+
+## Requirements
+
+- Install `codebase-memory-mcp` and make its executable available on `PATH`, or
+  set `CODEBASE_MEMORY_BIN` to the executable path.
+- Resolve the installed `cbm-onboard` skill directory.
+
+## Workflow
+
+1. Resolve the target Git repository. Default to the current repository.
+2. Run:
+
+   ```sh
+   <cbm-onboard-skill-directory>/scripts/cbm-onboard.sh <repo-path>
+   ```
+
+   The script resolves linked worktrees to the maintained checkout, reconciles
+   a marked baseline inside `.cbmignore`, preserves custom exclusions, and adds
+   a managed reindex block to `.git/hooks/post-commit` without deleting an
+   existing hook.
+
+3. Verify the project through the available Codebase Memory MCP interface with
+   `index_status` or `list_projects`.
+4. Report node and edge counts when available.
+5. Tell the user that `.cbmignore` is tracked and should be committed. The Git
+   hook is clone-local, so rerun onboarding after a fresh clone.
+
+The initial index uses full mode. Post-commit indexing uses fast mode in a
+detached process. Re-running onboarding is idempotent.
+
+Repositories dominated by YAML, prose, or shell may produce a thin graph; say
+so rather than refusing to index them.

--- a/skills/cbm-onboard/agents/openai.yaml
+++ b/skills/cbm-onboard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codebase Memory Onboard"
+  short_description: "Index and keep a repository graph current"
+  default_prompt: "Use $cbm-onboard to register this repository with codebase-memory-mcp."

--- a/skills/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/cbm-onboard/scripts/cbm-onboard.sh
@@ -19,6 +19,22 @@ ROOT="$(git -C "$TARGET" worktree list --porcelain 2>/dev/null |
   exit 1
 }
 
+IGNORE="$ROOT/.cbmignore"
+HOOK_PATH="$(git -C "$ROOT" rev-parse --git-path hooks/post-commit)"
+case "$HOOK_PATH" in
+  /*) HOOK="$HOOK_PATH" ;;
+  *) HOOK="$ROOT/$HOOK_PATH" ;;
+esac
+
+[ ! -L "$IGNORE" ] || {
+  printf 'refusing symlink target: %s\n' "$IGNORE" >&2
+  exit 1
+}
+[ ! -L "$HOOK" ] || {
+  printf 'refusing symlink target: %s\n' "$HOOK" >&2
+  exit 1
+}
+
 BEGIN_IGNORE="# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
 END_IGNORE="# <<< cbm-onboard managed baseline <<<"
 BEGIN_HOOK="# >>> cbm-onboard managed reindex >>>"
@@ -35,11 +51,12 @@ trap 'rm -f "$MANAGED_TMP" "$OUTPUT_TMP" "$HOOK_TMP"' EXIT
     ".pytest_cache/" ".mypy_cache/" ".ruff_cache/" ".tox/" \
     "node_modules/" "dist/" "build/" "*.egg-info/" \
     ".agentflow/" ".claude/worktrees/" ".codex/worktrees/" \
-    "*.db" "*.sqlite" "*.sqlite3" "*.csv" "*.parquet" ".env" "*.log"
+    "*.db" "*.sqlite" "*.sqlite3" "*.csv" "*.parquet" \
+    ".env" ".env.*" "*.pem" "*.key" "*.p12" "*.pfx" \
+    ".aws/" ".ssh/" ".secrets/" "secrets/" "credentials/" "*.log"
   printf '%s\n' "$END_IGNORE"
 } >"$MANAGED_TMP"
 
-IGNORE="$ROOT/.cbmignore"
 EXISTING="/dev/null"
 [ -e "$IGNORE" ] && EXISTING="$IGNORE"
 
@@ -55,12 +72,18 @@ awk -v begin="$BEGIN_IGNORE" -v end="$END_IGNORE" '
       if (rtrim(lines[i]) == begin) {
         found = 0
         for (j = i + 1; j <= n; j++) {
+          if (rtrim(lines[j]) == begin) { break }
           if (rtrim(lines[j]) == end) { found = j; break }
         }
         if (found) { i = found + 1; continue }
+        custom[++custom_n] = lines[i]
         i++; continue
       }
-      if (rtrim(lines[i]) == end || lines[i] in managed_set) { i++; continue }
+      if (rtrim(lines[i]) == end) {
+        custom[++custom_n] = lines[i]
+        i++; continue
+      }
+      if (lines[i] in managed_set) { i++; continue }
       custom[++custom_n] = lines[i]
       i++
     }
@@ -82,27 +105,55 @@ else
   printf '%s\n' "$IGNORE is already current"
 fi
 
-GIT_DIR="$(git -C "$ROOT" rev-parse --absolute-git-dir)"
-HOOK="$GIT_DIR/hooks/post-commit"
 mkdir -p "$(dirname "$HOOK")"
+INSTALL_HOOK=1
 if [ -e "$HOOK" ]; then
-  awk -v begin="$BEGIN_HOOK" -v end="$END_HOOK" '
-    $0 == begin { skipping = 1; next }
-    $0 == end { skipping = 0; next }
-    !skipping { print }
-  ' "$HOOK" >"$HOOK_TMP"
+  FIRST_LINE="$(sed -n '1p' "$HOOK")"
+  if ! printf '%s\n' "$FIRST_LINE" |
+    grep -Eq '^#!.*[/[:space:]](ba|da|k|z)?sh([[:space:]]|$)'; then
+    printf 'SKIP hook installation: existing hook is not a shell script; left unchanged: %s\n' \
+      "$HOOK" >&2
+    INSTALL_HOOK=0
+  fi
 else
   printf '%s\n' "#!/bin/sh" >"$HOOK_TMP"
 fi
 
-{
-  printf '\n%s\n' "$BEGIN_HOOK"
-  printf '"%s" "%s"\n' "$REINDEX" "$ROOT"
-  printf '%s\n' "$END_HOOK"
-} >>"$HOOK_TMP"
-cp "$HOOK_TMP" "$HOOK"
-chmod +x "$HOOK"
-printf '%s\n' "installed managed reindex command in $HOOK"
+if [ "$INSTALL_HOOK" -eq 1 ]; then
+  if [ -e "$HOOK" ]; then
+    awk -v begin="$BEGIN_HOOK" -v end="$END_HOOK" '
+      { lines[++n] = $0 }
+      END {
+        i = 1
+        while (i <= n) {
+          if (lines[i] == begin) {
+            found = 0
+            for (j = i + 1; j <= n; j++) {
+              if (lines[j] == begin) { break }
+              if (lines[j] == end) { found = j; break }
+            }
+            if (found) {
+              if (out_n > 0 && output[out_n] == "") out_n--
+              i = found + 1
+              continue
+            }
+          }
+          output[++out_n] = lines[i]
+          i++
+        }
+        for (i = 1; i <= out_n; i++) print output[i]
+      }
+    ' "$HOOK" >"$HOOK_TMP"
+  fi
+  {
+    printf '\n%s\n' "$BEGIN_HOOK"
+    printf '"%s" "%s"\n' "$REINDEX" "$ROOT"
+    printf '%s\n' "$END_HOOK"
+  } >>"$HOOK_TMP"
+  cp "$HOOK_TMP" "$HOOK"
+  chmod +x "$HOOK"
+  printf '%s\n' "installed managed reindex command in $HOOK"
+fi
 
 PAYLOAD="$(python3 -c \
   'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "full"}))' \

--- a/skills/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/cbm-onboard/scripts/cbm-onboard.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Register a repository with codebase-memory-mcp without clobbering local rules.
+
+set -eu
+
+BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true)}"
+[ -n "$BIN" ] && [ -x "$BIN" ] || {
+  printf '%s\n' "codebase-memory-mcp is not executable; install it or set CODEBASE_MEMORY_BIN" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REINDEX="$SCRIPT_DIR/cbm-reindex.sh"
+TARGET="${1:-.}"
+ROOT="$(git -C "$TARGET" worktree list --porcelain 2>/dev/null |
+  awk '/^worktree / { print substr($0, 10); exit }')"
+[ -n "$ROOT" ] || {
+  printf 'not a Git repository: %s\n' "$TARGET" >&2
+  exit 1
+}
+
+BEGIN_IGNORE="# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
+END_IGNORE="# <<< cbm-onboard managed baseline <<<"
+BEGIN_HOOK="# >>> cbm-onboard managed reindex >>>"
+END_HOOK="# <<< cbm-onboard managed reindex <<<"
+MANAGED_TMP="$(mktemp)"
+OUTPUT_TMP="$(mktemp)"
+HOOK_TMP="$(mktemp)"
+trap 'rm -f "$MANAGED_TMP" "$OUTPUT_TMP" "$HOOK_TMP"' EXIT
+
+{
+  printf '%s\n' "$BEGIN_IGNORE"
+  printf '%s\n' \
+    ".venv/" "venv/" "env/" "__pycache__/" "*.pyc" \
+    ".pytest_cache/" ".mypy_cache/" ".ruff_cache/" ".tox/" \
+    "node_modules/" "dist/" "build/" "*.egg-info/" \
+    ".agentflow/" ".claude/worktrees/" ".codex/worktrees/" \
+    "*.db" "*.sqlite" "*.sqlite3" "*.csv" "*.parquet" ".env" "*.log"
+  printf '%s\n' "$END_IGNORE"
+} >"$MANAGED_TMP"
+
+IGNORE="$ROOT/.cbmignore"
+EXISTING="/dev/null"
+[ -e "$IGNORE" ] && EXISTING="$IGNORE"
+
+awk -v begin="$BEGIN_IGNORE" -v end="$END_IGNORE" '
+  function rtrim(s) { sub(/[ \t]+$/, "", s); return s }
+  FNR == NR { managed[FNR] = $0; managed_set[$0] = 1; managed_n = FNR; next }
+  { lines[++n] = $0 }
+  END {
+    for (i = 1; i <= managed_n; i++) print managed[i]
+    custom_n = 0
+    i = 1
+    while (i <= n) {
+      if (rtrim(lines[i]) == begin) {
+        found = 0
+        for (j = i + 1; j <= n; j++) {
+          if (rtrim(lines[j]) == end) { found = j; break }
+        }
+        if (found) { i = found + 1; continue }
+        i++; continue
+      }
+      if (rtrim(lines[i]) == end || lines[i] in managed_set) { i++; continue }
+      custom[++custom_n] = lines[i]
+      i++
+    }
+    first = 1
+    last = custom_n
+    while (first <= last && custom[first] == "") first++
+    while (last >= first && custom[last] == "") last--
+    if (last >= first) {
+      print ""
+      for (i = first; i <= last; i++) print custom[i]
+    }
+  }
+' "$MANAGED_TMP" "$EXISTING" >"$OUTPUT_TMP"
+
+if [ ! -e "$IGNORE" ] || ! cmp -s "$OUTPUT_TMP" "$IGNORE"; then
+  cp "$OUTPUT_TMP" "$IGNORE"
+  printf '%s\n' "updated $IGNORE"
+else
+  printf '%s\n' "$IGNORE is already current"
+fi
+
+GIT_DIR="$(git -C "$ROOT" rev-parse --absolute-git-dir)"
+HOOK="$GIT_DIR/hooks/post-commit"
+mkdir -p "$(dirname "$HOOK")"
+if [ -e "$HOOK" ]; then
+  awk -v begin="$BEGIN_HOOK" -v end="$END_HOOK" '
+    $0 == begin { skipping = 1; next }
+    $0 == end { skipping = 0; next }
+    !skipping { print }
+  ' "$HOOK" >"$HOOK_TMP"
+else
+  printf '%s\n' "#!/bin/sh" >"$HOOK_TMP"
+fi
+
+{
+  printf '\n%s\n' "$BEGIN_HOOK"
+  printf '"%s" "%s"\n' "$REINDEX" "$ROOT"
+  printf '%s\n' "$END_HOOK"
+} >>"$HOOK_TMP"
+cp "$HOOK_TMP" "$HOOK"
+chmod +x "$HOOK"
+printf '%s\n' "installed managed reindex command in $HOOK"
+
+PAYLOAD="$(python3 -c \
+  'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "full"}))' \
+  "$ROOT")"
+"$BIN" cli index_repository "$PAYLOAD"
+printf '%s\n' "indexed $ROOT"

--- a/skills/cbm-onboard/scripts/cbm-reindex.sh
+++ b/skills/cbm-onboard/scripts/cbm-reindex.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Reindex one maintained checkout in fast mode after a commit.
+
+set -u
+
+BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true)}"
+[ -n "$BIN" ] && [ -x "$BIN" ] || exit 0
+
+ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+[ -n "$ROOT" ] || exit 0
+
+MAIN_ROOT="$(git -C "$ROOT" worktree list --porcelain 2>/dev/null |
+  awk '/^worktree / { print substr($0, 10); exit }')"
+[ -n "$MAIN_ROOT" ] || exit 0
+[ "$ROOT" = "$MAIN_ROOT" ] || exit 0
+
+PAYLOAD="$(python3 -c \
+  'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "fast"}))' \
+  "$ROOT")" || exit 0
+
+nohup "$BIN" cli index_repository "$PAYLOAD" \
+  >/dev/null 2>&1 </dev/null &

--- a/skills/drive-local-webapp/SKILL.md
+++ b/skills/drive-local-webapp/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: drive-local-webapp
+description: Launch or connect to a local development web server and drive it with a reusable headless-Chromium command interface. Use when asked to render, smoke-test, interact with, verify, or screenshot a local frontend or HTML mockup.
+---
+
+# Drive a local web app
+
+Use the bundled Playwright driver instead of writing a one-off browser script.
+It keeps one page alive while reading commands from standard input and reports
+each command as `OK` or `FAIL`.
+
+## One-time setup
+
+Resolve this installed skill's directory, then run:
+
+```sh
+cd <drive-local-webapp-skill-directory>
+npm ci
+npx playwright install chromium
+```
+
+Node.js 20 or newer is recommended. Browser binaries are cached by Playwright.
+Verify the installation reproducibly:
+
+```sh
+npm run self-check
+```
+
+## Workflow
+
+1. Start the target application's normal development or demo server. Use
+   throwaway fixtures, never production or personal data. Check that the chosen
+   port is free before binding it.
+2. Run `node scripts/driver.mjs` from this skill directory and pipe one command
+   per line:
+
+   ```sh
+   DRIVER_SCREENSHOT_DIR=/tmp/webapp-shots node scripts/driver.mjs <<'EOF'
+   nav http://127.0.0.1:8766/
+   wait-for text=Dashboard
+   click button:text-is("Settings")
+   fill input[placeholder="API token"] :: demo-token
+   click button:text-is("Save")
+   screenshot
+   console --errors
+   EOF
+   ```
+
+3. Treat any `FAIL` line or non-zero exit as a failed check. Treat a non-empty
+   `CONSOLE_ERRORS` array as a failed check unless the error is explicitly
+   expected.
+4. Inspect the screenshot itself. File existence does not prove the intended UI
+   rendered.
+
+If the host sandbox blocks Chromium process creation, rerun the same driver
+command with the client's narrowly scoped approval mechanism. Do not reinstall
+Chromium or alter the application to work around a host permission error.
+
+Only navigate to a local page you trust or a URL the user explicitly placed in
+scope. Headless Chromium is not a security boundary: page JavaScript can make
+network requests and exercise the permissions available to the browser process.
+Do not use this driver as a general-purpose browser for untrusted sites.
+
+## Commands
+
+```text
+nav <url>
+wait-for <selector>
+click <selector>
+fill <selector> :: <value>
+set <selector> :: <value>
+press <key>
+wait <milliseconds>
+eval <javascript-expression>
+screenshot [absolute-path]
+console --errors
+```
+
+Use `:text-is("Label")` for exact text. Playwright's `:has-text()` is
+case-insensitive substring matching and can silently click the wrong control.
+
+Keep screenshots outside the target repository. The driver defaults to the
+system temporary directory, or use `DRIVER_SCREENSHOT_DIR`.
+
+## Common failures
+
+- Selectors containing spaces require the literal ` :: ` separator for
+  `fill` and `set`.
+- Hidden tab content may exist in the DOM; click the actual tab before waiting
+  on its contents.
+- Charts initialized inside `display:none` containers may have zero width.
+  Activate the tab, wait, and verify the app resizes or lazily initializes the
+  chart.
+- A client-side token gate may leave the screen loading without a console
+  error. Inspect the application's setup UI and use a demo token.

--- a/skills/drive-local-webapp/SKILL.md
+++ b/skills/drive-local-webapp/SKILL.md
@@ -80,7 +80,8 @@ Use `:text-is("Label")` for exact text. Playwright's `:has-text()` is
 case-insensitive substring matching and can silently click the wrong control.
 
 Keep screenshots outside the target repository. The driver defaults to the
-system temporary directory, or use `DRIVER_SCREENSHOT_DIR`.
+system temporary directory, or use `DRIVER_SCREENSHOT_DIR`. It refuses to
+overwrite an existing screenshot path.
 
 ## Common failures
 

--- a/skills/drive-local-webapp/agents/openai.yaml
+++ b/skills/drive-local-webapp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Drive Local Web App"
+  short_description: "Verify local web apps in headless Chromium"
+  default_prompt: "Use $drive-local-webapp to smoke-test and screenshot this local web app."

--- a/skills/drive-local-webapp/package-lock.json
+++ b/skills/drive-local-webapp/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "drive-local-webapp-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "drive-local-webapp-skill",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/skills/drive-local-webapp/package.json
+++ b/skills/drive-local-webapp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "drive-local-webapp-skill",
+  "private": true,
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Reusable Playwright command driver bundled with the drive-local-webapp skill.",
+  "scripts": {
+    "self-check": "node scripts/self-check.mjs"
+  },
+  "dependencies": {
+    "playwright": "1.61.1"
+  }
+}

--- a/skills/drive-local-webapp/scripts/driver.mjs
+++ b/skills/drive-local-webapp/scripts/driver.mjs
@@ -15,7 +15,7 @@
 
 import { chromium } from "playwright";
 import { createInterface } from "node:readline";
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -27,6 +27,17 @@ let shotCount = 0;
 
 function selector(value) {
   return value.startsWith("text=") ? `text=${value.slice(5)}` : value;
+}
+
+async function writeNewScreenshot(file, contents) {
+  try {
+    await writeFile(file, contents, { flag: "wx" });
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      throw new Error(`screenshot path already exists: ${file}`);
+    }
+    throw error;
+  }
 }
 
 async function launchBrowser() {
@@ -118,7 +129,8 @@ async function main() {
         if (!path.isAbsolute(file)) {
           throw new Error("screenshot path must be absolute");
         }
-        await page.screenshot({ path: file, fullPage: true });
+        const screenshot = await page.screenshot({ fullPage: true });
+        await writeNewScreenshot(file, screenshot);
         console.log(`OK screenshot ${file}`);
       } else if (command === "console" && argument === "--errors") {
         console.log(`CONSOLE_ERRORS ${JSON.stringify(consoleErrors)}`);

--- a/skills/drive-local-webapp/scripts/driver.mjs
+++ b/skills/drive-local-webapp/scripts/driver.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Read one browser command per line from stdin and execute it against one page.
+//
+// Commands:
+//   nav <url>
+//   wait-for <selector>
+//   click <selector>
+//   fill <selector> :: <value>
+//   set <selector> :: <value>
+//   press <key>
+//   wait <milliseconds>
+//   eval <javascript-expression>
+//   screenshot [absolute-path]
+//   console --errors
+
+import { chromium } from "playwright";
+import { createInterface } from "node:readline";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const screenshotDir =
+  process.env.DRIVER_SCREENSHOT_DIR ||
+  path.join(tmpdir(), "drive-local-webapp");
+const consoleErrors = [];
+let shotCount = 0;
+
+function selector(value) {
+  return value.startsWith("text=") ? `text=${value.slice(5)}` : value;
+}
+
+async function launchBrowser() {
+  try {
+    return await chromium.launch();
+  } catch (error) {
+    const detail = String(error?.message || error);
+    const macPermissionError =
+      process.platform === "darwin" &&
+      /MachPortRendezvous|bootstrap_check_in/.test(detail) &&
+      /Permission denied \(1100\)/.test(detail);
+    if (!macPermissionError) throw error;
+
+    try {
+      return await chromium.launch({
+        args: ["--no-sandbox", "--single-process"],
+      });
+    } catch (fallbackError) {
+      console.error(
+        "HEADLESS-SANDBOX-BLOCKED: rerun this driver with the host client's " +
+          "narrow approval for starting Chromium.\n" +
+          String(fallbackError?.message || fallbackError),
+      );
+      process.exit(77);
+    }
+  }
+}
+
+async function main() {
+  const browser = await launchBrowser();
+  const page = await browser.newPage();
+  let failed = false;
+
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => consoleErrors.push(String(error)));
+
+  const input = createInterface({ input: process.stdin, terminal: false });
+  for await (const rawLine of input) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const firstSpace = line.indexOf(" ");
+    const command = firstSpace === -1 ? line : line.slice(0, firstSpace);
+    const argument =
+      firstSpace === -1 ? "" : line.slice(firstSpace + 1).trim();
+
+    try {
+      if (command === "nav") {
+        await page.goto(argument, { waitUntil: "domcontentloaded" });
+        console.log(`OK nav ${argument}`);
+      } else if (command === "wait-for") {
+        await page.waitForSelector(selector(argument), { timeout: 15000 });
+        console.log(`OK wait-for ${argument}`);
+      } else if (command === "click") {
+        await page.click(selector(argument), { timeout: 15000 });
+        console.log(`OK click ${argument}`);
+      } else if (command === "fill" || command === "set") {
+        const separator = argument.indexOf(" :: ");
+        if (separator === -1) {
+          throw new Error(`${command} needs "<selector> :: <value>"`);
+        }
+        const target = argument.slice(0, separator).trim();
+        const value = argument.slice(separator + 4);
+        await page.fill(selector(target), value, { timeout: 15000 });
+        if (command === "set") {
+          await page.dispatchEvent(selector(target), "change");
+        }
+        console.log(`OK ${command} ${target}`);
+      } else if (command === "press") {
+        await page.keyboard.press(argument);
+        console.log(`OK press ${argument}`);
+      } else if (command === "wait") {
+        const milliseconds = Number(argument);
+        if (!Number.isFinite(milliseconds) || milliseconds < 0) {
+          throw new Error("wait needs a non-negative number");
+        }
+        await page.waitForTimeout(milliseconds);
+        console.log(`OK wait ${milliseconds}ms`);
+      } else if (command === "eval") {
+        const result = await page.evaluate(argument);
+        console.log(`OK eval -> ${JSON.stringify(result)}`);
+      } else if (command === "screenshot") {
+        await mkdir(screenshotDir, { recursive: true });
+        shotCount += 1;
+        const file =
+          argument || path.join(screenshotDir, `${shotCount}.png`);
+        if (!path.isAbsolute(file)) {
+          throw new Error("screenshot path must be absolute");
+        }
+        await page.screenshot({ path: file, fullPage: true });
+        console.log(`OK screenshot ${file}`);
+      } else if (command === "console" && argument === "--errors") {
+        console.log(`CONSOLE_ERRORS ${JSON.stringify(consoleErrors)}`);
+      } else {
+        throw new Error(`unknown command: ${command}`);
+      }
+    } catch (error) {
+      failed = true;
+      const summary = String(error?.message || error).split("\n")[0];
+      console.log(`FAIL ${line} :: ${summary}`);
+    }
+  }
+
+  await browser.close();
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/skills/drive-local-webapp/scripts/self-check.mjs
+++ b/skills/drive-local-webapp/scripts/self-check.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const driver = path.join(directory, "driver.mjs");
+const page =
+  "data:text/html," +
+  encodeURIComponent(
+    '<h1 id="ready">Ready</h1><button id="go" onclick="this.textContent=\'Clicked\'">Go</button>',
+  );
+const commands = [
+  `nav ${page}`,
+  "wait-for #ready",
+  "click #go",
+  'eval document.querySelector("#go").textContent',
+  "console --errors",
+  "",
+].join("\n");
+
+const child = spawn(process.execPath, [driver], {
+  stdio: ["pipe", "pipe", "inherit"],
+});
+let output = "";
+child.stdout.setEncoding("utf8");
+child.stdout.on("data", (chunk) => {
+  output += chunk;
+  process.stdout.write(chunk);
+});
+child.stdin.end(commands);
+
+child.on("exit", (status) => {
+  const expected = [
+    "OK wait-for #ready",
+    'OK eval -> "Clicked"',
+    "CONSOLE_ERRORS []",
+  ];
+  if (status !== 0 || expected.some((line) => !output.includes(line))) {
+    console.error("SELF_CHECK_FAILED");
+    process.exit(1);
+  }
+  console.log("SELF_CHECK_OK");
+});

--- a/skills/drive-local-webapp/scripts/self-check.mjs
+++ b/skills/drive-local-webapp/scripts/self-check.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -11,35 +13,60 @@ const page =
   encodeURIComponent(
     '<h1 id="ready">Ready</h1><button id="go" onclick="this.textContent=\'Clicked\'">Go</button>',
   );
-const commands = [
+
+function runDriver(commands) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [driver], {
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    let output = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+      process.stdout.write(chunk);
+    });
+    child.on("error", reject);
+    child.on("exit", (status) => resolve({ output, status }));
+    child.stdin.end([...commands, ""].join("\n"));
+  });
+}
+
+const success = await runDriver([
   `nav ${page}`,
   "wait-for #ready",
   "click #go",
   'eval document.querySelector("#go").textContent',
   "console --errors",
-  "",
-].join("\n");
+]);
+const expected = [
+  "OK wait-for #ready",
+  'OK eval -> "Clicked"',
+  "CONSOLE_ERRORS []",
+];
+if (
+  success.status !== 0 ||
+  expected.some((line) => !success.output.includes(line))
+) {
+  console.error("SELF_CHECK_FAILED");
+  process.exit(1);
+}
 
-const child = spawn(process.execPath, [driver], {
-  stdio: ["pipe", "pipe", "inherit"],
-});
-let output = "";
-child.stdout.setEncoding("utf8");
-child.stdout.on("data", (chunk) => {
-  output += chunk;
-  process.stdout.write(chunk);
-});
-child.stdin.end(commands);
+const scratch = await mkdtemp(path.join(tmpdir(), "drive-local-webapp-check-"));
+const existing = path.join(scratch, "existing.png");
+await writeFile(existing, "sentinel", "utf8");
+const overwrite = await runDriver([
+  `nav ${page}`,
+  `screenshot ${existing}`,
+]);
+const unchanged = await readFile(existing, "utf8");
+await rm(scratch, { recursive: true });
+if (
+  overwrite.status === 0 ||
+  !overwrite.output.includes("screenshot path already exists") ||
+  unchanged !== "sentinel"
+) {
+  console.error("SELF_CHECK_OVERWRITE_FAILED");
+  process.exit(1);
+}
 
-child.on("exit", (status) => {
-  const expected = [
-    "OK wait-for #ready",
-    'OK eval -> "Clicked"',
-    "CONSOLE_ERRORS []",
-  ];
-  if (status !== 0 || expected.some((line) => !output.includes(line))) {
-    console.error("SELF_CHECK_FAILED");
-    process.exit(1);
-  }
-  console.log("SELF_CHECK_OK");
-});
+console.log("SELF_CHECK_OK");

--- a/skills/spin-worktree/SKILL.md
+++ b/skills/spin-worktree/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: spin-worktree
+description: Create an isolated Git worktree for issue, pull-request, branch, or parallel agent work without editing the control checkout. Use when starting task work from fresh remote state, avoiding a dirty or shared checkout, or preparing a dedicated worktree for another agent.
+---
+
+# Spin an isolated worktree
+
+Keep the ordinary checkout as the control checkout and create one worktree per
+task. The bundled helper refuses to update a dirty control checkout.
+
+By default worktrees live under `${AGENT_WORKTREE_ROOT:-~/worktrees}`:
+
+```text
+~/worktrees/<repository>/<task>
+```
+
+## Workflow
+
+1. Resolve the control repository and pass it explicitly with `--repo`.
+2. Resolve this installed skill's directory.
+3. Run one of the commands below.
+4. Report the exact path and use it as the working directory.
+5. Do not remove the worktree automatically. Cleanup belongs to task closeout
+   after merge.
+
+New issue branch:
+
+```sh
+python3 <spin-worktree-skill-directory>/scripts/spin-worktree.py \
+  --repo /path/to/repository \
+  --issue 317 \
+  --slug rescue-context
+```
+
+Existing pull-request branch, discovered with GitHub CLI:
+
+```sh
+python3 <spin-worktree-skill-directory>/scripts/spin-worktree.py \
+  --repo /path/to/repository \
+  --pr 321
+```
+
+Existing branch:
+
+```sh
+python3 <spin-worktree-skill-directory>/scripts/spin-worktree.py \
+  --repo /path/to/repository \
+  --branch codex/issue-316 \
+  --name pr321
+```
+
+Use `--dry-run` to inspect commands. Override defaults with
+`--worktree-root`, `--remote`, `--base`, or `--branch-prefix`.
+
+## Guardrails
+
+- Use one worktree path and branch per task.
+- Never switch branches in another agent's active worktree.
+- Do not reuse an existing target path unless inspection proves it belongs to
+  the same task.
+- New issue work updates the remote and starts from its current default branch
+  unless `--base` is supplied.
+- Pull-request discovery requires authenticated `gh`; known branch names do
+  not.

--- a/skills/spin-worktree/SKILL.md
+++ b/skills/spin-worktree/SKILL.md
@@ -60,5 +60,8 @@ Use `--dry-run` to inspect commands. Override defaults with
   the same task.
 - New issue work updates the remote and starts from its current default branch
   unless `--base` is supplied.
-- Pull-request discovery requires authenticated `gh`; known branch names do
-  not.
+- Existing local branches do not require a remote.
+- Pull-request discovery requires authenticated `gh`. A same-repository head
+  is fetched when needed. A fork head fails with the exact fork and branch to
+  configure, rather than pretending it exists under `origin`.
+- `--name` accepts one relative directory leaf, never a path.

--- a/skills/spin-worktree/agents/openai.yaml
+++ b/skills/spin-worktree/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Spin Worktree"
+  short_description: "Create isolated Git worktrees for tasks"
+  default_prompt: "Use $spin-worktree to create an isolated worktree for this task."

--- a/skills/spin-worktree/scripts/spin-worktree.py
+++ b/skills/spin-worktree/scripts/spin-worktree.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Create an isolated Git worktree for issue or branch work."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_ROOT = Path(
+    os.environ.get("AGENT_WORKTREE_ROOT", str(Path.home() / "worktrees"))
+).expanduser()
+DEFAULT_REMOTE = "origin"
+
+
+class SpinError(RuntimeError):
+    """A safe, user-facing worktree setup failure."""
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Optional[Path] = None,
+    capture: bool = False,
+    dry_run: bool = False,
+) -> str:
+    print("$ " + " ".join(command), flush=True)
+    if dry_run:
+        return ""
+    options: dict[str, object] = {"text": True}
+    if cwd is not None:
+        options["cwd"] = str(cwd)
+    if capture:
+        options["stdout"] = subprocess.PIPE
+        options["stderr"] = subprocess.PIPE
+    try:
+        completed = subprocess.run(command, check=True, **options)
+    except FileNotFoundError as error:
+        raise SpinError(f"required command not found: {command[0]}") from error
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() if capture and error.stderr else ""
+        raise SpinError(detail or f"command exited {error.returncode}") from error
+    return str(completed.stdout).strip() if capture else ""
+
+
+def git(
+    repo: Path, *arguments: str, capture: bool = False, dry_run: bool = False
+) -> str:
+    return run(
+        ["git", "-C", str(repo), *arguments],
+        capture=capture,
+        dry_run=dry_run,
+    )
+
+
+def slugify(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "task"
+
+
+def repository_root(path: Path) -> Path:
+    try:
+        value = run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            capture=True,
+        )
+    except SpinError as error:
+        raise SpinError(f"{path} is not a Git checkout") from error
+    return Path(value).resolve()
+
+
+def require_clean(repo: Path, *, dry_run: bool) -> None:
+    if dry_run:
+        return
+    if git(repo, "status", "--short", capture=True):
+        raise SpinError(f"control checkout is dirty: {repo}")
+
+
+def local_branch_exists(repo: Path, branch: str) -> bool:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            f"refs/heads/{branch}",
+        ],
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def remote_default_branch(repo: Path, remote: str) -> str:
+    symbolic = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            f"refs/remotes/{remote}/HEAD",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    if symbolic.returncode == 0 and symbolic.stdout.strip():
+        return symbolic.stdout.strip().removeprefix(f"{remote}/")
+    for candidate in ("main", "master"):
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                f"refs/remotes/{remote}/{candidate}",
+            ],
+            check=False,
+        )
+        if result.returncode == 0:
+            return candidate
+    raise SpinError(f"cannot determine the default branch for remote {remote}")
+
+
+def discover_pr_branch(repo: Path, pull_request: int) -> str:
+    value = run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pull_request),
+            "--json",
+            "headRefName",
+            "--jq",
+            ".headRefName",
+        ],
+        cwd=repo,
+        capture=True,
+    )
+    if not value:
+        raise SpinError(f"could not resolve pull request #{pull_request}")
+    return value
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="control checkout")
+    parser.add_argument("--worktree-root", default=str(DEFAULT_ROOT))
+    parser.add_argument("--remote", default=DEFAULT_REMOTE)
+    parser.add_argument("--base", help="base branch for new issue work")
+    parser.add_argument("--branch-prefix", default="codex")
+    parser.add_argument("--issue", type=int)
+    parser.add_argument("--slug")
+    parser.add_argument("--pr", type=int)
+    parser.add_argument("--branch")
+    parser.add_argument("--name", help="worktree directory name")
+    parser.add_argument("--dry-run", action="store_true")
+    arguments = parser.parse_args()
+
+    modes = (
+        arguments.issue is not None,
+        arguments.pr is not None,
+        arguments.branch is not None,
+    )
+    if sum(modes) != 1:
+        parser.error("choose exactly one of --issue, --pr, or --branch")
+    if arguments.slug and arguments.issue is None:
+        parser.error("--slug requires --issue")
+    return arguments
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        repo = repository_root(Path(arguments.repo).expanduser())
+        require_clean(repo, dry_run=arguments.dry_run)
+        root = Path(arguments.worktree_root).expanduser().resolve()
+
+        if arguments.issue is not None:
+            git(repo, "fetch", arguments.remote, dry_run=arguments.dry_run)
+            base = arguments.base or remote_default_branch(repo, arguments.remote)
+            branch_slug = slugify(arguments.slug or f"issue-{arguments.issue}")
+            branch = (
+                f"{arguments.branch_prefix}/{arguments.issue}-{branch_slug}"
+                if arguments.slug
+                else f"{arguments.branch_prefix}/issue-{arguments.issue}"
+            )
+            task_name = arguments.name or str(arguments.issue)
+            start_point = f"{arguments.remote}/{base}"
+            new_branch = True
+        else:
+            branch = arguments.branch or discover_pr_branch(repo, arguments.pr)
+            git(
+                repo,
+                "fetch",
+                arguments.remote,
+                branch,
+                dry_run=arguments.dry_run,
+            )
+            task_name = arguments.name or (
+                f"pr{arguments.pr}" if arguments.pr else slugify(branch)
+            )
+            start_point = branch
+            new_branch = not local_branch_exists(repo, branch)
+            if new_branch:
+                git(
+                    repo,
+                    "branch",
+                    "--track",
+                    branch,
+                    f"{arguments.remote}/{branch}",
+                    dry_run=arguments.dry_run,
+                )
+                new_branch = False
+
+        destination = root / repo.name / task_name
+        if not arguments.dry_run and destination.exists():
+            raise SpinError(f"target already exists: {destination}")
+
+        command = ["worktree", "add", str(destination)]
+        if new_branch:
+            command.extend(["-b", branch, start_point])
+        else:
+            command.append(branch)
+        git(repo, *command, dry_run=arguments.dry_run)
+    except SpinError as error:
+        print(f"spin-worktree: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "repo": str(repo),
+                "worktree": str(destination),
+                "branch": branch,
+                "dry_run": arguments.dry_run,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/spin-worktree/scripts/spin-worktree.py
+++ b/skills/spin-worktree/scripts/spin-worktree.py
@@ -63,6 +63,18 @@ def slugify(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "task"
 
 
+def safe_leaf(value: str) -> str:
+    if (
+        not value
+        or value in {".", ".."}
+        or Path(value).is_absolute()
+        or "/" in value
+        or "\\" in value
+    ):
+        raise SpinError("--name must be one safe relative directory name")
+    return value
+
+
 def repository_root(path: Path) -> Path:
     try:
         value = run(
@@ -140,16 +152,27 @@ def discover_pr_branch(repo: Path, pull_request: int) -> str:
             "view",
             str(pull_request),
             "--json",
-            "headRefName",
-            "--jq",
-            ".headRefName",
+            "headRefName,isCrossRepository,headRepository,headRepositoryOwner",
         ],
         cwd=repo,
         capture=True,
     )
-    if not value:
+    try:
+        metadata = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise SpinError(f"could not resolve pull request #{pull_request}") from error
+    branch = metadata.get("headRefName")
+    if not branch:
         raise SpinError(f"could not resolve pull request #{pull_request}")
-    return value
+    if metadata.get("isCrossRepository"):
+        owner = (metadata.get("headRepositoryOwner") or {}).get("login", "unknown")
+        repository = (metadata.get("headRepository") or {}).get("name", "unknown")
+        raise SpinError(
+            f"pull request #{pull_request} comes from fork {owner}/{repository}; "
+            "add that fork as a Git remote, fetch its head branch, then rerun with "
+            f"--branch {branch}"
+        )
+    return str(branch)
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -182,6 +205,8 @@ def parse_arguments() -> argparse.Namespace:
 def main() -> int:
     arguments = parse_arguments()
     try:
+        if arguments.name is not None:
+            safe_leaf(arguments.name)
         repo = repository_root(Path(arguments.repo).expanduser())
         require_clean(repo, dry_run=arguments.dry_run)
         root = Path(arguments.worktree_root).expanduser().resolve()
@@ -195,24 +220,25 @@ def main() -> int:
                 if arguments.slug
                 else f"{arguments.branch_prefix}/issue-{arguments.issue}"
             )
-            task_name = arguments.name or str(arguments.issue)
+            task_name = safe_leaf(arguments.name or str(arguments.issue))
             start_point = f"{arguments.remote}/{base}"
             new_branch = True
         else:
             branch = arguments.branch or discover_pr_branch(repo, arguments.pr)
-            git(
-                repo,
-                "fetch",
-                arguments.remote,
-                branch,
-                dry_run=arguments.dry_run,
-            )
-            task_name = arguments.name or (
-                f"pr{arguments.pr}" if arguments.pr else slugify(branch)
+            task_name = safe_leaf(
+                arguments.name
+                or (f"pr{arguments.pr}" if arguments.pr else slugify(branch))
             )
             start_point = branch
             new_branch = not local_branch_exists(repo, branch)
             if new_branch:
+                git(
+                    repo,
+                    "fetch",
+                    arguments.remote,
+                    branch,
+                    dry_run=arguments.dry_run,
+                )
                 git(
                     repo,
                     "branch",

--- a/skills/ui-mockups/SKILL.md
+++ b/skills/ui-mockups/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: ui-mockups
+description: Explore a UI surface as several radically different, repository-grounded HTML mockups, render them, and converge on a locked visual specification. Use when asked to design, mock up, compare, or redesign a screen, dashboard, flow, or component before implementation.
+---
+
+# UI mockups
+
+Produce several genuinely different HTML mockups using the target application's
+real visual language, data shape, and rendering stack. Render every variant,
+iterate with the reviewer, and preserve one locked mockup as the implementation
+specification.
+
+Use `drive-local-webapp` to render and exercise the mockups. If it is not
+installed, ask to install it from this repository before the screenshot phase.
+Use parallel subagents when the client supports them. Optional interviewing,
+module-design, and visual-audit skills may improve the workflow, but their
+absence is not a blocker.
+
+## Choose the review mode
+
+- **Interactive mode:** keep the server running, give the user the live URLs,
+  and wait for their choice before locking a direction.
+- **AgentFlow/headless mode:** never wait for browser review. Render the required
+  states, inspect screenshots and console output, choose the direction that best
+  satisfies the brief, and lock it. Produce the screenshots in the
+  orchestrator's evidence/artifact directory plus
+  `mockups/<surface>.locked.md`: a contract of at most 150 words stating the
+  chosen concept, primary behavior, required states, details implementation
+  must preserve, and evidence paths.
+
+## Ground rules
+
+1. **Ground every variant.**
+   - Read `DESIGN.md` and `PRODUCT.md` when present, then verify their claims
+     against the shipping frontend.
+   - Lift actual light and dark theme tokens, fonts, radii, and shadows.
+   - Use the application's shipping UI or chart library at its shipping version.
+   - Prefer a deliberately manufactured fixture with the real schema. A
+     captured payload must come from a throwaway development/demo environment.
+     Never collect production, private, personal, health, credential, or
+     customer data for a mockup.
+   - Fork relevant render logic so the winner can be lifted into the app.
+2. **Vary the concept, not the decoration.** Change the layout metaphor,
+   information hierarchy, interaction model, or visualization. Three variants
+   that differ only in color are one design.
+3. **Mark throwaway chrome.** Label variant switchers, seed controls, and other
+   mock-only scaffolding in comments.
+4. **Inspect rendered output.** Source review alone does not validate a visual
+   artifact.
+
+## Workflow
+
+### 1. Establish the ledger
+
+Read `mockups/INDEX.md`. Create it if absent. Record one row per surface:
+
+```markdown
+| Surface | Concept | Status | Issue | File |
+| --- | --- | --- | --- | --- |
+```
+
+Treat `locked` entries as binding precedent for adjacent surfaces. For
+`shipped` entries, use the application itself as ground truth rather than old
+mockup markup.
+
+### 2. Build a grounding kit
+
+Collect:
+
+- the relevant screen and its primary user question;
+- visual tokens and their source files;
+- the UI/chart library and version;
+- the shipping render module or component;
+- the real data shape from a safe fixture or throwaway demo environment;
+- required states such as empty, typical, dense, error, mobile, light, and dark.
+
+Save runtime captures as `mockups/<surface>.capture.json` and add
+`*.capture.json` to `.gitignore`. Do not commit captures unless they are
+deliberately manufactured fixtures containing no sensitive data.
+
+### 3. Fix the brief
+
+Define one surface, one decision, hard constraints, states to render, and three
+or four named concept directions. A short inline interview is enough when no
+interviewing skill is installed.
+
+### 4. Fan out
+
+Give one fresh subagent exactly one concept. Fill in
+[the variant prompt](references/variant-agent-prompt.md) with the grounding kit
+and shared brief. Each agent writes:
+
+- `mockups/<surface>-<concept>.html`;
+- `mockups/<surface>-<concept>-chart.js` when rendering logic is non-trivial.
+
+If parallel agents are unavailable, create the variants sequentially while
+keeping each concept brief isolated from the others.
+
+### 5. Render and inspect
+
+Serve `mockups/` over HTTP, then use `drive-local-webapp` to render every
+required state. Store screenshots in a temporary directory outside the
+repository. Inspect the actual images and console errors.
+
+In interactive mode, keep the server alive for review. Open the served URLs
+when the environment and user permit browser control; otherwise return the
+URLs. In AgentFlow/headless mode, save the rendered evidence and continue
+without opening a browser or waiting for a person.
+
+### 6. Review tersely and iterate
+
+For each variant, give one line describing its design bet and one line of
+judgment. Recommend one direction. Incorporate review feedback in a new render
+round rather than arguing from source.
+
+### 7. Lock the winner
+
+For interaction-heavy finalists, walk the primary task with two or three useful
+perspectives: an impatient expert, a confused first-time user, a keyboard-only
+user, a stress tester, or a distracted mobile user. Name the first concrete
+element that stalls each walkthrough and fix it.
+
+Run an installed visual-audit skill on the finalist when available; otherwise
+check contrast, keyboard focus, responsive overflow, and target sizes directly.
+Then:
+
+1. Add a `LOCKED` header comment to the winning HTML and companion JavaScript.
+2. In AgentFlow/headless mode, write the required 150-word-or-shorter locked
+   contract and retain its evidence screenshots.
+3. Delete losing variants and their screenshots.
+4. Update `mockups/INDEX.md` with status `locked`.
+5. Reference the locked file from the implementation issue.
+
+After implementation ships, set the ledger row to `shipped` and archive the
+mockup. The application then becomes the source of truth.

--- a/skills/ui-mockups/SKILL.md
+++ b/skills/ui-mockups/SKILL.md
@@ -12,9 +12,18 @@ specification.
 
 Use `drive-local-webapp` to render and exercise the mockups. If it is not
 installed, ask to install it from this repository before the screenshot phase.
-Use parallel subagents when the client supports them. Optional interviewing,
-module-design, and visual-audit skills may improve the workflow, but their
-absence is not a blocker.
+Use parallel subagents when the client supports them.
+
+Optional integrations have explicit fallbacks:
+
+- Use Codebase Memory for structural discovery when available; otherwise use
+  repository search and direct file reads.
+- Use `grilling` to sharpen the brief when installed; otherwise run the inline
+  interview in step 3.
+- Use `codebase-design` for a non-trivial render module when installed;
+  otherwise preserve the shipping module shape and keep the logic local.
+- Use `impeccable` for the final craft gate when installed; otherwise perform
+  the manual checks in step 7.
 
 ## Choose the review mode
 

--- a/skills/ui-mockups/agents/openai.yaml
+++ b/skills/ui-mockups/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UI Mockups"
+  short_description: "Design grounded UI variants before implementation"
+  default_prompt: "Use $ui-mockups to explore and lock visual directions for this UI surface."

--- a/skills/ui-mockups/references/variant-agent-prompt.md
+++ b/skills/ui-mockups/references/variant-agent-prompt.md
@@ -1,0 +1,43 @@
+# Per-variant prompt
+
+Fill every placeholder. Give one fresh subagent one concept and no sibling
+implementation details.
+
+```markdown
+Design one UI mockup variant. Commit to the assigned concept; do not blend it
+with the sibling directions.
+
+## Assigned concept
+
+<concept name> — <layout, visualization, and interaction bet; explain how it
+differs from the named sibling concepts>
+
+## Surface and decision
+
+<screen or component, the one question it must answer, and hard constraints>
+
+## Grounding kit
+
+- Theme: <tokens copied from the named source files, light and dark>
+- UI/chart library: <library, exact version, and existing loading pattern>
+- Data: `fetch('./<surface>.capture.json')` using <real field names and shape>
+- Render source: <shipping module or component to fork>
+
+Use only the safe development fixture or captured demo payload supplied here.
+Do not access production, customer, credential, health, or personal data.
+
+## Required states
+
+<empty, typical, dense, error, mobile, light, dark, or named fixture states>
+
+## Deliverables
+
+- `mockups/<surface>-<concept>.html`
+- `mockups/<surface>-<concept>-chart.js` when rendering is non-trivial
+
+Lift the shipping theme and library. Bind the real fields. Mark mock-only
+controls with a `not part of the real app` comment. Do not start a server or
+take screenshots; the orchestrator handles rendering.
+
+Report the files written and one sentence describing the design bet.
+```

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CBM_SCRIPT = ROOT / "skills" / "cbm-onboard" / "scripts" / "cbm-onboard.sh"
+SPIN_SCRIPT = ROOT / "skills" / "spin-worktree" / "scripts" / "spin-worktree.py"
+BEGIN_IGNORE = "# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
+BEGIN_HOOK = "# >>> cbm-onboard managed reindex >>>"
+
+
+def run(
+    command: list[str], *, cwd: Path, env: Optional[dict[str, str]] = None
+):
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+class CbmOnboardTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.scratch = Path(self.temporary.name)
+        self.repo = self.scratch / "repo"
+        self.repo.mkdir()
+        result = run(["git", "init", "-b", "main"], cwd=self.repo)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.binary = self.scratch / "codebase-memory-mcp"
+        self.binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        self.binary.chmod(0o755)
+        self.environment = os.environ.copy()
+        self.environment["CODEBASE_MEMORY_BIN"] = str(self.binary)
+        self.environment["PRIVATE_SENTINEL"] = "must-not-appear"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def onboard(self):
+        result = run(
+            [str(CBM_SCRIPT), str(self.repo)],
+            cwd=ROOT,
+            env=self.environment,
+        )
+        self.assertNotIn("must-not-appear", result.stdout + result.stderr)
+        return result
+
+    def test_refuses_cbmignore_symlink_without_touching_target(self):
+        target = self.scratch / "outside-ignore"
+        target.write_text("sentinel\n", encoding="utf-8")
+        (self.repo / ".cbmignore").symlink_to(target)
+
+        result = self.onboard()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing symlink target", result.stderr)
+        self.assertEqual(target.read_text(encoding="utf-8"), "sentinel\n")
+
+    def test_refuses_hook_symlink_and_honors_core_hooks_path(self):
+        run(
+            ["git", "config", "core.hooksPath", ".custom-hooks"],
+            cwd=self.repo,
+        )
+        hooks = self.repo / ".custom-hooks"
+        hooks.mkdir()
+        target = self.scratch / "outside-hook"
+        target.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        (hooks / "post-commit").symlink_to(target)
+
+        result = self.onboard()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing symlink target", result.stderr)
+        self.assertEqual(
+            target.read_text(encoding="utf-8"),
+            "#!/bin/sh\nexit 0\n",
+        )
+        self.assertFalse((self.repo / ".git" / "hooks" / "post-commit").exists())
+
+    def test_preserves_unmatched_markers_foreign_hook_and_is_idempotent(self):
+        run(
+            ["git", "config", "core.hooksPath", ".custom-hooks"],
+            cwd=self.repo,
+        )
+        hooks = self.repo / ".custom-hooks"
+        hooks.mkdir()
+        ignore_original = f"custom-before/\n{BEGIN_IGNORE}\ncustom-after/\n"
+        hook_original = (
+            "#!/bin/sh\n"
+            "printf '%s\\n' foreign-hook\n"
+            f"{BEGIN_HOOK}\n"
+            "printf '%s\\n' after-unmatched-marker\n"
+        )
+        (self.repo / ".cbmignore").write_text(ignore_original, encoding="utf-8")
+        hook = hooks / "post-commit"
+        hook.write_text(hook_original, encoding="utf-8")
+        hook.chmod(0o755)
+
+        first = self.onboard()
+        self.assertEqual(first.returncode, 0, first.stderr)
+        first_ignore = (self.repo / ".cbmignore").read_bytes()
+        first_hook = hook.read_bytes()
+        second = self.onboard()
+        self.assertEqual(second.returncode, 0, second.stderr)
+
+        self.assertEqual((self.repo / ".cbmignore").read_bytes(), first_ignore)
+        self.assertEqual(hook.read_bytes(), first_hook)
+        self.assertIn(ignore_original, first_ignore.decode())
+        self.assertIn(hook_original, first_hook.decode())
+        for exclusion in (".env.*", "*.pem", "*.key", "credentials/", "secrets/"):
+            self.assertIn(exclusion, first_ignore.decode())
+        self.assertFalse((self.repo / ".git" / "hooks" / "post-commit").exists())
+
+    def test_skips_non_shell_foreign_hook_without_modifying_it(self):
+        run(
+            ["git", "config", "core.hooksPath", ".custom-hooks"],
+            cwd=self.repo,
+        )
+        hooks = self.repo / ".custom-hooks"
+        hooks.mkdir()
+        hook = hooks / "post-commit"
+        original = "#!/usr/bin/env python3\nprint('foreign')\n"
+        hook.write_text(original, encoding="utf-8")
+        hook.chmod(0o755)
+
+        result = self.onboard()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("SKIP hook installation", result.stderr)
+        self.assertEqual(hook.read_text(encoding="utf-8"), original)
+
+
+class SpinWorktreeTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.scratch = Path(self.temporary.name)
+        self.repo = self.scratch / "repo"
+        self.repo.mkdir()
+        self.assertEqual(
+            run(["git", "init", "-b", "main"], cwd=self.repo).returncode,
+            0,
+        )
+        run(["git", "config", "user.name", "Test User"], cwd=self.repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=self.repo)
+        (self.repo / "README.md").write_text("fixture\n", encoding="utf-8")
+        run(["git", "add", "README.md"], cwd=self.repo)
+        self.assertEqual(
+            run(["git", "commit", "-m", "fixture"], cwd=self.repo).returncode,
+            0,
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def spin(self, *arguments: str):
+        return run(
+            [
+                "python3",
+                str(SPIN_SCRIPT),
+                "--repo",
+                str(self.repo),
+                "--worktree-root",
+                str(self.scratch / "worktrees"),
+                *arguments,
+            ],
+            cwd=ROOT,
+        )
+
+    def test_rejects_names_that_can_escape_the_task_directory(self):
+        for unsafe in ("", ".", "..", "../escape", "nested/name", "nested\\name", "/tmp/x"):
+            with self.subTest(unsafe=unsafe):
+                result = self.spin(
+                    "--issue",
+                    "1",
+                    "--name",
+                    unsafe,
+                    "--dry-run",
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("one safe relative directory name", result.stderr)
+        self.assertFalse((self.scratch / "escape").exists())
+
+    def test_uses_an_existing_local_branch_without_an_origin_remote(self):
+        run(["git", "branch", "local-topic"], cwd=self.repo)
+
+        result = self.spin(
+            "--branch",
+            "local-topic",
+            "--name",
+            "local-topic",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(
+            (self.scratch / "worktrees" / "repo" / "local-topic" / ".git").exists()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Publishes four portable coding-agent skills:

- compare grounded UI directions and lock one before implementation;
- verify a trusted local web app in headless Chromium;
- register a repository with Codebase Memory and keep its graph current;
- create isolated worktrees for issue and pull-request work.

The repository also establishes Apache-2.0 licensing, contribution and security
terms, standard installation commands, and an automated portability check.

## Why

These workflows previously lived in one private machine setup. AgentFlow and
other users need a versioned, recoverable source that does not assume Connor's
paths, private data, or private repositories.

## What to check

- UI work supports both live human review and unattended AgentFlow review.
- Optional Matt Pocock and visual-quality skills are referenced, not copied.
- Browser automation warns against untrusted pages and passes its self-check.
- Codebase Memory onboarding preserves existing ignore rules and Git hooks.
- No private paths, captured data, credentials, or generated screenshots are
  present.

## Validation

- Repository validator
- Official skill validator for all four skills
- Python, JavaScript, and shell syntax checks
- Browser driver self-check
- Worktree dry run
- Private-path, endpoint, credential-pattern, and disclosure scan
