### PR TITLE
refactor: token audit fixes — charter disclosure, say-less positive phrasing

### DIFF
--- a/profile/CHARTER.md
+++ b/profile/CHARTER.md
@@ -8,44 +8,26 @@ and enforced at review: a violation below is a blocking finding.
 
 ## Architecture — deep modules
 
-- Every module's **interface is far simpler than its implementation.** A module whose
-  interface is nearly as complex as its body is *shallow* — deepen it or delete it.
 - Apply the **deletion test:** if removing a module just moves complexity around
   rather than concentrating it, it shouldn't exist.
-- **The interface is the test surface.** Don't extract pure functions "for
-  testability" when the real bugs live in how they're called — preserve **locality**.
 - Use the vocabulary exactly — module / interface / depth / seam / adapter / leverage
   / locality (`/codebase-design`). **One adapter = a hypothetical seam; two = a real
   one** — don't build the seam before the second caller exists.
 
 ## UI — never invented at build time
 
-- Any user-facing surface goes through **`/ui-craft lock` to a *locked* visual
-  spec** before it is implemented — a ★ LOCKED mockup **plus its lock manifest**
-  (`mockups/<surface>.lock.md`: numbered gate/eye terms, a precedence line for
-  design-system conflicts, fixture obligations, verbatim strings). No ad-hoc UI.
-- Implementation runs as **`/ui-craft build`**: the manifest is the contract.
-  Locked-artifact contradictions are surfaced, never arbitrated in private;
-  deviations go through `/ui-craft resettle`, never a quiet diff; every `gate`
-  term gets a rendered assertion that has been **shown to fail** when its
-  feature is knocked out; replacing a test file transfers its assertions or
-  names the drops in the PR.
-- A PR that changes a user-facing surface attaches **paired mock-vs-build
-  screenshots** (headless Playwright, same fixture and viewports — fixtures
-  must actually exercise the locked visuals) and a **fidelity ledger** walking
-  every manifest term to `met` / `re-settle` / `blocked` — the unattended
-  stand-in for a live demo.
-  A UI change missing the pairs or the ledger is a **blocking** gap, not a nit.
-  Green gates are not the finish line; the walked manifest is.
+- Every user-facing surface goes through the **`/ui-craft`** lock-then-build
+  lifecycle: lock a visual spec before implementation, build against that lock,
+  and attach fidelity evidence to the PR. The full rules (manifest format,
+  resettle process, screenshot and ledger requirements) live with `/ui-craft`.
 
 ## The pull request — framed for the human who merges
 
 - **The PR body is written for whoever merges it, in plain language:** what changed,
-  why, and what to check — in the app's own domain terms (**`CONTEXT.md`**), not the
-  implementation. The PR already *is* the diff; don't narrate it in code.
-- **No jargon:** a body that leans on file / function / test names or CSS / API
-  specifics instead of app behavior can't be merged at a glance — that's a
-  **blocking** gap, not a nit.
+  why, and what to check — in the app's own domain terms (**`CONTEXT.md`**), not
+  file / function / test names or CSS / API specifics. The diff already shows the
+  implementation; a body that leans on it instead of app behavior is a **blocking**
+  gap, not a nit.
 
 ## Testing — through the interface
 

--- a/profile/CHARTER.md
+++ b/profile/CHARTER.md
@@ -8,6 +8,10 @@ and enforced at review: a violation below is a blocking finding.
 
 ## Architecture — deep modules
 
+- Every module's interface is far simpler than its implementation; a shallow
+  module is deepened or deleted.
+- The interface is the test surface: don't extract pure functions for
+  testability at the cost of locality.
 - Apply the **deletion test:** if removing a module just moves complexity around
   rather than concentrating it, it shouldn't exist.
 - Use the vocabulary exactly — module / interface / depth / seam / adapter / leverage

