### PR TITLE
orchestrate: fan out mockup drafts one sub-agent per concept direction

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -81,6 +81,11 @@ When coordinator mode runs a ui-craft lifecycle, the delegation split is:
 
 - **Mockup drafts (lock phase)**: Sol; Spark when a design system or existing
   lock is there to reuse (and for fast iteration rounds); Opus escalation.
+  **Fan out one sub-agent per concept direction, in parallel** — each agent
+  gets the brief plus exactly one named direction and never sees the others'
+  output. Never ask a single agent for N variants: one context produces N
+  shades of one idea, and the divergence the lock phase exists to compare is
+  lost. Iteration rounds on an already-chosen direction may stay single-agent.
 - **Visual judgment** — critiquing renders, deciding what locks: stays with the
   coordinator (verification + operator-facing decisions). Persona-critique
   reading passes may go to Terra/Opus, but the lock call is surfaced to the


### PR DESCRIPTION
## What changed

The /ui-craft composition section of the orchestrate skill now requires the coordinator to spawn one parallel sub-agent per mockup concept direction — each gets the brief plus exactly one named direction, blind to the others — instead of asking one agent for all the variants. One context produces shades of one idea; the lock phase's whole value is comparing genuinely divergent takes. Iteration rounds on an already-chosen direction stay single-agent.

## What to check

The new sentence sits in the "Mockup drafts (lock phase)" bullet and doesn't change the model routing (Sol / Spark / Opus escalation), only the dispatch shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)