### PR TITLE
docs(orchestrate): route worktree creation through spin-worktree

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -52,6 +52,10 @@ review is not optional); prototyping routes straight to **Opus**.
 - The coordinator keeps for itself: small mechanical glue (git/gh plumbing,
   toggles, log checks, daemon restarts), verification probes, and all
   communication/decisions with the operator.
+- Worktree creation is not raw git plumbing: when preparing a worktree for a
+  sub-agent (or any task work), invoke the `spin-worktree` skill so worktrees
+  land under its `~/worktrees/<repository>/<task>` convention, not ad-hoc
+  paths next to the checkout.
 
 ## Routing
 


### PR DESCRIPTION
Coordinator mode treated worktree creation as the git plumbing it keeps for itself, so worktrees ended up at ad-hoc paths next to the checkout instead of spin-worktree's ~/worktrees convention. One bullet in the coordinator ruling now routes worktree creation through the spin-worktree skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)