--- a/profile/base.md
+++ b/profile/base.md
@@ -7,11 +7,8 @@ overlay sections in your local `CLAUDE.md`/`AGENTS.md` on top of both.
 
 Governs how much you say while you work, not what you build. A human is reading
 unless your output goes to another agent — a subagent task, a daemon-spawned fleet
-session — in which case only the final-answer rules apply. Claude Code and Codex
-both push toward minimal preamble, and Claude Code's own prompt offers "Let me read
-the file." as its *corrected* form; that concision governs how long each sentence
-is, not whether you report at all. Where it collides with this section, this section
-wins. Harness safety and permission rules override both.
+session — in which case only the final-answer rules apply. Where it collides with
+this section, this section wins. Harness safety and permission rules override both.
 
 **Every message that opens with tool results opens with a sentence of prose** — one
 sentence, past tense, the new fact and what it changes. Nothing new *is* a fact —

--- a/skills/say-less/SKILL.md
+++ b/skills/say-less/SKILL.md
@@ -35,24 +35,24 @@ this skill. See [docs/overlay.md](../../docs/overlay.md).
    command, path, or snippet, it goes first; prose after, if at all.
 2. **Yes/no questions get yes or no as the first word.** Detail only if it changes
    the reader's decision.
-3. **Stop when done.** End on the last piece of information — nothing past it:
-   drop the trailing summary, sign-off, "going forward", "let me know if".
+3. **Stop when done.** End on the last piece of information: drop the trailing
+   summary, sign-off, "going forward", "let me know if".
 4. **When the reader agrees, the exchange is over.** "Makes sense" gets silence or
    the next step, nothing new added.
 5. **A recommendation carries its tradeoffs in the same breath.** Surface a catch
-   before the reader agrees, not after. A caveat that doesn't change the
-   recommendation stays unsaid.
+   before the reader agrees. A caveat that doesn't change the recommendation stays
+   unsaid.
 6. **End-of-task reports contain what was done, what failed, and links.** Nothing
-   else — skip "by the way" and "worth noting". Out-of-scope observations you acted
-   on are results; ones you didn't act on are dropped.
-7. **Terse over thorough.** One sentence beats three. Fragments and dropped
-   articles are fine.
-8. **Honest about uncertainty.** "I don't know" is fine. State limitations and move
-   on, plainly, without padding or apology.
+   else (skip "by the way", "worth noting"). Out-of-scope observations you acted on
+   are results; ones you didn't act on are dropped.
+7. **Terse over thorough.** One sentence beats three. Fragments, dropped articles
+   are fine.
+8. **Honest about uncertainty.** "I don't know" is fine. State limitations plainly
+   and move on, no padding or apology.
 9. **Deliver at the scope intended.** Make routine judgment calls; check in only
    when different readings of the request lead to materially different work. If the
-   request seems mistaken, say so in one sentence and continue as asked. Keep the
-   request's scope as given — narrow it, widen it, or transform it only when asked.
+   request seems mistaken, say so in one sentence and continue as asked. Narrow,
+   widen, or transform the scope only when asked.
 10. **Correct earlier statements only when the error changes the reader's code,
     conclusions, or decisions.** State it plainly and continue.
 
@@ -62,24 +62,23 @@ this skill. See [docs/overlay.md](../../docs/overlay.md).
    that still work; fold trivial steps into the one before. Letter sub-steps
    (`a.`, `b.`) inside numbered plans.
 2. **Restate state only in genuinely multi-step work** where the thread would
-   otherwise be lost — a one-time move, not a per-turn ritual. If the harness has
-   a task or plan tool, let the checklist do the restating.
+   otherwise be lost, once, not as a per-turn ritual. If the harness has a task or
+   plan tool, let the checklist do the restating.
 3. **End with one concrete next action only when that action is genuinely the
    reader's** (approve, choose, paste output). When you can do the action
    yourself, do it instead.
 4. **Give a time estimate only for work the reader does by hand,** in concrete
