### PR TITLE
Grow the pack to twelve skills and relicense to MIT

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,10 +41,10 @@ jobs:
           --agent codex --copy --yes
       - name: Verify installed skills
         run: |
-          test -f .agents/skills/ui-mockups/SKILL.md
-          test -f .agents/skills/drive-local-webapp/SKILL.md
-          test -f .agents/skills/cbm-onboard/SKILL.md
-          test -f .agents/skills/spin-worktree/SKILL.md
+          for skill in ui-mockups drive-local-webapp cbm-onboard spin-worktree \
+            research interface-craft implement tdd review prototype grilling wayfinder; do
+            test -f ".agents/skills/$skill/SKILL.md"
+          done
       - name: Install pinned browser driver dependencies
         working-directory: skills/drive-local-webapp
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,14 @@ directly to a pull request.
 Keep each skill self-contained, concise, and portable:
 
 - Put triggering context in `SKILL.md` frontmatter.
-- Keep machine-specific paths, personal data, credentials, generated files,
-  and copied third-party skills out of the repository.
+- Keep machine-specific paths, personal data, credentials, and generated files
+  out of the repository.
+- Third-party skills may be included only under a compatible license with
+  attribution preserved in `LICENSE` and `NOTICE`, and must be edited to be
+  self-contained (no dangling references to skills or files not in this pack).
 - Bundle deterministic helpers under the skill's `scripts/` directory.
