### PR TITLE
Add /scope triage front door, absorbing grilling as its interview mode

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Verify installed skills
         run: |
           for skill in drive-local-webapp cbm-onboard spin-worktree research \
-            implement tdd review prototype grilling wayfinder plan-review \
+            implement tdd review prototype scope wayfinder plan-review \
             ui-craft orchestrate; do
             test -f ".agents/skills/$skill/SKILL.md"
           done

--- a/NOTICE
+++ b/NOTICE
@@ -5,7 +5,7 @@ This repository is MIT licensed; see LICENSE for the authoritative license and
 copyright notices.
 
 The implement, tdd, review, and prototype skills are adopted from, and the
-grilling skill is derived from, Matt Pocock's public skills repository
+scope skill's interview mode is derived from, Matt Pocock's public skills repository
 (https://github.com/mattpocock/skills), MIT licensed,
 copyright (c) 2026 Matt Pocock.
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 | [`drive-local-webapp`](skills/drive-local-webapp/SKILL.md) | Drive and screenshot a local web app with headless Chromium | Node.js 20+; installs Playwright locally |
 | [`cbm-onboard`](skills/cbm-onboard/SKILL.md) | Index a repository with codebase-memory-mcp and keep it current | `codebase-memory-mcp` on `PATH` |
 | [`spin-worktree`](skills/spin-worktree/SKILL.md) | Create isolated Git worktrees for issue and PR work | Git; GitHub CLI only for `--pr` discovery |
-| [`grilling`](skills/grilling/SKILL.md) | Relentlessly interview the user to stress-test a plan or design before building | — |
+| [`scope`](skills/scope/SKILL.md) | Triage front door for work that isn't ready to build: classify the dominant uncertainty and route to one specialist skill, including a bundled interview mode | — |
 | [`plan-review`](skills/plan-review/SKILL.md) | Adversarially review a plan or work order with cold agents before building | Parallel-agent support recommended |
 | [`orchestrate`](skills/orchestrate/SKILL.md) | Flip the session into coordinator mode: delegate all real work to sub-agents routed by an empirically benchmarked model capability table | Codex CLI for GPT-tier sub-agents; table re-benchmarked per its bundled procedure |
-| [`wayfinder`](skills/wayfinder/SKILL.md) | Chart a large, foggy effort as a GitHub map of decision tickets, then hand clear subtrees to implementation | GitHub CLI; composes with `research`, `grilling`, `ui-craft` |
+| [`wayfinder`](skills/wayfinder/SKILL.md) | Chart a large, foggy effort as a GitHub map of decision tickets, then hand clear subtrees to implementation | GitHub CLI; composes with `research`, `scope`'s interview mode, `ui-craft` |
 | [`research`](skills/research/SKILL.md) | Investigate a question against primary sources and capture findings as Markdown in the repo | — |
 | [`prototype`](skills/prototype/SKILL.md) | Build a throwaway prototype — a terminal app for logic questions or switchable UI variants in the real app | — |
 | [`tdd`](skills/tdd/SKILL.md) | Test-driven development through public interfaces, red-green-refactor | — |
@@ -58,7 +58,7 @@ Optional integrations are enhancements, not hidden runtime requirements:
   ordinary repository search and file reads.
 - **`codebase-design`:** referenced by `tdd`; helps shape non-trivial module
   interfaces. Without it, keep the shipping module shape and preserve locality.
-- **`domain-modeling`:** referenced by `grilling` and `wayfinder`; maintains a
+- **`domain-modeling`:** referenced by `scope`'s interview mode and `wayfinder`; maintains a
   project's domain vocabulary. Without it, ground terms in the repo's own docs.
 - **`impeccable`:** adds a final visual-quality audit. Without it, run the
   explicit contrast, focus, overflow, and target-size checks.
@@ -72,7 +72,7 @@ npx skills add mattpocock/skills --skill codebase-design --skill domain-modeling
 ## Attribution
 
 The `implement`, `tdd`, `review`, and `prototype` skills are adopted from — and
-`grilling` is derived from — [Matt Pocock's skills
+`scope`'s interview mode is derived from — [Matt Pocock's skills
 repository](https://github.com/mattpocock/skills) (MIT, copyright (c) 2026 Matt
 Pocock), lightly edited here to be self-contained. See [LICENSE](LICENSE) and
 [NOTICE](NOTICE).

--- a/docs/orchestrate-spec.md
+++ b/docs/orchestrate-spec.md
@@ -1,6 +1,6 @@
 # /orchestrate — locked spec (2026-08-03)
 
-Settled in a grilling session; this file is the fixed reference the finished
+Settled in a scope interview session; this file is the fixed reference the finished
 skill is compared against. Changes after this point are deviations and must be
 called out, not silently absorbed.
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -20,7 +20,7 @@ EXPECTED = {
     "tdd",
     "review",
     "prototype",
-    "grilling",
+    "scope",
     "wayfinder",
     "plan-review",
     "ui-craft",

--- a/skills/grilling/agents/openai.yaml
+++ b/skills/grilling/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Grilling"
-  short_description: "Interview the user until a plan is fully settled"
-  default_prompt: "Use $grilling to stress-test this plan before building."

--- a/skills/scope/SKILL.md
+++ b/skills/scope/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: scope
+description: Triage front door for work that isn't ready to build. Classifies the dominant uncertainty and routes to one specialist skill. Use for 'let's scope this', '/scope', 'scope this out', 'not sure how to approach', 'grill me on this', 'stress-test this plan', or any request carrying real ambiguity about what to do next.
+---
+
+# Scope
+
+Diagnose why work isn't buildable yet, route to exactly one specialist skill, and open
+a ledger the moment routing happens. Never do the specialist's work yourself — a
+correct route with no other output is a complete session.
+
+## Routing table
+
+Classify the **dominant** uncertainty — the one that, if resolved, makes the others
+tractable — and route to exactly one of:
+
+- **Big and foggy, many interlocking decisions that block each other** → `wayfinder`.
+- **A concrete plan or design exists but is untested** → interview mode
+  ([references/interview.md](references/interview.md), in this skill).
+- **Missing facts answerable from docs or sources** → `research`.
+- **Only answerable by feeling it out in running code** → `prototype`.
+- **The dominant uncertainty is what a user-facing surface should look like** →
+  `ui-craft`, lock phase.
+- **Mixed or unclear** → ask the user **one** framing question, then route. One
+  question at a time, always — never a menu of questions.
+
+If the request already names a specialist by trigger phrase (a `grill`-style trigger
+names interview mode; a wayfinder map names `wayfinder`), route there directly without
+re-diagnosing.
+
+## Ledger — required
+
+At the moment routing happens, open a ledger before invoking the specialist:
+
+- **Path:** `docs/scope/<slug>.md` in the target project's repo when that path is
+  writable; otherwise the session scratchpad. `<slug>` is a short kebab-case name for
+  the work.
+- **Sections:** `Decisions`, `Open questions`, `Spawned tasks`.
+- **Decisions** get appended **at the moment each one settles** — never batched at
+  session end. Each entry: the decision, a one-line why, and a disposition tag —
+  `→ ADR`, `→ issue`, or `inline`.
+- The ledger is the durable session state. A fresh agent resumes by reading it, not by
+  re-deriving context from chat history.
+
+## Exit protocol
+
+The session is not done until every disposition is discharged:
+
+- Every `→ ADR` decision has a real ADR written.
+- Every `→ issue` decision has a filed GitHub issue.
+- The ledger's remaining-dispositions list is empty.
+
+Report which dispositions remain open if the session ends early; do not report the
+scoping work as finished while any disposition is outstanding.

--- a/skills/scope/agents/openai.yaml
+++ b/skills/scope/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Scope"
+  short_description: "Triage front door: classify the dominant uncertainty and route to one specialist skill"
+  default_prompt: "Use $scope to figure out how to approach this before building."

--- a/skills/scope/references/interview.md
+++ b/skills/scope/references/interview.md
@@ -1,29 +1,26 @@
----
-name: grilling
-description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
----
+# Interview mode
 
-Interview me relentlessly about every aspect of this plan until we reach a
-shared understanding. Map the plan as a **design tree**: every decision branches
-into the decisions that depend on it.
+Routed here from `scope` when a concrete plan or design exists but is untested.
+Interview me relentlessly about every aspect of the plan until we reach a shared
+understanding. Map the plan as a **design tree**: every decision branches into the
+decisions that depend on it.
 
-Work the tree in **rounds**. The **frontier** is every decision whose
-prerequisites are already settled — everything I can answer now without either
-of us guessing at an earlier answer. Ask the whole frontier in one numbered
-round, then wait for my answers before continuing. Keep tightly coupled
-questions together so I can scroll through the round and dictate answers by
-number.
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are
+already settled — everything I can answer now without either of us guessing at an
+earlier answer. Ask the whole frontier in one numbered round, then wait for my answers
+before continuing. Keep tightly coupled questions together so I can scroll through the
+round and dictate answers by number.
 
-After each response, record the settled decisions, recompute the frontier, and
-ask the next round. If one answer could materially change whether or how another
-question should be asked, those questions are not on the same frontier: ask the
+After each response, record the settled decisions in the scope ledger, recompute the
+frontier, and ask the next round. If one answer could materially change whether or how
+another question should be asked, those questions are not on the same frontier: ask the
 dependency first and save the downstream question for a later round.
 
-Finding facts is your job; making decisions is mine. If a frontier question
-needs a fact from the environment, explore it instead of asking me. When
-subagents are available, dispatch fact-finding to a subagent and continue with
-the rest of the frontier; treat only questions downstream of that exploration
-as blocked. Put every actual decision to me.
+Finding facts is your job; making decisions is mine. If a frontier question needs a
+fact from the environment, explore it instead of asking me. When subagents are
+available, dispatch fact-finding to a subagent and continue with the rest of the
+frontier; treat only questions downstream of that exploration as blocked. Put every
+actual decision to me.
 
 ## Voice rules — I have not read the code as deeply as you have
 
@@ -97,20 +94,20 @@ implementation detail:
   answer to "don't handle it"; make me overrule the default rather than making
   me strip speculative hardening out later.
 
-## Docs as you go (default)
+## Docs as you go
 
-When the session is grounded in a repo, load the `/domain-modeling` skill at
-the start and apply it throughout: the moment a decision crystallises that
-constrains architecture or behavior, write the ADR (`docs/adr/`); the moment
-a fuzzy term gets sharpened, update the glossary (`CONTEXT.md`). Write them
-as they land, not in a batch at the end — a decision that only exists in
-chat is lost to the next session. Challenge terms against the existing
+Load the `domain-modeling` skill at the start when available, and apply it throughout:
+the moment a decision crystallises that constrains architecture or behavior, append it
+to the scope ledger's `Decisions` section with its disposition tag (`→ ADR`, `→ issue`,
+or `inline`); the moment a fuzzy term gets sharpened, update the glossary
+(`CONTEXT.md`). Write these as they land, not in a batch at the end — a decision that
+only exists in chat is lost to the next session. Challenge terms against the existing
 glossary as you interview.
 
 ## Closing
 
-The session is done when the frontier is empty: every branch has been visited
-and nothing remains silently assumed. End with a compact summary of every
-decision made (the shared understanding), flag anything deferred or defaulted,
-and list the ADRs/glossary entries written during the session. Do not enact the
-plan until I confirm we have reached a shared understanding.
+The session is done when the frontier is empty: every branch has been visited and
+nothing remains silently assumed. End with a compact summary of every decision made
+(the shared understanding), flag anything deferred or defaulted, and confirm every
+ledger disposition — `→ ADR`, `→ issue` — has been discharged per scope's exit
+protocol. Do not enact the plan until I confirm we have reached a shared understanding.

--- a/skills/ui-craft/reference/lock.md
+++ b/skills/ui-craft/reference/lock.md
@@ -37,8 +37,8 @@ Write the design brief from `design-rules.md` (job, audience and setting,
 direction, signature move, density, constraints, anti-references) plus: one
 surface, one decision, hard constraints, states to render, and three or four
 named concept directions that differ in layout metaphor, information
-hierarchy, or interaction model — not decoration. Use `grilling` to sharpen
-the brief when installed.
+hierarchy, or interaction model — not decoration. Use `scope`'s interview mode to
+sharpen the brief when installed.
 
 ### 4. Fan out
 

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -89,9 +89,9 @@ Apply exactly one ticket-type label:
 - **`wayfinder:prototype` (HITL):** Invoke `/ui-craft`. Produce repository-grounded
   variants, iterate with the human, and finish with a locked visual spec linked from the
   ticket. That artifact also satisfies any later review gate that demands a locked design.
-- **`wayfinder:grilling` (HITL):** Invoke `/grilling`, plus a domain-modelling skill when
-  one is available; ask one question at a time. Never answer the human's side of the
-  exchange.
+- **`wayfinder:interview` (HITL):** Invoke `/scope`'s interview mode, plus a
+  domain-modelling skill when one is available; ask one question at a time. Never
+  answer the human's side of the exchange.
 - **`wayfinder:task` (HITL):** A prerequisite that genuinely needs the human in the loop.
   It earns a place only by unblocking a decision, not by delivering the destination — and
   it is never an execution errand: a prerequisite that must *change the world* before a
@@ -131,8 +131,8 @@ not add it to `Decisions so far`.
 
 When the user brings a loose idea:
 
-1. Run `/grilling`, and a domain-modelling skill when one is available, to name the
-   destination. The destination fixes scope, so settle it first.
+1. Run `/scope`'s interview mode, and a domain-modelling skill when one is available, to
+   name the destination. The destination fixes scope, so settle it first.
 2. Grill breadth-first across the effort. Surface precise decisions, dependency order, and
    coarse fog without resolving any ticket.
 3. If the route is already clear and fits one session, stop and tell the user a map would

--- a/skills/wayfinder/references/github-tracker.md
+++ b/skills/wayfinder/references/github-tracker.md
@@ -14,9 +14,17 @@ the state of any issue:
 gh label create wayfinder:map       --color 5319e7 --description "Map of decisions for a multi-session effort" --force
 gh label create wayfinder:research  --color 0e8a16 --description "AFK research decision" --force
 gh label create wayfinder:prototype --color 1d76db --description "HITL locked UI mockup decision" --force
-gh label create wayfinder:grilling  --color fbca04 --description "HITL grilling or domain decision" --force
+gh label create wayfinder:interview --color fbca04 --description "HITL interview or domain decision" --force
 gh label create wayfinder:task      --color c5def5 --description "Prerequisite action that unblocks a decision" --force
 gh label create wayfinder:awaiting-disposition --color bfdadc --description "Completed research awaiting human disposition" --force
+```
+
+Repositories labeled under the pre-scope vocabulary carry `wayfinder:grilling` instead of
+`wayfinder:interview`. Renaming the label migrates every ticket that carries it in one
+step — run this before the create block, and skip it when the old label is absent:
+
+```sh
+gh label edit wayfinder:grilling --name wayfinder:interview --description "HITL interview or domain decision" 2>/dev/null || true
 ```
 
 Every map and decision ticket carries exactly one of the first five ticket-type labels.
@@ -36,7 +44,7 @@ gh issue create --repo OWNER/REPO --title "Map: <destination>" \
   --body-file /path/to/map-body.md --label wayfinder:map
 
 gh issue create --repo OWNER/REPO --title "Decide <question>" \
-  --body-file /path/to/ticket-body.md --label wayfinder:grilling
+  --body-file /path/to/ticket-body.md --label wayfinder:interview
 ```
 
 Capture the returned URLs or resolve titles immediately; never guess issue numbers.


### PR DESCRIPTION
## What changed

- New `scope` skill: a triage front door for work that isn't ready to build. It names the dominant uncertainty and routes to exactly one specialist — wayfinder for big foggy efforts, a bundled interview mode for untested plans, research for missing facts, prototype for feel-it-out questions, ui-craft's lock phase for visual uncertainty — asking the user at most one framing question when the signal is mixed.
- The `grilling` skill is absorbed: its interviewing method moves unchanged into scope's interview reference, so "grill me on this" still works but the front door decides when interviewing is the right tool.
- Scope sessions now keep a **ledger on disk**: every settled decision is written down the moment it settles, tagged for where it must land (an ADR, a filed issue, or inline), and the session cannot close while any of those obligations is undischarged. Compaction or handoff no longer loses decisions — a fresh agent resumes from the ledger.
- Wayfinder's interview ticket label is now `wayfinder:interview`; the tracker reference documents a one-step label rename that migrates existing tickets, and the rename has already been applied to the four repos that carried the old label.

## What to check

- The routing table in `skills/scope/SKILL.md` — six routes, one question at a time.
- The interview mode reads as grilling did: frontier rounds, ≤6-line behavior-phrased questions, explain/ground-it escape hatches.
- `scripts/validate.py` passes (13 skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)