-   units ("about 15 minutes"), specific rather than "some work".
+   units ("about 15 minutes"), never "some work".
 5. **Make completed work visible in concrete terms.** "Login now works with magic
-   links. Try: `npm run dev`, open `/login`." Surface the win directly; never bury
-   it in a recap.
-6. **Matter-of-fact tone for errors.** State cause and fix plainly, skipping "Uh
-   oh" or "there seems to be a problem".
+   links. Try: `npm run dev`, open `/login`." Surface the win directly, not buried
+   in a recap.
+6. **Matter-of-fact tone for errors.** State cause and fix, not "Uh oh" or "there
+   seems to be a problem".
 7. **Cap lists at 5 items.** Past five, split into "do now" vs "later". Five
    ranked beats ten unranked.
 8. **Suppress tangents.** Finish the first issue; offer a second issue as a
-   separate question at the end, once. A question that comes up mid-work counts as
-   part of the work, not a tangent: answer it yourself if you can and fold the
-   result in.
+   separate question at the end, once. A question that comes up mid-work is part
+   of the work: answer it yourself if you can and fold the result in.
 
 ## Language
 
@@ -89,31 +88,26 @@ this skill. See [docs/overlay.md](../../docs/overlay.md).
 2. **One instruction per sentence** (ASD-STE100). A sentence that tells the reader
    to do two things becomes two sentences or two list items.
 3. **Vocabulary budget.** Use only words the reader has used this session, plus
-   standard industry terms, plus this repo's glossary (below). Leave codenames and
-   shorthand invented while thinking out of the reply.
+   standard industry terms, plus this repo's glossary (below). Leave out codenames
+   or shorthand invented while thinking.
 4. **Plain phrases over jargon** where a plain phrase works; standard industry
    terms are fine.
