### PR TITLE
fix(cbm-onboard): reindex the checkout that fired the hook, not the main root

### DIFF
--- a/skills/cbm-onboard/SKILL.md
+++ b/skills/cbm-onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cbm-onboard
-description: Register a Git repository with codebase-memory-mcp, create a managed .cbmignore baseline, install a non-clobbering post-commit reindex hook, and run the initial index. Use when asked to index, onboard, register, or keep a repository current in Codebase Memory.
+description: Register a Git repository with codebase-memory-mcp, create a managed .cbmignore baseline, install non-clobbering post-commit/post-merge/post-checkout reindex hooks, and run the initial index. Use when asked to index, onboard, register, or keep a repository current in Codebase Memory.
 ---
 
 # Onboard a repository to Codebase Memory
@@ -25,19 +25,27 @@ project. Never index a directory containing several repositories.
 
    The script resolves linked worktrees to the maintained checkout, reconciles
    a marked baseline inside `.cbmignore`, preserves custom exclusions, and adds
-   a managed reindex block to Git's configured `post-commit` hook without
-   deleting an existing shell hook. It refuses symlink targets. A non-shell
-   foreign hook is left unchanged with a warning because composing it would be
-   unsafe.
+   a managed reindex block to Git's configured `post-commit`, `post-merge`, and
+   `post-checkout` hooks without deleting an existing shell hook. The
+   `post-checkout` block carries a `[ "$3" = "1" ] || exit 0` guard so it only
+   fires on branch checkouts, not per-file checkouts. It refuses symlink
+   targets. A non-shell foreign hook is left unchanged with a warning because
+   composing it would be unsafe.
+
+   Pass `--this-checkout` to onboard the current checkout as-is instead of
+   resolving to the main worktree — use this for a linked worktree that wants
+   its own `.cbmignore` and hooks rather than sharing the control checkout's.
 
 3. Verify the project through the available Codebase Memory MCP interface with
    `index_status` or `list_projects`.
 4. Report node and edge counts when available.
 5. Tell the user that `.cbmignore` is tracked and should be committed. The Git
-   hook is clone-local, so rerun onboarding after a fresh clone.
+   hooks are clone-local, so rerun onboarding after a fresh clone.
 
-The initial index uses full mode. Post-commit indexing uses fast mode in a
-detached process. Re-running onboarding is idempotent.
+The initial index uses full mode. post-commit/post-merge/post-checkout
+indexing uses fast mode in a detached process and always exits 0, so a broken
+index never fails a commit, merge, or checkout. Re-running onboarding is
+idempotent.
 
 Repositories dominated by YAML, prose, or shell may produce a thin graph; say
 so rather than refusing to index them.

--- a/skills/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/cbm-onboard/scripts/cbm-onboard.sh
@@ -11,27 +11,31 @@ BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 REINDEX="$SCRIPT_DIR/cbm-reindex.sh"
-TARGET="${1:-.}"
-ROOT="$(git -C "$TARGET" worktree list --porcelain 2>/dev/null |
-  awk '/^worktree / { print substr($0, 10); exit }')"
+
+THIS_CHECKOUT=0
+TARGET="."
+for arg in "$@"; do
+  case "$arg" in
+    --this-checkout) THIS_CHECKOUT=1 ;;
+    *) TARGET="$arg" ;;
+  esac
+done
+
+if [ "$THIS_CHECKOUT" -eq 1 ]; then
+  ROOT="$(git -C "$TARGET" rev-parse --show-toplevel 2>/dev/null || true)"
+else
+  ROOT="$(git -C "$TARGET" worktree list --porcelain 2>/dev/null |
+    awk '/^worktree / { print substr($0, 10); exit }')"
+fi
 [ -n "$ROOT" ] || {
   printf 'not a Git repository: %s\n' "$TARGET" >&2
   exit 1
 }
 
 IGNORE="$ROOT/.cbmignore"