-- Document optional upstream dependencies rather than copying them.
+- Document optional upstream dependencies in the README rather than copying
+  them when a reference can simply stay optional.
 - Run `python3 scripts/validate.py` before opening a pull request.
 
 ## Developer Certificate of Origin

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,22 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Connor Griffin
+Portions copyright (c) 2026 Matt Pocock (https://github.com/mattpocock/skills)
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 Connor Griffin
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,13 @@
 Connor Griffin's agent skills
 Copyright 2026 Connor Griffin
 
-The ui-mockups workflow composes with, but does not redistribute, skills from
-Matt Pocock's public skills repository:
-https://github.com/mattpocock/skills
+This repository is MIT licensed; see LICENSE for the authoritative license and
+copyright notices.
+
+The implement, tdd, review, and prototype skills are adopted from, and the
+grilling skill is derived from, Matt Pocock's public skills repository
+(https://github.com/mattpocock/skills), MIT licensed,
+copyright (c) 2026 Matt Pocock.
 
 The installation examples use the open source skills CLI:
 https://github.com/vercel-labs/skills

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Contributions require a Signed-off-by trailer under the
 
 ## License and support
 
-Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE). Security reports belong
+MIT, from v0.2.0 onward (v0.1.0 was published under Apache-2.0, and that grant
+stands for copies taken at that tag). See [LICENSE](LICENSE) and
+[NOTICE](NOTICE). Security reports belong
 in the private channel described in [SECURITY.md](SECURITY.md); everything else
 uses GitHub issues.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 | [`drive-local-webapp`](skills/drive-local-webapp/SKILL.md) | Drive and screenshot a local web app with headless Chromium | Node.js 20+; installs Playwright locally |
 | [`cbm-onboard`](skills/cbm-onboard/SKILL.md) | Index a repository with codebase-memory-mcp and keep it current | `codebase-memory-mcp` on `PATH` |
 | [`spin-worktree`](skills/spin-worktree/SKILL.md) | Create isolated Git worktrees for issue and PR work | Git; GitHub CLI only for `--pr` discovery |
+| [`grilling`](skills/grilling/SKILL.md) | Relentlessly interview the user to stress-test a plan or design before building | — |
+| [`wayfinder`](skills/wayfinder/SKILL.md) | Chart a large, foggy effort as a GitHub map of decision tickets, then hand clear subtrees to implementation | GitHub CLI; composes with `research`, `grilling`, `ui-mockups` |
+| [`research`](skills/research/SKILL.md) | Investigate a question against primary sources and capture findings as Markdown in the repo | — |
+| [`prototype`](skills/prototype/SKILL.md) | Build a throwaway prototype — a terminal app for logic questions or switchable UI variants in the real app | — |
+| [`interface-craft`](skills/interface-craft/SKILL.md) | Design distinctive, production-quality web and product interfaces | — |
+| [`tdd`](skills/tdd/SKILL.md) | Test-driven development through public interfaces, red-green-refactor | — |
+| [`review`](skills/review/SKILL.md) | Review changed code against the project's standards and the originating issue | — |
+| [`implement`](skills/implement/SKILL.md) | Implement a PRD or issue set via `tdd`, then `review`, then commit | `tdd` and `review` from this pack |
 
 ## Install
 
@@ -47,19 +55,26 @@ Optional integrations are enhancements, not hidden runtime requirements:
 
 - **Codebase Memory:** accelerates structural exploration. Without it, use
   ordinary repository search and file reads.
-- **`grilling`:** sharpens the UI brief. Without it, run the short inline
-  interview described by `ui-mockups`.
-- **`codebase-design`:** helps shape non-trivial render logic. Without it, keep
-  the shipping module shape and preserve locality.
+- **`codebase-design`:** referenced by `tdd`; helps shape non-trivial module
+  interfaces. Without it, keep the shipping module shape and preserve locality.
+- **`domain-modeling`:** referenced by `grilling` and `wayfinder`; maintains a
+  project's domain vocabulary. Without it, ground terms in the repo's own docs.
 - **`impeccable`:** adds a final visual-quality audit. Without it, run the
   explicit contrast, focus, overflow, and target-size checks.
 
-Install Matt Pocock's optional skills from their owner rather than copying them
-into this pack:
+Install Matt Pocock's optional skills from their repository:
 
 ```sh
-npx skills add mattpocock/skills --skill grilling --skill codebase-design
+npx skills add mattpocock/skills --skill codebase-design --skill domain-modeling
 ```
+
+## Attribution
+
+The `implement`, `tdd`, `review`, and `prototype` skills are adopted from — and
+`grilling` is derived from — [Matt Pocock's skills
+repository](https://github.com/mattpocock/skills) (MIT, copyright (c) 2026 Matt
+Pocock), lightly edited here to be self-contained. See [LICENSE](LICENSE) and
+[NOTICE](NOTICE).
 
 ## Development
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -11,7 +11,20 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS = ROOT / "skills"
-EXPECTED = {"ui-mockups", "drive-local-webapp", "cbm-onboard", "spin-worktree"}
+EXPECTED = {
+    "ui-mockups",
+    "drive-local-webapp",
+    "cbm-onboard",
+    "spin-worktree",
+    "research",
+    "interface-craft",
+    "implement",
+    "tdd",
+    "review",
+    "prototype",
+    "grilling",
+    "wayfinder",
+}
 FORBIDDEN = (
     re.compile("/" + "Users/"),
     re.compile("~/" + "Code/" + "ConnorGriffin"),

--- a/skills/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/cbm-onboard/scripts/cbm-onboard.sh
@@ -50,7 +50,7 @@ trap 'rm -f "$MANAGED_TMP" "$OUTPUT_TMP" "$HOOK_TMP"' EXIT
     ".venv/" "venv/" "env/" "__pycache__/" "*.pyc" \
     ".pytest_cache/" ".mypy_cache/" ".ruff_cache/" ".tox/" \
     "node_modules/" "dist/" "build/" "*.egg-info/" \
-    ".agentflow/" ".claude/worktrees/" ".codex/worktrees/" \
+    ".agentflow/" ".claude/worktrees/" ".codex/worktrees/" ".impeccable/" \
     "*.db" "*.sqlite" "*.sqlite3" "*.csv" "*.parquet" \
     ".env" ".env.*" "*.pem" "*.key" "*.p12" "*.pfx" \
     ".aws/" ".ssh/" ".secrets/" "secrets/" "credentials/" "*.log"

--- a/skills/grilling/SKILL.md
+++ b/skills/grilling/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: grilling
+description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a
+shared understanding. Map the plan as a **design tree**: every decision branches
+into the decisions that depend on it.
+
+Work the tree in **rounds**. The **frontier** is every decision whose
+prerequisites are already settled — everything I can answer now without either
+of us guessing at an earlier answer. Ask the whole frontier in one numbered
+round, then wait for my answers before continuing. Keep tightly coupled
+questions together so I can scroll through the round and dictate answers by
+number.
+
+After each response, record the settled decisions, recompute the frontier, and
+ask the next round. If one answer could materially change whether or how another
+question should be asked, those questions are not on the same frontier: ask the
+dependency first and save the downstream question for a later round.
+
+Finding facts is your job; making decisions is mine. If a frontier question
+needs a fact from the environment, explore it instead of asking me. When
+subagents are available, dispatch fact-finding to a subagent and continue with
+the rest of the frontier; treat only questions downstream of that exploration
+as blocked. Put every actual decision to me.
+
+## Voice rules — I have not read the code as deeply as you have
+
+1. **Phrase every question as app behavior, not code.** "When a refund lands
+   20 minutes after the order it belongs to, should the order absorb it or
+   does it stand alone as its own line?" — never "should `merge_events`
+   dedupe by `source_event_id`?" A code term is allowed only as a one-line
+   parenthetical when it genuinely disambiguates.
+
+2. **Hard budget: ≤6 lines per question.** Number every question. Include the
+   question, 2–3 concrete options
+   grounded in real examples where possible ("on June 30 this would have
+   meant…"), and your recommended answer. No preamble, no context essay, no
+   restating what we've already agreed. Depth only when I ask for it. A
+   verbose question makes me agree just to make it stop — that produces a
+   confidently wrong spec, which is worse than no spec.
+
+3. **Make shorthand answers easy.** Use stable numbers within the session and
+   concise, distinct option labels so answers like "1 yes; 2 B; 3 your
+   recommendation" are unambiguous. Accept free-form or partial answers too;
+   carry unanswered decisions into the next round without re-asking settled
+   ones.
+
+4. **`explain` escape hatch.** If I say "explain", stop and produce a proper
+   explainer for the current question — a diagram, worked example, or
+   screenshot-illustrated HTML page — open it in my browser, then re-ask the
+   question.
+
+5. **`ground it` escape hatch — and offer it proactively.** If I say "I'm not
+   sure", "ground this in my real data", or similar, stop asking and run a
+   **read-only** exploration against the real data: how often does this case
+   occur, what's the actual impact, what would each option have done on my
+   real history. Come back with a ≤6-line verdict — prevalence, impact,
+   recommendation — and re-ask the question with the options now priced.
+   When the honest basis for an answer is my data rather than my preference,
+   don't demand an opinion: lead with "I can measure this — want me to?"
+   Real data may be sensitive (a production database snapshot containing real
+   customer records, say): explorations are strictly read-only, and never copy
+   real data outside the repo's sanctioned paths. If the repo documents a
+   fresh-snapshot pull for its real data, run that first and ground against
+   the snapshot, never a live or authoritative database.
+
+6. **"I don't know" is an accepted answer.** Offer it where genuine. Convert
+   it into either a `ground it` measurement or an explicit "decide at
+   implementation, here's the default" note — never pressure a choice.
+
+7. **Check every question before sending — especially deep in a session.**
+   Drift back into jargon happens precisely when the topic gets technical
+   and the conversation gets long. Before each question, verify: ≤6 lines?
+   Phrased as app behavior? Code symbols only in parentheticals? If the
+   question seems to *need* the technical backstory to be answerable,
+   that's not license to inline it — that's the `explain` artifact's job:
+   offer it in one line instead. Rewrite until the checks pass; do not
+   send the draft that fails them.
+
+## Docs as you go (default)
+
+When the session is grounded in a repo, load the `/domain-modeling` skill at
+the start and apply it throughout: the moment a decision crystallises that
+constrains architecture or behavior, write the ADR (`docs/adr/`); the moment
+a fuzzy term gets sharpened, update the glossary (`CONTEXT.md`). Write them
+as they land, not in a batch at the end — a decision that only exists in
+chat is lost to the next session. Challenge terms against the existing
+glossary as you interview.
+
+## Closing
+
+The session is done when the frontier is empty: every branch has been visited
+and nothing remains silently assumed. End with a compact summary of every
+decision made (the shared understanding), flag anything deferred or defaulted,
+and list the ADRs/glossary entries written during the session. Do not enact the
+plan until I confirm we have reached a shared understanding.

--- a/skills/grilling/agents/openai.yaml
+++ b/skills/grilling/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Grilling"
+  short_description: "Interview the user until a plan is fully settled"
+  default_prompt: "Use $grilling to stress-test this plan before building."

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: implement
+description: "Implement a piece of work based on a PRD or set of issues."
+---
+
+Implement the work described by the user in the PRD or issues.
+
+Use /tdd where possible, at pre-agreed seams.
+
+Run typechecking regularly, single test files regularly, and the full test suite once at the end.
+
+Once done, use /review to review the work.
+
+Commit your work to the current branch.

--- a/skills/implement/agents/openai.yaml
+++ b/skills/implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Implement"
+  short_description: "Build the work described in a PRD or issues"
+  default_prompt: "Use $implement to build the work described in this PRD or set of issues."

--- a/skills/interface-craft/SKILL.md
+++ b/skills/interface-craft/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: interface-craft
+description: Design or redesign distinctive, production-quality web and product interfaces. Use for UI work that needs a grounded visual direction, non-generic layouts, refined interaction and motion, design-system discipline, critique, or a final visual and accessibility quality pass.
+---
+
+# Interface Craft
+
+Build interfaces with an intentional point of view. Do not decorate a default
+component layout. Make the interface clearer, more useful, and unmistakably
+specific to the product.
+
+## Operating contract
+
+- Preserve product truth, real content, existing behavior, and accessibility.
+- Use the project's established design system when it is sound. Extend it with
+  explicit tokens; do not introduce a competing visual language accidentally.
+- Make one strong, defensible visual direction. Do not combine fashionable
+  aesthetics until they become anonymous.
+- Treat references as evidence, not as a collage. Borrow a principle, never a
+  brand's surface treatment wholesale.
+- Match visual density to the job. Marketing can breathe; operational tools
+  should earn every pixel with faster comprehension or action.
+- Do not add a dependency just to make a UI feel designed.
+
+## Route the work
+
+Start by choosing one path. Do not code before completing its required first
+step.
+
+| Situation | First step | Finish condition |
+| --- | --- | --- |
+| New surface | Write a design brief and compare directions | A locked visual spec exists |
+| Existing bland surface | Audit the live UI before changing it | Improvements retain behavior and product truth |
+| Small component | Inspect its parent flow, states, and tokens | Component improves the whole flow, not only itself |
+| Motion request | Make an animation decision before implementation | Motion has purpose, timing, and reduced-motion behavior |
+| Final pass | Run the quality gate | Screenshots and checks show no material regressions |
+
+## 1. Ground the work
+
+Read the smallest useful set of real materials before proposing visuals:
+
+1. Product purpose, audience, primary job, and current user language.
+2. Existing `PRODUCT.md`, `DESIGN.md`, design tokens, typography, theme,
+   representative screen, and component primitives.
+3. Real data shape and all relevant states: typical, dense, empty, loading,
+   error, permission-limited, and mobile when applicable.
+4. Three visual references or named qualities, plus one anti-reference. If no
+   references exist, derive them from the product's physical world, artifacts,
+   and audience instead of the software category.
+
+State these decisions in a compact design brief before code:
+
+```text
+Job: what the person must understand or do here.
+Audience and setting: who uses it, when, and under what pressure or attention.
+Direction: a precise visual world in one sentence.
+Signature move: one visible typographic, structural, material, or interaction choice.
+Density: sparse / balanced / dense, and why.
+Constraints: existing tokens, required content, a11y, responsiveness, performance.
+Anti-references: motifs this surface must avoid.
+```
+
+If the brief is weak, make a provisional choice and label it. Do not hide a
+generic default behind words such as "clean," "modern," or "premium."
+
+## 2. Create a system before components
+
+Choose a limited token system. Every repeated visual value must trace back to it.
+
+- **Type:** Choose roles for display, body, labels, and data. Use a deliberate
+  scale, optical line-height, and tabular figures for aligned numeric data.
+  Keep prose to roughly 65–75ch. Use sentence case unless uppercase carries
+  real meaning.
+- **Color:** Choose a color strategy: restrained, committed, full palette, or
+  drenched. Use one dominant accent role unless the data model requires more.
+  Use perceptual color values when the stack permits. Verify contrast; normal
+  body text needs 4.5:1.
+- **Space and geometry:** Define a spacing rhythm, container behavior, corner
+  logic, elevation, and z-index scale. Vary rhythm intentionally; uniform
+  padding everywhere is not refinement.
+- **Material:** Pick surfaces, borders, shadows, texture, and image treatment
+  from the direction. A blur, gradient, grain, or shadow must communicate
+  hierarchy, atmosphere, or interaction—not merely announce "modern UI."
+- **Motion:** Define standard durations, easing, transform origins, and a
+  reduced-motion fallback before adding effects.
+
+Avoid the category reflex: do not make a product dashboard dark just because it
+is a tool, or a marketing site pale beige just because it is "warm." Derive the
+choice from the audience and scene.
+
+## 3. Explore before committing
+
+For a whole page or major surface, produce three conceptually different
+directions. Change the information hierarchy, layout metaphor, interaction
+model, or density—not only colors and rounded corners.
+
+Give each direction an idea-based name and assess it against the brief:
+
+- **Information shape:** What becomes immediate? What recedes?
+- **Spatial model:** Editorial flow, command surface, timeline, canvas,
+  catalogue, split workspace, narrative, or another model native to the job.
+- **Signature move:** The one memorable choice that stays useful.
+- **Risk:** What could confuse, slow, exclude, or over-stylize the result?
+
+Ground prototypes in the shipping theme, components, and real data where
+possible. For data-heavy UI, use the same chart library and data field names as
+the product. Compare rendered screenshots at the relevant states. Select one
+direction, record it as the visual spec, then implement it rather than blending
+the three proposals.
+
+For an existing project, do not redesign blindly. First capture what users rely
+on, identify visual debt, and change the highest-leverage constraints first:
+
+1. hierarchy and typography,
+2. color and contrast,
+3. layout and spatial rhythm,
+4. interaction feedback and missing states,
+5. component clichés and ornament.
+
+Keep a redesign focused and reviewable. Do not migrate framework, CSS strategy,
+or component library unless that is the actual task.
+
+## 4. Build with visual intent
+
+Use semantic HTML and native controls where they fit. Keep the DOM and CSS
+simple enough to preserve the direction under responsive and state changes.
+
+### Structure and hierarchy
+
+- Make the primary task and next action obvious without relying on decoration.
+- Use layout to express relationships. Do not wrap every conceptual grouping in
+  a bordered, shadowed card.
+- Prefer meaningful asymmetry, mixed scale, or a strong reading order when the
+  content supports it. Do not force novelty into dense operational UI.
+- Use a grid for two-dimensional composition and flex for one-dimensional
+  alignment. Prevent accidental blank cells and arbitrary fixed heights.
+- Test optical alignment. Mathematical centering can look wrong by a pixel or
+  two.
+
+### Refuse generic scaffolding
+
+Rewrite these unless the content genuinely requires them:
+
+- a hero metric with tiny label and decorative gradient;
+- three identical icon-title-copy cards;
+- nested cards and repeated faint borders;
+- numbered or uppercase eyebrow labels above every section;
+- purple-blue gradients, default glass panels, or unmotivated glow;
+- a left sidebar simply because the surface is called a dashboard;
+- default icon metaphors, pill badges, avatar circles, or a sun/moon toggle;
+- symmetrical marketing sections assembled from the same alternating pattern.
+
+Do not replace one cliché with an arbitrary novelty. The alternative must make
+the hierarchy or task better.
+
+### Content and states
+
+- Use real product language and credible content. Never hide incomplete design
+  behind lorem ipsum, fabricated metrics, or generic AI copy.
+- Design loading, empty, error, offline, success, disabled, overflow, and
+  permission states as first-class screens.
+- Use clear labels and direct errors. Give the user a next action and a way
+  back from dead ends.
+- Ensure keyboard focus, target size, logical tab order, and announcements for
+  state changes. Include a skip link where page structure warrants it.
+
+### Responsive behavior
+
+- Design the narrow layout, do not merely stack the desktop layout.
+- Test long labels, large text settings, keyboard navigation, low-motion mode,
+  and both themes if supported.
+- Prevent horizontal scroll and clipped overlays. Use popover, dialog, portal,
+  or fixed positioning when a layer must escape a scrolling container.
+
+## 5. Add motion only where it helps
+
+Ask four questions before implementing animation:
+
+1. How often will people see it? Remove or nearly remove animation from
+   high-frequency and keyboard-driven actions.
+2. What is its job: spatial continuity, feedback, state indication,
+   explanation, or rare delight? Do not animate just to make a screen feel
+   expensive.
+3. What movement fits it? Entering UI generally accelerates quickly then
+   settles; exiting UI can accelerate away; on-screen movement uses a balanced
+   curve. Avoid slow starts for responsive controls.
+4. What is the smallest effective duration? Typical ranges: press 100–160ms,
+   tooltip/popover 125–200ms, select/dropdown 150–250ms, modal/drawer 200–500ms.
+
+Animate transforms and opacity in preference to layout properties. Give buttons
+clear hover and pressed feedback; make popovers originate from their trigger;
+preserve perceived continuity when elements enter or leave. Use a reduced-motion
+alternative that retains access to all content and state changes. Do not block
+initial rendering behind a reveal animation.
+
+## 6. Critique in layers
+
+Review the rendered interface, not only source code. Diagnose in this order:
+
+1. **Comprehension:** Can a first-time user identify purpose, current state,
+   hierarchy, and next action?
+2. **Product fit:** Does the visual direction belong to this product and its
+   audience rather than its software category?
+3. **Composition:** Are reading order, density, containers, rhythm, scale, and
+   alignment intentional?
+4. **Craft:** Are contrast, type, surfaces, icons, images, and states coherent?
+5. **Interaction:** Does feedback arrive promptly and motion make state changes
+   easier to understand?
+6. **Resilience:** Does it work with real data, every important state, keyboard,
+   touch, responsive widths, and reduced motion?
+
+For code-review findings, use exact before/after changes with a reason:
+
+| Before | After | Why |
+| --- | --- | --- |
+| `transition: all 300ms` | `transition: transform 160ms var(--ease-out)` | Avoid unintended animated properties and sharpen feedback. |
+
+Prioritize by user impact. Do not produce a long cosmetic punch list while an
+empty state, unclear action, or inaccessible contrast remains unresolved.
+
+## 7. Ship only after the quality gate
+
+Before declaring UI work complete:
+
+- Confirm the implementation matches the selected visual direction and uses
+  the intended tokens.
+- Compare screenshots with the locked spec at the states that matter.
+- Check normal and large-text contrast, keyboard focus, semantic landmarks,
+  target sizes, error messaging, and reduced-motion behavior.
+- Check loading, empty, error, dense, and narrow-width states using real or
+  representative data.
+- Verify no horizontal overflow, clipped layer, unreadable control, dead
+  action, missing import, or console error.
+- Remove temporary mockup controls, fake data, and unused variants. Preserve
+  the selected spec and record why it won.
+
+Report only: chosen direction, material changes, evidence checked, and any
+known limitation. Do not congratulate the work or explain generic design theory.

--- a/skills/interface-craft/agents/openai.yaml
+++ b/skills/interface-craft/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Interface Craft"
+  short_description: "Build distinctive, usable web interfaces."
+  default_prompt: "Use $interface-craft to design or redesign this interface with a grounded visual direction and production-quality craft."

--- a/skills/prototype/LOGIC.md
+++ b/skills/prototype/LOGIC.md
@@ -1,0 +1,79 @@
+# Logic Prototype
+
+A tiny interactive terminal app that lets the user drive a state model by hand. Use this when the question is about **business logic, state transitions, or data shape** — the kind of thing that looks reasonable on paper but only feels wrong once you push it through real cases.
+
+## When this is the right shape
+
+- "I'm not sure if this state machine handles the edge case where X then Y."
+- "Does this data model actually let me represent the case where..."
+- "I want to feel out what the API should look like before writing it."
+- Anything where the user wants to **press buttons and watch state change**.
+
+If the question is "what should this look like" — wrong branch. Use [UI.md](UI.md).
+
+## Process
+
+### 1. State the question
+
+Before writing code, write down what state model and what question you're prototyping. One paragraph, in the prototype's README or a comment at the top of the file. A logic prototype that answers the wrong question is pure waste — make the question explicit so it can be checked later, whether the user is watching now or returning to it AFK.
+
+### 2. Pick the language
+
+Use whatever the host project uses. If the project has no obvious runtime (e.g. a docs repo), ask.
+
+Match the project's existing conventions for tooling — don't add a new package manager or runtime just for the prototype.
+
+### 3. Isolate the logic in a portable module
+
+Put the actual logic — the bit that's answering the question — behind a small, pure interface that could be lifted out and dropped into the real codebase later. The TUI around it is throwaway; the logic module shouldn't be.
+
+The right shape depends on the question:
+
+- **A pure reducer** — `(state, action) => state`. Good when actions are discrete events and state is a single value.
+- **A state machine** — explicit states and transitions. Good when "which actions are even legal right now" is part of the question.
+- **A small set of pure functions** over a plain data type. Good when there's no implicit current state — just transformations.
+- **A class or module with a clear method surface** when the logic genuinely owns ongoing internal state.
+
+Pick whichever shape best fits the question being asked, *not* whichever is easiest to wire to a TUI. Keep it pure: no I/O, no terminal code, no `console.log` for control flow. The TUI imports it and calls into it; nothing flows the other direction.
+
+This is what makes the prototype useful past its own lifetime. When the question's been answered, the validated reducer / machine / function set can be lifted into the real module — the TUI shell gets deleted.
+
+### 4. Build the smallest TUI that exposes the state
+
+Build it as a **lightweight TUI** — on every tick, clear the screen (`console.clear()` / `print("\033[2J\033[H")` / equivalent) and re-render the whole frame. The user should always see one stable view, not an ever-growing scrollback.
+
+Each frame has two parts, in this order:
+
+1. **Current state**, pretty-printed and diff-friendly (one field per line, or formatted JSON). Use **bold** for field names or section headers and **dim** for less important context (timestamps, IDs, derived values). Native ANSI escape codes are fine — `\x1b[1m` bold, `\x1b[2m` dim, `\x1b[0m` reset. No need to pull in a styling library unless one is already in the project.
+2. **Keyboard shortcuts**, listed at the bottom: `[a] add user  [d] delete user  [t] tick clock  [q] quit`. Bold the key, dim the description, or vice-versa — whatever reads cleanly.
+
+Behaviour:
+
+1. **Initialise state** — a single in-memory object/struct. Render the first frame on start.
+2. **Read one keystroke (or one line)** at a time, dispatch to a handler that mutates state.
+3. **Re-render** the full frame after every action — don't append, replace.
+4. **Loop until quit.**
+
+The whole frame should fit on one screen.
+
+### 5. Make it runnable in one command
+
+Add a script to the project's existing task runner (`package.json` scripts, `Makefile`, `justfile`, `pyproject.toml`). The user should run `pnpm run <prototype-name>` or equivalent — never need to remember a path.
+
+If the host project has no task runner, just put the command at the top of the prototype's README.
+
+### 6. Hand it over
+
+Give the user the run command. They'll drive it themselves; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" — those are the bugs in the _idea_, which is the whole point. If they want new actions added, add them. Prototypes evolve.
+
+### 7. Capture the answer
+
+When the prototype has done its job, the answer to the question is the only thing worth keeping. If the user is around, ask what it taught them. If not, leave a `NOTES.md` next to the prototype so the answer can be filled in (or filled in by you, if you've watched the session) before the prototype gets deleted.
+
+## Anti-patterns
+
+- **Don't add tests.** A prototype that needs tests is no longer a prototype.
+- **Don't wire it to the real database.** Use an in-memory store unless the question is specifically about persistence.
+- **Don't generalise.** No "what if we wanted to support X later." The prototype answers one question.
+- **Don't blur the logic and the TUI together.** If the reducer / state machine references `console.log`, prompts, or terminal escape codes, it's no longer portable. Keep the TUI as a thin shell over a pure module.
+- **Don't ship the TUI shell into production.** The shell is optimised for being driven by hand from a terminal. The logic module behind it is the bit worth keeping.

--- a/skills/prototype/SKILL.md
+++ b/skills/prototype/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: prototype
+description: Build a throwaway prototype to flesh out a design — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route.
+---
+
+# Prototype
+
+A prototype is **throwaway code that answers a question**. The question decides the shape.
+
+## Pick a branch
+
+Identify which question is being answered — from the user's prompt, the surrounding code, or by asking if the user is around:
+
+- **"Does this logic / state model feel right?"** → [LOGIC.md](LOGIC.md). Build a tiny interactive terminal app that pushes the state machine through cases that are hard to reason about on paper.
+- **"What should this look like?"** → [UI.md](UI.md). Generate several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+
+The two branches produce very different artifacts — getting this wrong wastes the whole prototype. If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch better matches the surrounding code (a backend module → logic; a page or component → UI) and state the assumption at the top of the prototype.
+
+### Prototype vs. ui-mockups
+
+The UI branch overlaps with the `ui-mockups` skill — pick deliberately:
+
+- **`ui-mockups`** is a *pre-implementation* exploration. It produces standalone static HTML mockups, outside the app, screenshotted and iterated until a visual spec is **locked**. Reach for it when nothing is built yet and the deliverable is an agreed-on design.
+- **`prototype`'s UI branch** produces throwaway *runnable* variants **inside the actual app**, wired to real routing, components, and data. Reach for it when the question can only be answered by real app behavior — interaction, live state, existing components under real content.
+
+If you only need to see what it should look like, use `ui-mockups`. If you need to feel how it behaves, prototype it in the app.
+
+## Rules that apply to both
+
+1. **Throwaway from day one, and clearly marked as such.** Locate the prototype code close to where it will actually be used (next to the module or page it's prototyping for) so context is obvious — but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; don't invent a new top-level structure.
+2. **One command to run.** Whatever the project's existing task runner supports — `pnpm <name>`, `python <path>`, `bun <path>`, etc. The user must be able to start it without thinking.
+3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is _checking_, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
+4. **Skip the polish.** No tests, no error handling beyond what makes the prototype _runnable_, no abstractions. The point is to learn something fast and then delete it.
+5. **Surface the state.** After every action (logic) or on every variant switch (UI), print or render the full relevant state so the user can see what changed.
+6. **Delete or absorb when done.** When the prototype has answered its question, either delete it or fold the validated decision into the real code — don't leave it rotting in the repo.
+
+## When done
+
+The _answer_ is the only thing worth keeping from a prototype. Capture it somewhere durable (commit message, ADR, issue, or a `NOTES.md` next to the prototype) along with the question it was answering. If the user is around, that capture is a quick conversation; if not, leave the placeholder so they (or you, on the next pass) can fill in the verdict before deleting the prototype.

--- a/skills/prototype/UI.md
+++ b/skills/prototype/UI.md
@@ -1,0 +1,112 @@
+# UI Prototype
+
+Generate **several radically different UI variations** on a single route, switchable from a floating bottom bar. The user flips between variants in the browser, picks one (or steals bits from each), then throws the rest away.
+
+If the question is about logic/state rather than what something looks like — wrong branch. Use [LOGIC.md](LOGIC.md).
+
+## When this is the right shape
+
+- "What should this page look like?"
+- "I want to see a few options for this dashboard before committing."
+- "Try a different layout for the settings screen."
+- Any time the user would otherwise spend a day picking between three vague mockups in their head.
+
+## Two sub-shapes — strongly prefer sub-shape A
+
+A UI prototype is much easier to judge when it's **butting up against the rest of the app** — real header, real sidebar, real data, real density. A throwaway route on its own is a vacuum: every variant looks fine in isolation. Default to sub-shape A whenever there's a plausible existing page to host the variants. Only reach for sub-shape B if the prototype genuinely has no nearby home.
+
+### Sub-shape A — adjustment to an existing page (preferred)
+
+The route already exists. Variants are rendered **on the same route**, gated by a `?variant=` URL search param. The existing data fetching, params, and auth all stay — only the rendering swaps. This is the default; pick it unless there's a specific reason not to.
+
+If the prototype is for something that doesn't yet have a page but *would naturally live inside one* (a new section of the dashboard, a new card on the settings screen, a new step in an existing flow) — that's still sub-shape A. Mount the variants inside the host page.
+
+### Sub-shape B — a new page (last resort)
+
+Only use this when the thing being prototyped genuinely has no existing page to live inside — e.g. an entirely new top-level surface, or a flow that can't be embedded anywhere sensible.
+
+Create a **throwaway route** following whatever routing convention the project already uses — don't invent a new top-level structure. Name it so it's obviously a prototype (e.g. include the word `prototype` in the path or filename). Same `?variant=` pattern.
+
+Before committing to sub-shape B, sanity-check: is there really no existing page this could be embedded in? An empty route hides design problems that a populated one would expose.
+
+In both sub-shapes the floating bottom bar is identical.
+
+## Process
+
+### 1. State the question and pick N
+
+Default to **3 variants**. More than 5 stops being radically different and starts being noise — cap there.
+
+Write down the plan in one line, in the prototype's location or a top-of-file comment:
+
+> "Three variants of the settings page, switchable via `?variant=`, on the existing `/settings` route."
+
+This works whether the user is here to push back or not.
+
+### 2. Generate radically different variants
+
+Draft each variant. Hold each one to:
+
+- The page's purpose and the data it has access to.
+- The project's component library / styling system (TailwindCSS, shadcn, MUI, plain CSS, whatever).
+- A clear exported component name, e.g. `VariantA`, `VariantB`, `VariantC`.
+
+Variants must be **structurally different** — different layout, different information hierarchy, different primary affordance, not just different colours. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
+
+### 3. Wire them together
+
+Create a single switcher component on the route:
+
+```tsx
+// pseudo-code — adapt to the project's framework
+const variant = searchParams.get('variant') ?? 'A';
+return (
+  <>
+    {variant === 'A' && <VariantA {...data} />}
+    {variant === 'B' && <VariantB {...data} />}
+    {variant === 'C' && <VariantC {...data} />}
+    <PrototypeSwitcher variants={['A','B','C']} current={variant} />
+  </>
+);
+```
+
+For sub-shape A (existing page): keep all the existing data fetching above the switcher; only the rendered subtree changes per variant.
+
+For sub-shape B (new page): the throwaway route under `/prototype/<name>` mounts the same switcher.
+
+### 4. Build the floating switcher
+
+A small fixed-position bar at the bottom-centre of the screen with three pieces:
+
+- **Left arrow** — cycles to the previous variant (wraps around).
+- **Variant label** — shows the current variant key and, if the variant exports a name, that name too. e.g. `B — Sidebar layout`.
+- **Right arrow** — cycles forward (wraps around).
+
+Behaviour:
+
+- Clicking an arrow updates the URL search param (use the framework's router — `router.replace` on Next, `navigate` on React Router, etc) so the variant is shareable and reload-stable.
+- Keyboard: `←` and `→` arrow keys also cycle. Don't intercept arrow keys when an `<input>`, `<textarea>`, or `[contenteditable]` is focused.
+- Visually distinct from the page (e.g. high-contrast pill, subtle shadow) so it's obviously not part of the design being evaluated.
+- Hidden in production builds — gate on `process.env.NODE_ENV !== 'production'` or an equivalent check, so a stray prototype merge can't ship the bar to users.
+
+Put the switcher in a single shared component so both sub-shapes can reuse it. Locate it wherever shared UI lives in the project.
+
+### 5. Hand it over
+
+Surface the URL (and the `?variant=` keys). The user will flip through whenever they get to it. The interesting feedback is usually **"I want the header from B with the sidebar from C"** — that's the actual design they want.
+
+### 6. Capture the answer and clean up
+
+Once a variant has won, write down which one and why (commit message, ADR, issue, or a `NOTES.md` next to the prototype if running AFK and the user hasn't responded yet). Then:
+
+- **Sub-shape A** — delete the losing variants and the switcher; fold the winner into the existing page.
+- **Sub-shape B** — promote the winning variant to a real route, delete the throwaway route and the switcher.
+
+Don't leave variant components or the switcher lying around. They rot fast and confuse the next reader.
+
+## Anti-patterns
+
+- **Variants that differ only in colour or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
+- **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>` defeats the point. Each variant should be free to throw out the layout.
+- **Wiring variants to real mutations.** Read-only prototypes are fine. If a variant needs to mutate, point it at a stub — the question is "what should this look like", not "does the backend work".
+- **Promoting the prototype directly to production.** The variant code was written under prototype constraints (no tests, minimal error handling). Rewrite it properly when you fold it in.

--- a/skills/prototype/agents/openai.yaml
+++ b/skills/prototype/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prototype"
+  short_description: "Answer a design question with throwaway runnable code"
+  default_prompt: "Use $prototype to answer this design question with a throwaway runnable prototype."

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: research
+description: Investigate a question against high-trust primary sources and capture the findings as a Markdown file in the repo. Use when the user wants a topic researched, docs or API facts gathered, or reading legwork delegated to a background agent.
+---
+
+Use exactly one research worker; never create a chain of workers.
+
+- **Root or interactive agent:** Spawn one background agent with this skill and the
+  complete research task attached. You may keep working while it reads, but supervise it
+  to completion before ending the turn or reporting the research complete.
+- **Already a spawned, background, or subagent worker:** Perform the research directly.
+  Never spawn another background agent or nested worker.
+- If the worker fails or is interrupted, report the failure explicitly. Do not describe a
+  successful spawn as completed research.
+
+The research worker's job:
+
+1. Investigate the question against **primary sources** — official docs, source code,
+   specs, first-party APIs — not a secondary write-up of them. Follow every claim back to
+   the source that owns it.
+2. Write the findings to a single Markdown file, citing each claim's source.
+3. Save it where the repo already keeps such notes; match the existing convention, and if
+   there is none, put it somewhere sensible and say where.

--- a/skills/research/agents/openai.yaml
+++ b/skills/research/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Research"
+  short_description: "Research primary sources in a background agent"
+  default_prompt: "Use $research to investigate this question against primary sources and save the findings in the repository."

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: review
+description: Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes — Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/PRD asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to "review since X".
+---
+
+Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+
+- **Standards** — does the code conform to this repo's documented coding standards?
+- **Spec** — does the code faithfully implement the originating issue / PRD / spec?
+
+Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+
+If the project documents its issue tracker (a file under `docs/` describing how to fetch issues, or a note in `CONTRIBUTING.md` / `README.md`), follow that. Otherwise infer it from the git remotes — a GitHub remote means GitHub Issues via the `gh` CLI, which is the default assumption. If neither resolves, ask the user where issues live rather than guessing.
+
+## Process
+
+### 1. Pin the fixed point
+
+Whatever the user said is the fixed point — a commit SHA, branch name, tag, `main`, `HEAD~5`, etc. If they didn't specify one, ask for it.
+
+Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
+
+Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here — not inside two parallel sub-agents.
+
+### 2. Identify the spec source
+
+Look for the originating spec, in this order:
+
+1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.) — fetch them from the issue tracker identified above (`gh issue view <n>` for GitHub).
+2. A path the user passed as an argument.
+3. A PRD/spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report "no spec available".
+
+### 3. Identify the standards sources
+
+Anything in the repo that documents how code should be written, such as `CODING_STANDARDS.md` or `CONTRIBUTING.md`.
+
+### 4. Spawn both sub-agents in parallel
+
+Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both.
+
+**Standards sub-agent prompt** — include:
+
+- The full diff command and commit list.
+- The list of standards-source files you found in step 3.
+- The brief: "Report — per file/hunk where relevant — every place the diff violates a documented standard. Cite the standard (file + the rule). Distinguish hard violations from judgement calls. Skip anything tooling enforces. Under 400 words."
+
+**Spec sub-agent prompt** — include:
+
+- The diff command and commit list.
+- The path or fetched contents of the spec.
+- The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
+
+If the spec is missing, skip the Spec sub-agent and note this in the final report.
+
+### 5. Aggregate
+
+Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings — the two axes are deliberately separate (see _Why two axes_).
+
+End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes — that's the reranking the separation exists to prevent.
+
+## Why two axes
+
+A change can pass one axis and fail the other:
+
+- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+Reporting them separately stops one axis from masking the other.

--- a/skills/review/agents/openai.yaml
+++ b/skills/review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review"
+  short_description: "Review a diff against standards and spec in parallel"
+  default_prompt: "Use $review to review the changes since this fixed point along the standards and spec axes."

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: tdd
+description: Test-driven development. Use when the user wants to build features or fix bugs test-first, mentions "red-green-refactor", or wants integration tests.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, read `CONTEXT.md` (if it exists) so that test names and interface vocabulary match the project's domain language, and respect ADRs in the area you're touching.
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Identify opportunities for deep modules (small interface, deep implementation) — run the `/codebase-design` skill for the vocabulary and the testability checks
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Get user approval on the plan
+
+Ask: "What should the public interface look like? Which behaviors are most important to test?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/skills/tdd/agents/openai.yaml
+++ b/skills/tdd/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TDD"
+  short_description: "Build features test-first, one vertical slice at a time"
+  default_prompt: "Use $tdd to build this behavior test-first, one red-green cycle at a time."

--- a/skills/tdd/mocking.md
+++ b/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/skills/tdd/refactoring.md
+++ b/skills/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/skills/tdd/tests.md
+++ b/skills/tdd/tests.md
@@ -1,0 +1,61 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: wayfinder
+description: Chart and resolve a large, foggy effort as a GitHub map of decision tickets, then hand clear independent subtrees to your implementation workflow as ordinary build issues. Use when an idea is too large or uncertain for one session, when the user invokes wayfinder or supplies a wayfinder map, or when planning must settle research, UI, domain, and scope decisions before implementation begins.
+---
+
+# Wayfinder
+
+Find the way to a destination across multiple sessions. Maintain one `wayfinder:map`
+issue with child decision tickets, resolve one decision per session, and file build
+issues only when no open decision can invalidate their subtree.
+
+## Operating rules
+
+- **Plan, do not build.** Resolve decisions and create planning artifacts. The pull to
+  implement is normally the signal to hand a clear subtree to whatever process builds
+  your work.
+- **Refer by name.** In human-facing text, wrap issue links in their titles. Never make
+  people decode a wall of bare issue numbers.
+- **Keep one source for each answer.** The resolution lives in its ticket comment. The map
+  keeps only a one-line gist and link. An ADR keeps only the lasting ruling.
+- **Work one decision per session.** Parallel AFK research tickets are the sole exception.
+- **Use GitHub's native structure.** Read
+  [references/github-tracker.md](references/github-tracker.md) before any tracker action.
+  Do not replace child issues, blocking relationships, or label claims with body text.
+
+## The map
+
+The map is a GitHub issue labelled `wayfinder:map`. Its decision tickets are native child
+issues. The map body is the low-resolution view loaded at the start of every session:
+
+```markdown
+## Destination
+
+<One or two lines describing what this effort is finding its way to.>
+
+## Notes
+
+<Domain, standing preferences, and skills every session must consult.>
+
+## Decisions so far
+
+- [<closed ticket title>](https://github.com/<org>/<repo>/issues/<n>) — <one-line gist>
+
+## Awaiting disposition
+
+- [<open research ticket title>](https://github.com/<org>/<repo>/issues/<n>) — <findings are complete; build candidates need rulings>
+
+## Not yet specified
+
+<In-scope fog that cannot yet be phrased as a precise question.>
+
+## Handoffs
+
+- [<build issue title>](https://github.com/<org>/<repo>/issues/<n>) — <independent subtree handed off>
+
+## Out of scope
+
+<Work consciously ruled beyond the destination, with reasons.>
+```
+
+The map is an index, not a duplicate store. Discover live work from its open child issues,
+not by maintaining another ticket list in the body.
+
+## Decision tickets
+
+Each ticket is sized to one agent session and has this body:
+
+```markdown
+## Question
+
+<The precise decision or investigation this ticket resolves.>
+```
+
+Apply exactly one ticket-type label:
+
+- **`wayfinder:research` (AFK-able):** Any investigation an unattended agent session can
+  finish alone — an internal repository audit as much as an outward read. Invoke `/research`
+  when the answer depends on documentation, third-party systems, or sources outside the
+  repository; ground directly in the repo when it doesn't. Record findings, sources, and
+  the decision they support. Treat `/research` as a required dependency for outward reads:
+  if it is unavailable, leave the ticket unclaimed and tell the human rather than
+  substituting a generic search pass. The label is a promise of AFK-ability — an unattended
+  session may be dispatched for an unclaimed research ticket, so apply it honestly.
+- **`wayfinder:prototype` (HITL):** Invoke `/ui-mockups`. Produce repository-grounded
+  variants, iterate with the human, and finish with a locked visual spec linked from the
+  ticket. That artifact also satisfies any later review gate that demands a locked design.
+- **`wayfinder:grilling` (HITL):** Invoke `/grilling`, plus a domain-modelling skill when
+  one is available; ask one question at a time. Never answer the human's side of the
+  exchange.
+- **`wayfinder:task` (HITL):** A prerequisite that genuinely needs the human in the loop.
+  It earns a place only by unblocking a decision, not by delivering the destination — and
+  it is never an execution errand: a prerequisite that must *change the world* before a
+  decision can be made is handed off as an ordinary build issue, and its landed result
+  feeds back into the map as a decision input.
+
+`wayfinder:awaiting-disposition` is durable state, not a ticket type or a claim. A research
+ticket in that state remains open, keeps its one `wayfinder:research` ticket-type label, and
+may temporarily also carry the distinct `wayfinder:resolving` claim while a human reconciles
+its findings.
+
+The claim is the `wayfinder:resolving` label, shared by human sessions and unattended
+workers. Assignment is not the claim: an unattended worker may run under the operator's own
+GitHub identity, so assignment cannot tell the two apart. Set the label before work, remove
+it on completion or when giving up, and skip open tickets already claimed. Native issue
+dependencies define order. The **frontier** is the map's child tickets that are open,
+unblocked, unclaimed, and not carrying `wayfinder:awaiting-disposition`.
+
+The session that launches a worker owns claim recovery. A successful spawn is not a
+durable outcome: supervise the worker until the ticket is resolved or the worker fails. On
+failure or interruption, remove its `wayfinder:resolving` claim before reporting the ticket
+available again. Never leave a claimed ticket behind with no live worker. If your
+environment has its own dispatcher that runs unclaimed research tickets unattended, that
+dispatcher owns them instead and charting does not spawn workers itself.
+
+## Fog and scope
+
+Put a question in a ticket when it can be stated precisely now, even if blocked. Keep it in
+`Not yet specified` when the question itself is still vague. Do not pre-slice fog: one patch
+may later become several tickets or none.
+
+Keep decided work, live tickets, and out-of-scope work out of the fog. When a ticket proves
+to be beyond the destination, close it, link it under `Out of scope` with the reason, and do
+not add it to `Decisions so far`.
+
+## Chart a map
+
+When the user brings a loose idea:
+
+1. Run `/grilling`, and a domain-modelling skill when one is available, to name the
+   destination. The destination fixes scope, so settle it first.
+2. Grill breadth-first across the effort. Surface precise decisions, dependency order, and
+   coarse fog without resolving any ticket.
+3. If the route is already clear and fits one session, stop and tell the user a map would
+   add no leverage.
+4. Ensure the six persistent `wayfinder:*` labels exist, then create the map with its destination,
+   notes, fog, and scope boundary.
+5. Create every currently precise decision ticket as a child of the map. Create all issues
+   first, then add native blocking relationships in a second pass.
+6. Verify `/research` is available and the environment can both launch and supervise
+   background workers. If either capability is unavailable, leave research tickets
+   unclaimed and report the missing prerequisite.
+7. For each research ticket already on the frontier, launch one separate AFK worker with
+   `/research` and the complete ticket-resolution task attached. Tell it explicitly that it
+   is already the background worker: it must research directly, never delegate again. Each
+   worker verifies eligibility, claims, researches, comments, and updates only its ticket
+   and the map. Its terminal findings comment must end with the structured candidate list
+   defined under **Reconcile completed research**. If that list contains any
+   `handoff_required` candidates, it adds `wayfinder:awaiting-disposition`, adds the ticket
+   under `Awaiting disposition`, releases its claim, and leaves the ticket open. Otherwise it
+   records the final gist under `Decisions so far`, closes the ticket, and releases its claim.
+8. Record every worker ID and supervise all workers to terminal completion. Spawn success
+   alone does not mean "research running." Before reporting success, verify the findings
+   comment and map update, then verify either an open, unclaimed awaiting-disposition ticket
+   or a closed ticket with no undisposed candidates. If a worker fails or is interrupted,
+   release its `wayfinder:resolving` claim and report the failure. If the user replaces the
+   task, reconcile or cancel every worker and release failed claims before switching work.
+9. Stop after every launch has reached a durable outcome. Charting creates the map; the
+   root session does not hand-resolve a research ticket while its worker runs.
+
+## Work through a map
+
+When the user supplies a map, optionally with a ticket:
+
+1. Load the map body, not every child body.
+2. Before selecting ordinary frontier work, inspect the map's open research children and
+   reconcile every one carrying `wayfinder:awaiting-disposition` by following **Reconcile
+   completed research** below. Restore a missing `Awaiting disposition` entry before
+   reconciling. Skip an awaiting child another session already claims with
+   `wayfinder:resolving`; that session owns finishing it. Re-read the map after each ticket;
+   do not begin frontier work while any unclaimed awaiting child or entry remains.
+3. If the user named a ticket, verify it is open and unblocked. Otherwise choose the first
+   frontier ticket in tracker order. Claim it before reading deeply or invoking another
+   skill.
+4. Resolve that one question. Load related tickets only as needed and invoke every skill in
+   the map's `Notes`.
+5. Post a resolution comment with the answer, supporting evidence or artifact links, and
+   the important alternatives rejected. Keep the full reasoning here.
+6. Decide whether the ruling is load-bearing. Create or update an ADR before closing when
+   the decision constrains multiple builds, is costly to reverse, settles architecture or
+   domain language, or must be enforced downstream. Follow the repository's ADR format and
+   index. Link the ADR from the resolution; keep reasoning in the ticket and the concise
+   ruling plus consequences in the ADR.
+7. Close the ticket and append its titled link plus one-line gist to `Decisions so far`.
+8. Create and wire newly precise tickets, graduate cleared fog, and remove invalidated or
+   out-of-scope tickets. Expect concurrent sessions and re-read tracker state before edits.
+9. Evaluate handoff eligibility for every affected independent subtree.
+
+## Reconcile completed research
+
+Completed unattended research with structured `handoff_required` candidates is not resolved
+until a human disposes every candidate. Keep the research ticket open, keep
+`wayfinder:awaiting-disposition`, and keep its titled link under the map's
+`Awaiting disposition` section throughout reconciliation.
+
+Claim the research ticket with `wayfinder:resolving`, then read its terminal findings comment.
+The worker writes every candidate in a final fenced YAML block using this envelope; an empty
+`candidates` list explicitly proves that no build disposition is pending:
+
+```yaml
+wayfinder_findings:
+  candidates:
+    - id: <stable identity unique within this research ticket>
+      disposition: handoff_required
+      title: <independently shippable outcome>
+      outcome: <observable result the build must produce>
+```
+
+Keep `id` byte-for-byte unchanged in every build issue or disposition comment. Candidate IDs,
+not titles or list position, are the replay identity. A missing or malformed envelope is not a
+completed research result: repair the findings comment before closing or reconciling the ticket.
+The operator may select zero or more candidates. For each independently shippable selected
+candidate, file one ordinary standalone build issue using **Hand clear work to implementation**;
+never combine independent candidates into an umbrella issue. Copy the candidate's exact
+structured identity into that issue's `Wayfinder candidate:` marker so replay can match the
+issue back to one candidate. For every unselected candidate, record that same identity in a
+disposition comment on the research ticket:
+
+- **No-build:** name the reason, the observable trigger that would invalidate the ruling, and
+  the condition that verifies no build is needed.
+- **Deferred:** name the observable trigger that reopens consideration and the condition that
+  will verify the later build is complete.
+
+A selected candidate is durably disposed only when all three handoff facts agree:
+
+1. the map's `Handoffs` entry links the build issue;
+2. the build issue body contains the exact marker `Wayfinder handoff: #<map>`; and
+3. the build issue has a native `blockedBy` edge to this terminal research child.
+
+A map link alone never counts as a handoff. Before filing anything, and again after every
+GitHub mutation, re-read the map, research comments and labels, candidate build issue bodies,
+and native dependencies. Derive completed work from GitHub: match existing map entries and
+ordinary issues carrying the exact marker and research dependency back to each structured
+candidate by its copied identity. Repair a partial three-fact handoff in place; never create a
+duplicate build issue, map line, or disposition comment. The tracker reference gives the
+mutation order and replay procedure.
+
+After every candidate has exactly one durable selected, no-build, or deferred disposition,
+finalize in order: remove the ticket's `Awaiting disposition` map entry, remove
+`wayfinder:awaiting-disposition`, append its titled link and explicit final gist under
+`Decisions so far`, then close the research ticket and release its claim.
+Close research only after every candidate has a durable disposition; never close it with an
+undisposed candidate.
+
+Maintainer invariant: closed research always has a durable disposition. No hidden
+issues-to-file list exists outside GitHub.
+
+## Hand clear work to implementation
+
+Hand off a subtree as soon as all of these are true:
+
+- its fog is empty;
+- no open decision anywhere on the map could invalidate its outcome, constraints, or
+  acceptance criteria;
+- every relevant load-bearing ruling is in an ADR;
+- any user-facing surface has a locked `/ui-mockups` spec.
+
+File a new ordinary GitHub issue in the repository that will build it. Do **not** make it a
+child decision ticket, and do **not** add any `wayfinder:*` label. Whatever intake your
+implementation workflow uses owns its own routing labels, briefs, and effort dials —
+wayfinder never sets them.
+
+Make the issue stand alone. Whoever picks it up grounds from the repository and will not
+chase the map's links to reconstruct context. Use the repository's domain terms and inline
+every relevant ruling:
+
+```markdown
+## Outcome
+
+<Observable result this build should deliver.>
+
+## Decided constraints
+
+- <Decision title>: <ruling stated inline, with ADR link when one exists>
+
+## Scope
+
+<What this ticket includes.>
+
+## Acceptance criteria
+
+- <Observable criterion>
+
+## Evidence and locked artifacts
+
+- <Research evidence or locked visual spec, with the operative conclusion repeated here>
+
+## Not part of this ticket
+
+- <Nearby work deliberately excluded>
+
+Wayfinder handoff: #<map>
+Wayfinder candidate: <candidate id — only when this issue came from a research disposition>
+```
+
+Before filing, reconcile existing handoff facts in GitHub. The two trailing marker lines are
+the issue's durable identity: keep `Wayfinder handoff: #<map>` byte-for-byte, and carry
+`Wayfinder candidate:` only when a research disposition produced this issue, repeating that
+candidate's `id` unchanged. Then add a native `blockedBy` edge from the build issue to at
+least one terminal decision child that cleared the work, and link the filed issue under the
+map's `Handoffs`. During research disposition, that dependency is the terminal research
+child. All three facts must agree before the handoff counts. If intake sends the issue back
+for more scoping or clarification, treat that as evidence the map was incomplete: create a
+new decision ticket for the gap, link the held build issue, and stop handing off dependent
+work until the gap is resolved.
+
+The map is complete when nothing remains in fog, no decision ticket is open, and every
+buildable subtree has been handed off (or the destination explicitly requires no build).

--- a/skills/wayfinder/agents/openai.yaml
+++ b/skills/wayfinder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wayfinder"
+  short_description: "Map a foggy effort as decision tickets"
+  default_prompt: "Use $wayfinder to chart this large effort as decision tickets and work the next clear decision."

--- a/skills/wayfinder/references/github-tracker.md
+++ b/skills/wayfinder/references/github-tracker.md
@@ -1,0 +1,216 @@
+# GitHub tracker operations
+
+Wayfinder uses GitHub's native child issues, dependencies, and labels. The
+commands below require a current GitHub CLI with `--add-sub-issue`, `--add-blocked-by`, and
+the `subIssues` / `blockedBy` JSON fields. Run `gh version` and `gh auth status` before the
+first mutation. Pass `--repo OWNER/REPO` explicitly when the working directory is ambiguous.
+
+## Labels
+
+Create the vocabulary once per repository. `--force` makes this idempotent without changing
+the state of any issue:
+
+```sh
+gh label create wayfinder:map       --color 5319e7 --description "Map of decisions for a multi-session effort" --force
+gh label create wayfinder:research  --color 0e8a16 --description "AFK research decision" --force
+gh label create wayfinder:prototype --color 1d76db --description "HITL locked UI mockup decision" --force
+gh label create wayfinder:grilling  --color fbca04 --description "HITL grilling or domain decision" --force
+gh label create wayfinder:task      --color c5def5 --description "Prerequisite action that unblocks a decision" --force
+gh label create wayfinder:awaiting-disposition --color bfdadc --description "Completed research awaiting human disposition" --force
+```
+
+Every map and decision ticket carries exactly one of the first five ticket-type labels.
+`wayfinder:awaiting-disposition` is additional state compatible with exactly one ticket-type
+label; it is not a second ticket type and is distinct from the transient
+`wayfinder:resolving` claim. Keep the `wayfinder:` namespace reserved for planning: whatever
+labels your implementation workflow uses live outside it, and nothing in that namespace
+belongs on a build issue.
+
+## Create the map and tickets
+
+Create issue bodies in a temporary file and use `--body-file` so Markdown is not damaged by
+shell quoting:
+
+```sh
+gh issue create --repo OWNER/REPO --title "Map: <destination>" \
+  --body-file /path/to/map-body.md --label wayfinder:map
+
+gh issue create --repo OWNER/REPO --title "Decide <question>" \
+  --body-file /path/to/ticket-body.md --label wayfinder:grilling
+```
+
+Capture the returned URLs or resolve titles immediately; never guess issue numbers.
+
+Add each decision ticket as a native child after both issues exist:
+
+```sh
+gh issue edit MAP_NUMBER --repo OWNER/REPO --add-sub-issue TICKET_NUMBER
+```
+
+Build issues filed at handoff are not children of the map. The child set remains the exact
+decision-ticket set used to calculate the frontier.
+
+## Wire dependencies
+
+If `BLOCKED_NUMBER` cannot be worked until `BLOCKER_NUMBER` closes:
+
+```sh
+gh issue edit BLOCKED_NUMBER --repo OWNER/REPO --add-blocked-by BLOCKER_NUMBER
+```
+
+Use `--remove-blocked-by`, `--add-blocking`, or `--remove-blocking` to correct edges. Never
+encode a dependency only as `Blocked by #N` prose; body prose is not queryable, and other
+tools may already read that convention for their own purposes. Wayfinder uses GitHub's
+native planning relationship.
+
+## Read the map and frontier
+
+Load the map at low resolution:
+
+```sh
+gh issue view MAP_NUMBER --repo OWNER/REPO \
+  --json number,title,url,body,state,subIssues,subIssuesSummary
+```
+
+List child numbers, then inspect only the open candidates:
+
+```sh
+gh issue view MAP_NUMBER --repo OWNER/REPO --json subIssues --jq '.subIssues[].number'
+
+gh issue view TICKET_NUMBER --repo OWNER/REPO \
+  --json number,title,url,state,labels,assignees,blockedBy
+```
+
+A ticket is on the frontier only when `state` is `OPEN`, it does not carry either the
+`wayfinder:resolving` or `wayfinder:awaiting-disposition` label, and every issue in
+`blockedBy` is closed. Preserve GitHub's returned child order when choosing the first
+frontier ticket. Tickets carrying `wayfinder:awaiting-disposition` are excluded from the frontier.
+
+## Claim and resolve
+
+The claim is the `wayfinder:resolving` label, shared by human sessions and unattended
+workers. Assignment cannot distinguish the two, since an unattended worker may run under the
+operator's own GitHub identity. Claim before doing work:
+
+```sh
+gh label create wayfinder:resolving --repo OWNER/REPO --color d4c5f9 \
+  --description "A session is resolving this decision ticket" --force
+gh issue edit TICKET_NUMBER --repo OWNER/REPO --add-label wayfinder:resolving
+```
+
+Re-read the issue after claiming. If another session won the race, choose another frontier
+ticket. Release the claim on completion or when giving up:
+
+```sh
+gh issue edit TICKET_NUMBER --repo OWNER/REPO --remove-label wayfinder:resolving
+```
+
+Post the full answer as a comment, then close only after its ADR and map update are durable:
+
+```sh
+gh issue comment TICKET_NUMBER --repo OWNER/REPO --body-file /path/to/resolution.md
+gh issue close TICKET_NUMBER --repo OWNER/REPO --reason completed
+```
+
+Update the map with `gh issue edit MAP_NUMBER --body-file ...`. Before every mutation,
+re-fetch the current body and child/dependency state so concurrent sessions do not overwrite
+one another.
+
+## Reconcile awaiting dispositions
+
+Human map sessions inspect every open research child and reconcile each one carrying
+`wayfinder:awaiting-disposition` before reading the ordinary frontier. The state label is the
+durable queue; `Awaiting disposition` is its map index. If either side is missing, restore the
+map entry for every labeled child before reconciling and do not treat an unlabeled map entry as
+disposed without checking its research ticket. For each pending child, load its labels and
+terminal findings comment. Skip it when another session already holds `wayfinder:resolving`;
+otherwise claim it and re-read to confirm the claim. Keep the ticket open, keep
+`wayfinder:awaiting-disposition`, and keep the map entry until every structured
+`handoff_required` candidate has a durable ruling.
+
+Treat GitHub as the recovery log. Before the first mutation and after every mutation:
+
+1. Re-fetch the map body, all open research children and their labels, research ticket
+   comments, and native relationships. Repair any mismatch between labeled children and the
+   map's `Awaiting disposition` index before continuing.
+2. Enumerate the map's `Handoffs` links and ordinary issues whose bodies contain the exact
+   `Wayfinder handoff: #<map>` marker, then inspect each issue's `blockedBy` relationships:
+
+   ```sh
+   gh search issues --repo OWNER/REPO --match body "Wayfinder handoff: #MAP_NUMBER" \
+     --json number,title,url,state,body --limit 100
+
+   gh issue view BUILD_NUMBER --repo OWNER/REPO --json number,title,url,state,body,blockedBy
+   ```
+
+   GitHub's search tokenizes text, so treat every hit as a candidate only: confirm the exact
+   marker line in the fetched body before matching, and never conclude an issue is absent from
+   an empty search result alone — the map's `Handoffs` links are the second read.
+3. Match records by the exact candidate identity copied into each build issue or disposition
+   comment: the build issue repeats it in its `Wayfinder candidate:` marker, and the
+   disposition comment repeats it verbatim. A selected candidate is complete only when one map
+   entry, one exact marker, and one native `blockedBy` edge to this terminal research child all
+   name the same build issue.
+4. If only one or two facts exist, repair that same build issue. If all three exist, record no
+   new mutation. Create a build issue only when no existing or partial record matches.
+5. Treat an existing disposition comment as complete only when it matches the candidate
+   identity and contains `no-build` or `deferred`, its required observable trigger, and its
+   verification condition. A no-build ruling must also contain its reason. Repair an incomplete
+   comment in place; never append a duplicate disposition.
+
+Read the findings and disposition comments, and repair one in place, by its comment URL:
+
+```sh
+gh issue view RESEARCH_NUMBER --repo OWNER/REPO --json comments \
+  --jq '.comments[] | {url, body}'
+
+# COMMENT_ID is the number after `#issuecomment-` in that comment's URL.
+gh api --method PATCH /repos/OWNER/REPO/issues/comments/COMMENT_ID \
+  --field body=@/path/to/disposition.md
+```
+
+Posting a second comment for a candidate that already has one is a duplicate disposition, not
+a repair.
+
+For each selected candidate, create its standalone build issue first, carrying both the
+`Wayfinder handoff: #<map>` and `Wayfinder candidate:` markers in its body, then add the
+truthful dependency, then add its titled map line:
+
+```sh
+gh issue edit BUILD_NUMBER --repo OWNER/REPO --add-blocked-by RESEARCH_NUMBER
+```
+
+Never make build issues map children or add `wayfinder:*` labels to them. Every unselected
+candidate must instead have a research-ticket disposition comment that says `no-build` or
+`deferred`; include its exact candidate identity, an observable trigger, and a verification
+condition. Selecting zero candidates is valid only when every candidate has one of those
+explicit rulings.
+
+Once replay proves that every candidate is disposed, re-fetch the map and finalize in this
+order: remove its `Awaiting disposition` line, remove the state label, append the research
+ticket's explicit final gist under `Decisions so far`, close the ticket, and release the claim.
+
+```sh
+gh issue edit RESEARCH_NUMBER --repo OWNER/REPO --remove-label wayfinder:awaiting-disposition
+gh issue close RESEARCH_NUMBER --repo OWNER/REPO --reason completed
+gh issue edit RESEARCH_NUMBER --repo OWNER/REPO --remove-label wayfinder:resolving
+```
+
+Replay the full read-and-match procedure after an interruption. Closed research always has a
+durable disposition; no hidden issues-to-file list exists outside GitHub.
+
+## Correct structure
+
+```sh
+# Move a ticket to another map.
+gh issue edit TICKET_NUMBER --repo OWNER/REPO --parent NEW_MAP_NUMBER
+
+# Remove it from the current parent.
+gh issue edit TICKET_NUMBER --repo OWNER/REPO --remove-parent
+
+# Remove a child from a known map.
+gh issue edit MAP_NUMBER --repo OWNER/REPO --remove-sub-issue TICKET_NUMBER
+```
+
+Closing an out-of-scope ticket removes it from the frontier; keep it as a child so the map
+retains its planning history.


### PR DESCRIPTION
## What changed

Eight new skills join the pack, bringing it to twelve:

- **research** — investigate a question against primary sources and capture findings in the repo
- **interface-craft** — design distinctive, production-quality web and product interfaces
- **grilling** — relentlessly interview the user to stress-test a plan before building
- **wayfinder** — chart a large, foggy effort as a GitHub map of decision tickets
- **implement / tdd / review / prototype** — a build-verify loop adopted from Matt Pocock's MIT-licensed skills repository, edited to be self-contained

The repository also moves from Apache-2.0 to MIT (first commit), effective from v0.2.0; v0.1.0 remains under the Apache grant it shipped with. Matt Pocock's copyright is preserved in LICENSE, NOTICE, and a README attribution section, and the old policy of not redistributing third-party skills is formally reversed in CONTRIBUTING.

One small behavior change to an existing skill: cbm-onboard's managed ignore baseline now also excludes `.impeccable/` generated workspaces.

## Why

These skills were maintained privately and are generic methodology with no private coupling — publishing them makes this repo the single source of truth and ends drift between the private and public copies.

## What to check

- The nine files that downstream automation pins by hash (ui-mockups and drive-local-webapp core files) are byte-identical to v0.1.0 — verified, and worth confirming.
- All twelve skills pass `python3 scripts/validate.py` (roster, frontmatter, links, forbidden-pattern and full-history scans); behavior tests and DCO pass on both commits.
- Every cross-skill reference either ships in this pack or is listed under the README's optional upstream skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)