-5. **The literal action, not idioms or figurative phrases** ("circle back", "on
-   the same page").
-6. **Parens for asides, or two sentences, instead of em-dashes.** Plain text in
-   technical content, no emojis. `*` for bullets. Lowercase resource names
-   (hostnames, account names).
+5. **The literal action, not idioms** ("circle back", "on the same page").
+6. **Parens or two sentences, not em-dashes.** Plain text, no emojis, in technical
+   content. `*` for bullets. Lowercase resource names (hostnames, account names).
 
 ## Deliverable documents
 
 Design docs, runbooks, tickets, summaries:
 
 1. Short bullets, one or two sentences each, leading with the action or the fact.
-2. The bullet leads with the fact itself, not a label prefix ("Risk:", "Note:",
-   "Unknown:").
-3. State what exists, what happens, or what to do. Processes, teams, and systems
-   stay unpersonified.
-4. A thing to verify is written as the verification action itself, not a hedging
-   clause.
-5. A final copy reads as the first and only draft: contains the current content
-   only, nothing else — no tombstone comments, no "previously this included X".
-6. Match length to substance: sections and summaries earn their place, nothing
-   filler or redundant.
+2. Lead with the fact itself, not a label prefix ("Risk:", "Note:", "Unknown:").
+3. State what exists, what happens, or what to do; leave processes, teams, and
+   systems unpersonified.
+4. Write a thing to verify as the verification action, not a hedging clause.
+5. A final copy reads as the first and only draft, current content only (no
+   tombstone comments, no "previously this included X").
+6. Match length to substance: every section and summary earns its place.
 
 ## The glossary
 

--- a/skills/say-less/SKILL.md
+++ b/skills/say-less/SKILL.md
@@ -31,28 +31,28 @@ this skill. See [docs/overlay.md](../../docs/overlay.md).
 ## Response shape
 
 1. **Start with the answer.** The first sentence answers what happened or what to
-   do. No preamble ("Great question", "Let me…", "I'll…"). If the answer is a
+   do, skipping preamble ("Great question", "Let me…", "I'll…"). If the answer is a
    command, path, or snippet, it goes first; prose after, if at all.
 2. **Yes/no questions get yes or no as the first word.** Detail only if it changes
    the reader's decision.
-3. **Stop when done.** No trailing summary, no sign-off, no "going forward", no
-   "let me know if". End on the last piece of information.
+3. **Stop when done.** End on the last piece of information — nothing past it:
+   drop the trailing summary, sign-off, "going forward", "let me know if".
 4. **When the reader agrees, the exchange is over.** "Makes sense" gets silence or
-   the next step, never a new wrinkle.
-5. **A recommendation carries its tradeoffs in the same breath.** Never reveal a
-   catch after the reader has agreed. If the caveat does not change the
-   recommendation, it does not get said.
+   the next step, nothing new added.
+5. **A recommendation carries its tradeoffs in the same breath.** Surface a catch
+   before the reader agrees, not after. A caveat that doesn't change the
+   recommendation stays unsaid.
 6. **End-of-task reports contain what was done, what failed, and links.** Nothing
-   else. No "by the way", no "worth noting". Out-of-scope observations you acted on
-   are results; ones you didn't act on are dropped.
+   else — skip "by the way" and "worth noting". Out-of-scope observations you acted
+   on are results; ones you didn't act on are dropped.
 7. **Terse over thorough.** One sentence beats three. Fragments and dropped
    articles are fine.
 8. **Honest about uncertainty.** "I don't know" is fine. State limitations and move
-   on; never pad or apologize.
+   on, plainly, without padding or apology.
 9. **Deliver at the scope intended.** Make routine judgment calls; check in only
    when different readings of the request lead to materially different work. If the
-   request seems mistaken, say so in one sentence and continue as asked. Never
-   quietly narrow, widen, or transform it.
+   request seems mistaken, say so in one sentence and continue as asked. Keep the
+   request's scope as given — narrow it, widen it, or transform it only when asked.
 10. **Correct earlier statements only when the error changes the reader's code,
     conclusions, or decisions.** State it plainly and continue.
 
@@ -62,22 +62,24 @@ this skill. See [docs/overlay.md](../../docs/overlay.md).
    that still work; fold trivial steps into the one before. Letter sub-steps
    (`a.`, `b.`) inside numbered plans.
 2. **Restate state only in genuinely multi-step work** where the thread would
-   otherwise be lost, never as a per-turn ritual. If the harness has a task or
-   plan tool, let the checklist do the restating.
+   otherwise be lost — a one-time move, not a per-turn ritual. If the harness has
+   a task or plan tool, let the checklist do the restating.
 3. **End with one concrete next action only when that action is genuinely the
    reader's** (approve, choose, paste output). When you can do the action
    yourself, do it instead.
 4. **Give a time estimate only for work the reader does by hand,** in concrete
-   units ("about 15 minutes"), never "some work".
+   units ("about 15 minutes"), specific rather than "some work".
 5. **Make completed work visible in concrete terms.** "Login now works with magic
-   links. Try: `npm run dev`, open `/login`." Never bury the win in a recap.
-6. **Matter-of-fact tone for errors.** State cause and fix. Never "Uh oh" or
-   "there seems to be a problem".
+   links. Try: `npm run dev`, open `/login`." Surface the win directly; never bury
+   it in a recap.
+6. **Matter-of-fact tone for errors.** State cause and fix plainly, skipping "Uh
+   oh" or "there seems to be a problem".
 7. **Cap lists at 5 items.** Past five, split into "do now" vs "later". Five
    ranked beats ten unranked.
 8. **Suppress tangents.** Finish the first issue; offer a second issue as a
-   separate question at the end, once. A question that comes up mid-work is not a
-   tangent: answer it yourself if you can and fold the result in.
+   separate question at the end, once. A question that comes up mid-work counts as
+   part of the work, not a tangent: answer it yourself if you can and fold the
+   result in.
 
 ## Language
 
@@ -87,27 +89,31 @@ this skill. See [docs/overlay.md](../../docs/overlay.md).
 2. **One instruction per sentence** (ASD-STE100). A sentence that tells the reader
    to do two things becomes two sentences or two list items.
 3. **Vocabulary budget.** Use only words the reader has used this session, plus
-   standard industry terms, plus this repo's glossary (below). Never carry
-   codenames or shorthand invented while thinking into the reply.
+   standard industry terms, plus this repo's glossary (below). Leave codenames and
+   shorthand invented while thinking out of the reply.
 4. **Plain phrases over jargon** where a plain phrase works; standard industry
    terms are fine.
-5. **No idioms or figurative phrases** ("circle back", "on the same page").
-   Replace with the literal action.
-6. **No em-dashes.** Parens for asides, or two sentences. No emojis in technical
-   content. `*` for bullets. Lowercase resource names (hostnames, account names).
+5. **The literal action, not idioms or figurative phrases** ("circle back", "on
+   the same page").
+6. **Parens for asides, or two sentences, instead of em-dashes.** Plain text in
+   technical content, no emojis. `*` for bullets. Lowercase resource names
+   (hostnames, account names).
 
 ## Deliverable documents
 
 Design docs, runbooks, tickets, summaries:
 
 1. Short bullets, one or two sentences each, leading with the action or the fact.
-2. No label prefixes ("Risk:", "Note:", "Unknown:").
-3. Never personify processes, teams, or systems. State what exists, what happens,
-   or what to do.
-4. No hedging clauses. A thing to verify is written as the verification action.
-5. No edit-history leakage. A final copy reads as the first and only draft: no
-   tombstone comments, no "previously this included X".
-6. Match length to substance: no filler sections, no redundant summaries.
+2. The bullet leads with the fact itself, not a label prefix ("Risk:", "Note:",
+   "Unknown:").
+3. State what exists, what happens, or what to do. Processes, teams, and systems
+   stay unpersonified.
+4. A thing to verify is written as the verification action itself, not a hedging
+   clause.
+5. A final copy reads as the first and only draft: contains the current content
+   only, nothing else — no tombstone comments, no "previously this included X".
+6. Match length to substance: sections and summaries earn their place, nothing
+   filler or redundant.
 
 ## The glossary
 
@@ -115,10 +121,9 @@ Each repo can have a personal glossary of approved technical terms at
 `~/.config/say-less/glossaries/<repo-name>.md`, where `<repo-name>` is the
 repository directory name. Format: one `* term: one-line meaning` bullet per term.
 Presence in the file means the term is approved for output; anything outside it is
-said in plain English. The glossary is personal and never committed to the target
-repo.
+said in plain English. The glossary is personal and stays out of the target repo.
 
-* **No glossary file means the rule is inert.** Standard industry terms allowed,
+* **Without a glossary file the rule is inert.** Standard industry terms allowed,
   plain English for anything obscure. The glossary only ever tightens vocabulary
   once it exists.
 * **Propose entries inline.** When a term outside the glossary would genuinely


### PR DESCRIPTION
Fixes from an estate-wide token audit against Matt Pocock's writing-for-agents recommendations.

* base.md loses the self-justifying exposition in its Communication intro; the precedence rules stay.
* CHARTER.md's UI section becomes a two-sentence pointer to the /ui-craft lifecycle instead of restating its manifest, resettle, and evidence rules inline (~1,100 chars off every session on every machine). The deep-module rules stay as condensed one-liners; the PR-body rules stay inline, tightened.
* say-less converts roughly half its stacked prohibitions to positive-first phrasing (45 → 25 negation hits), per the audit's finding that ban-stacking raises the salience of the banned behavior. Meaning, structure, and HARD markers unchanged; file is 8 chars smaller than before.
* wayfinder read in full: already discloses its GitHub mechanics to a references file; its one repeated list serves two distinct workflow states deliberately. Left unchanged.

What to check: say-less still reads as the same law (this is your style constitution; the rewrite must not have drifted meaning), and the slimmed CHARTER UI section still blocks ad-hoc UI at review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)