-HOOK_PATH="$(git -C "$ROOT" rev-parse --git-path hooks/post-commit)"
-case "$HOOK_PATH" in
-  /*) HOOK="$HOOK_PATH" ;;
-  *) HOOK="$ROOT/$HOOK_PATH" ;;
-esac
 
 [ ! -L "$IGNORE" ] || {
   printf 'refusing symlink target: %s\n' "$IGNORE" >&2
-  exit 1
-}
-[ ! -L "$HOOK" ] || {
-  printf 'refusing symlink target: %s\n' "$HOOK" >&2
   exit 1
 }
 
@@ -105,21 +109,44 @@ else
   printf '%s\n' "$IGNORE is already current"
 fi
 
-mkdir -p "$(dirname "$HOOK")"
-INSTALL_HOOK=1
-if [ -e "$HOOK" ]; then
-  FIRST_LINE="$(sed -n '1p' "$HOOK")"
-  if ! printf '%s\n' "$FIRST_LINE" |
-    grep -Eq '^#!.*[/[:space:]](ba|da|k|z)?sh([[:space:]]|$)'; then
-    printf 'SKIP hook installation: existing hook is not a shell script; left unchanged: %s\n' \
-      "$HOOK" >&2
-    INSTALL_HOOK=0
-  fi
-else
-  printf '%s\n' "#!/bin/sh" >"$HOOK_TMP"
-fi
+COMMON_DIR="$(git -C "$ROOT" rev-parse --git-common-dir)"
+case "$COMMON_DIR" in
+  /*) : ;;
+  *) COMMON_DIR="$ROOT/$COMMON_DIR" ;;
+esac
 
-if [ "$INSTALL_HOOK" -eq 1 ]; then
+for HOOK_NAME in post-commit post-merge post-checkout; do
+  # Install into the repo-local hooks dir directly (git-common-dir, worktree-
+  # safe), not via `git rev-parse --git-path`: a global core.hooksPath
+  # override (e.g. a dotfiles-managed dispatcher) makes --git-path resolve
+  # outside the repo, which this script would then correctly refuse as a
+  # symlink target. The repo-local path is what such dispatchers themselves
+  # run first, so installing there composes with them instead of being
+  # silently shadowed.
+  HOOK="$COMMON_DIR/hooks/$HOOK_NAME"
+
+  if [ -L "$HOOK" ]; then
+    printf 'refusing symlink target: %s\n' "$HOOK" >&2
+    continue
+  fi
+
+  : >"$HOOK_TMP"
+  mkdir -p "$(dirname "$HOOK")"
+  INSTALL_HOOK=1
+  if [ -e "$HOOK" ]; then
+    FIRST_LINE="$(sed -n '1p' "$HOOK")"
+    if ! printf '%s\n' "$FIRST_LINE" |
+      grep -Eq '^#!.*[/[:space:]](ba|da|k|z)?sh([[:space:]]|$)'; then
+      printf 'SKIP hook installation: existing hook is not a shell script; left unchanged: %s\n' \
+        "$HOOK" >&2
+      INSTALL_HOOK=0
+    fi
+  else
+    printf '%s\n' "#!/bin/sh" >"$HOOK_TMP"
+  fi
+
+  [ "$INSTALL_HOOK" -eq 1 ] || continue
+
   if [ -e "$HOOK" ]; then
     awk -v begin="$BEGIN_HOOK" -v end="$END_HOOK" '
       { lines[++n] = $0 }
@@ -147,16 +174,23 @@ if [ "$INSTALL_HOOK" -eq 1 ]; then
   fi
   {
     printf '\n%s\n' "$BEGIN_HOOK"
-    printf '"%s" "%s"\n' "$REINDEX" "$ROOT"
+    if [ "$HOOK_NAME" = "post-checkout" ]; then
+      printf '%s\n' '[ "$3" = "1" ] || exit 0'
+    fi
+    printf '"%s"\n' "$REINDEX"
     printf '%s\n' "$END_HOOK"
   } >>"$HOOK_TMP"
   cp "$HOOK_TMP" "$HOOK"
   chmod +x "$HOOK"
   printf '%s\n' "installed managed reindex command in $HOOK"
-fi
+done
 
-PAYLOAD="$(python3 -c \
-  'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "full"}))' \
-  "$ROOT")"
-"$BIN" cli index_repository "$PAYLOAD"
-printf '%s\n' "indexed $ROOT"
+if [ "${CBM_SKIP_INDEX:-0}" = "1" ]; then
+  printf '%s\n' "skipped initial index (CBM_SKIP_INDEX=1): $ROOT"
+else
+  PAYLOAD="$(python3 -c \
+    'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "full"}))' \
+    "$ROOT")"
+  "$BIN" cli index_repository "$PAYLOAD"
+  printf '%s\n' "indexed $ROOT"
+fi

--- a/skills/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/cbm-onboard/scripts/cbm-onboard.sh
@@ -115,18 +115,26 @@ case "$COMMON_DIR" in
   *) COMMON_DIR="$ROOT/$COMMON_DIR" ;;
 esac
 
+# Honor an explicit core.hooksPath (e.g. a dotfiles-managed dispatcher):
+# install alongside it rather than shadowing it under .git/hooks. Fall back
+# to the repo-local, worktree-safe hooks dir when unset.
+HOOKS_PATH="$(git -C "$ROOT" config --get core.hooksPath 2>/dev/null || true)"
+if [ -n "$HOOKS_PATH" ]; then
+  case "$HOOKS_PATH" in
+    /*) HOOKS_DIR="$HOOKS_PATH" ;;
+    *) HOOKS_DIR="$ROOT/$HOOKS_PATH" ;;
+  esac
+else
+  HOOKS_DIR="$COMMON_DIR/hooks"
+fi
+
+HOOK_SYMLINK_REFUSED=0
 for HOOK_NAME in post-commit post-merge post-checkout; do
-  # Install into the repo-local hooks dir directly (git-common-dir, worktree-
-  # safe), not via `git rev-parse --git-path`: a global core.hooksPath
-  # override (e.g. a dotfiles-managed dispatcher) makes --git-path resolve
-  # outside the repo, which this script would then correctly refuse as a
-  # symlink target. The repo-local path is what such dispatchers themselves
-  # run first, so installing there composes with them instead of being
-  # silently shadowed.
-  HOOK="$COMMON_DIR/hooks/$HOOK_NAME"
+  HOOK="$HOOKS_DIR/$HOOK_NAME"
 
   if [ -L "$HOOK" ]; then
     printf 'refusing symlink target: %s\n' "$HOOK" >&2
+    HOOK_SYMLINK_REFUSED=1
     continue
   fi
 
@@ -184,6 +192,8 @@ for HOOK_NAME in post-commit post-merge post-checkout; do
   chmod +x "$HOOK"
   printf '%s\n' "installed managed reindex command in $HOOK"
 done
+
+[ "$HOOK_SYMLINK_REFUSED" -eq 0 ] || exit 1
 
 if [ "${CBM_SKIP_INDEX:-0}" = "1" ]; then
   printf '%s\n' "skipped initial index (CBM_SKIP_INDEX=1): $ROOT"

--- a/skills/cbm-onboard/scripts/cbm-reindex.sh
+++ b/skills/cbm-onboard/scripts/cbm-reindex.sh
@@ -6,13 +6,8 @@ set -u
 BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true)}"
 [ -n "$BIN" ] && [ -x "$BIN" ] || exit 0
 
-ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+ROOT="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD" && git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$ROOT" ] || exit 0
-
-MAIN_ROOT="$(git -C "$ROOT" worktree list --porcelain 2>/dev/null |
-  awk '/^worktree / { print substr($0, 10); exit }')"
-[ -n "$MAIN_ROOT" ] || exit 0
-[ "$ROOT" = "$MAIN_ROOT" ] || exit 0
 
 PAYLOAD="$(python3 -c \
   'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "fast"}))' \


### PR DESCRIPTION
* hooks on post-commit, post-merge, post-checkout (branch switches only)
* --this-checkout flag for worktree onboarding; compose with a global hooksPath

🤖 Generated with [Claude Code](https://claude.com/claude-code)