### PR TITLE
docs(scope): lock the interview question format

### DIFF
--- a/skills/scope/references/interview-format.lock.md
+++ b/skills/scope/references/interview-format.lock.md
@@ -1,0 +1,24 @@
+# Lock manifest — interview question format
+
+Locked: 2026-08-05 by Connor Griffin (live iteration in a scoping session, 4 concepts compared rendered)
+Mock: the fenced sample in interview.md rule 2 (medium is chat-rendered markdown; no HTML mockup exists)
+Supersedes: the unlocked format prose that rule 2 carried before this date
+
+## Precedence
+
+This manifest wins for question rendering wherever interview mode runs; client-specific markdown rendering quirks never justify a format deviation.
+
+## Terms
+
+| # | Term | Kind | Evidence expected |
+|---|------|------|-------------------|
+| 1 | Question line is bold, numbered `**N. …?**`, phrased as behavior | gate | rendered round |
+| 2 | Options and rec form one blockquote; options one per line as `A.` `B.` `C.`, 2-4 of them | gate | rendered round |
+| 3 | Rec is the quote's last line: nbsp-indented, `↳` prefix, fully italic, why in the same sentence | gate | rendered round |
+| 4 | Rec reads visually subordinate to the options above it | eye | rendered round |
+| 5 | Never tables, never bulleted options, no em-dashes, no answer-coaching lines ("answer like…") | gate | rendered round |
+| 6 | ≤6 lines per question; whole round sent as one message; stable numbering across the session | gate | rendered round |
+
+## Verbatim strings
+
+`↳ *rec X: …*` — the rec line's shape, including the arrow and the lowercase "rec".

--- a/skills/scope/references/interview.md
+++ b/skills/scope/references/interview.md
@@ -30,26 +30,28 @@ actual decision to me.
    dedupe by `source_event_id`?" A code term is allowed only as a one-line
    parenthetical when it genuinely disambiguates.
 
-2. **Hard budget: ≤6 lines per question, rendered in exactly this format:**
+2. **Hard budget: ≤6 lines per question, rendered in exactly this format
+   (★ locked 2026-08-05, see interview-format.lock.md):**
 
    ```
    **1. Question, phrased as behavior?**
    > A. first option
    > B. second option
    > C. third option
-
-   *rec B: one-line why*
+   > &nbsp;&nbsp;&nbsp;&nbsp;↳ *rec B: one-line why*
    ```
 
-   The question line is bold and numbered. Options live in a blockquote, one
-   per line, capital letters with periods, never bulleted, never in a table.
-   The recommendation sits below the quote on its own italic line, visually
-   diminished relative to the options, with its why in the same breath.
-   Options are 2–4, concrete, grounded in real examples where possible ("on
-   June 30 this would have meant…"). No em-dashes anywhere. No preamble, no
-   context essay, no restating what we've already agreed. Depth only when I
-   ask for it. A verbose question makes me agree just to make it stop — that
-   produces a confidently wrong spec, which is worse than no spec.
+   Each question is one visual unit: bold numbered question line, then a
+   single blockquote holding the options (one per line, capital letters with
+   periods, never bulleted, never in a table) and, as its last line, the
+   recommendation — indented with non-breaking spaces, led by ↳, fully
+   italic, why in the same breath — visually subordinate to the options
+   above it. Options are 2–4, concrete, grounded in real examples where
+   possible ("on June 30 this would have meant…"). No em-dashes anywhere in
+   rendered questions. No preamble, no context essay, no restating what
+   we've already agreed. Depth only when I ask for it. A verbose question
+   makes me agree just to make it stop — that produces a confidently wrong
+   spec, which is worse than no spec.
 
 3. **Accept shorthand answers; never coach them.** Use stable numbers within
    the session and concise, distinct option labels so answers like "1 yes;

--- a/skills/scope/references/interview.md
+++ b/skills/scope/references/interview.md
@@ -30,19 +30,33 @@ actual decision to me.
    dedupe by `source_event_id`?" A code term is allowed only as a one-line
    parenthetical when it genuinely disambiguates.
 
-2. **Hard budget: ≤6 lines per question.** Number every question. Include the
-   question, 2–3 concrete options
-   grounded in real examples where possible ("on June 30 this would have
-   meant…"), and your recommended answer. No preamble, no context essay, no
-   restating what we've already agreed. Depth only when I ask for it. A
-   verbose question makes me agree just to make it stop — that produces a
-   confidently wrong spec, which is worse than no spec.
+2. **Hard budget: ≤6 lines per question, rendered in exactly this format:**
 
-3. **Make shorthand answers easy.** Use stable numbers within the session and
-   concise, distinct option labels so answers like "1 yes; 2 B; 3 your
-   recommendation" are unambiguous. Accept free-form or partial answers too;
-   carry unanswered decisions into the next round without re-asking settled
-   ones.
+   ```
+   **1. Question, phrased as behavior?**
+   > A. first option
+   > B. second option
+   > C. third option
+
+   *rec B: one-line why*
+   ```
+
+   The question line is bold and numbered. Options live in a blockquote, one
+   per line, capital letters with periods, never bulleted, never in a table.
+   The recommendation sits below the quote on its own italic line, visually
+   diminished relative to the options, with its why in the same breath.
+   Options are 2–4, concrete, grounded in real examples where possible ("on
+   June 30 this would have meant…"). No em-dashes anywhere. No preamble, no
+   context essay, no restating what we've already agreed. Depth only when I
+   ask for it. A verbose question makes me agree just to make it stop — that
+   produces a confidently wrong spec, which is worse than no spec.
+
+3. **Accept shorthand answers; never coach them.** Use stable numbers within
+   the session and concise, distinct option labels so answers like "1 yes;
+   2 B; 3 rec" are unambiguous — and never print instructions on how to
+   answer ("answer like…"); the format makes it obvious. Accept free-form or
+   partial answers too; carry unanswered decisions into the next round
+   without re-asking settled ones.
 
 4. **`explain` escape hatch.** If I say "explain", stop and produce a proper
    explainer for the current question — a diagram, worked example, or


### PR DESCRIPTION
Locks the question format interview mode renders, settled by live iteration in a scoping session:

* Question line bold and numbered, phrased as behavior.
* Options in a blockquote, one per line, capital letters with periods. Never bullets, never tables.
* Recommendation below the options on its own italic line, visually diminished, with its why in the same sentence.
* No em-dashes in rendered questions, and no answer-coaching lines ("answer like...") — shorthand answers stay accepted, just never instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)