### PR TITLE
feat(writing-great-skills): adopt skill with estate-audit doctor verb

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,6 +9,11 @@ scope skill's interview mode is derived from, Matt Pocock's public skills reposi
 (https://github.com/mattpocock/skills), MIT licensed,
 copyright (c) 2026 Matt Pocock.
 
+The writing-great-skills skill's references/writing-for-agents.md is an original
+rewrite of the concepts in Matt Pocock's writing-for-agents skill
+(https://github.com/mattpocock/skills), MIT licensed,
+copyright (c) 2026 Matt Pocock.
+
 The ui-craft skill absorbs reference material and the design-antipattern
 detector from Paul Bakaus's Impeccable project
 (https://github.com/pbakaus/impeccable), Apache License 2.0,

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 | [`review`](skills/review/SKILL.md) | Review changed code against the project's standards and the originating issue | — |
 | [`implement`](skills/implement/SKILL.md) | Implement a PRD or issue set via `tdd`, then `review`, then commit | `tdd` and `review` from this pack |
 | [`say-less`](skills/say-less/SKILL.md) | Answer-first output shaping with a per-repo glossary of approved terms; adapted from i-have-adhd, merged with this pack's reader-preference rules and an ASD-STE100 subset | Optional prompt hook for always-on digest; see [docs/overlay.md](docs/overlay.md) |
+| [`writing-great-skills`](skills/writing-great-skills/SKILL.md) | Write or review a skill against a shared pointer/load/pruning vocabulary; `doctor` verb audits the loaded skill and `CLAUDE.md`/`AGENTS.md` estate for token cost and trigger risk | Hand-only; invoke by name |
 
 ## Install
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -80,11 +80,23 @@ def validate_frontmatter(path: Path, errors: list[str]) -> None:
         for line in match.group(1).splitlines()
         if ":" in line
     }
-    if fields != {"name", "description"}:
+    required = {"name", "description"}
+    allowed = required | {"disable-model-invocation"}
+    if fields < required or fields - allowed:
         fail(
             errors,
-            f"{path.relative_to(ROOT)}: frontmatter must contain only name and description",
+            f"{path.relative_to(ROOT)}: frontmatter must contain name and description, "
+            "plus an optional disable-model-invocation",
         )
+    if "disable-model-invocation" in fields:
+        value_match = re.search(
+            r"^disable-model-invocation:\s*(.+)$", match.group(1), re.MULTILINE
+        )
+        if not value_match or value_match.group(1).strip() != "true":
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: disable-model-invocation must be true when present",
+            )
     name_match = re.search(r"^name:\s*(.+)$", match.group(1), re.MULTILINE)
     if not name_match or name_match.group(1).strip() != path.parent.name:
         fail(errors, f"{path.relative_to(ROOT)}: name must match directory")

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -30,6 +30,7 @@ EXPECTED = {
     "persona-review",
     "ui-craft",
     "orchestrate",
+    "writing-great-skills",
 }
 FORBIDDEN = (
     re.compile("/" + "Users/"),

--- a/skills/writing-great-skills/GLOSSARY.md
+++ b/skills/writing-great-skills/GLOSSARY.md
@@ -1,0 +1,195 @@
+# Glossary — Building Great Skills
+
+The domain model for what makes a skill great. A skill exists to wrangle determinism out of a stochastic system; the root virtue is **Predictability**, and every term below is a lever on it. This is the disclosed reference for [`writing-great-skills`](SKILL.md).
+
+The terms are grouped by axis: **Invocation** (how a skill is reached), **Information Hierarchy** (how its content is arranged), **Steering** (how the agent's runtime behaviour is shaped), and **Pruning** (how it is kept lean). Each **failure mode** lives beside the lever that cures it, tagged _failure mode_.
+
+**Bold terms** in any definition are themselves defined in this glossary; find them by their heading.
+
+## Predictability
+
+The degree to which a skill makes the agent behave the same _way_ on every run — the same process, not the same output (a brainstorming skill should _predictably_ diverge; its tokens vary, its behaviour doesn't). The root virtue every other term serves — cost and maintainability are symptoms of it, not rivals.
+
+_Avoid_: consistency, reliability, robustness, output-determinism
+
+## Invocation
+
+How a skill is reached — and the two loads you pay for the choice.
+
+### Model-Invoked
+
+A skill that keeps its **description** field, so the agent can see it and fire it autonomously — and the human can still type its name, so model-invocation always _includes_ user reach. There is no model-only state: a description only ever _adds_ agent discovery, never removes the human's. Pays a permanent **context load** on every turn in exchange for that discoverability. Reachable by other skills, because the description that makes it agent-discoverable makes it invocable. A model-invoked skill whose content is all **reference** is also one home for shared reference: another skill can invoke it, so reference needed by several skills lives in one place. Pick model-invocation only when the agent must reach the skill on its own; if it never fires except by hand, drop the description and pay no context load.
+
+_Avoid_: ability, tool, capability
+
+### User-Invoked
+
+A skill with its **description** stripped — invisible to the agent and reachable only by the human typing its name (user-_only_, where **model-invoked** is user-_and-agent_). Trades agent-discoverability for zero **context load**. Because it has no description, nothing but the human can reach it: no other skill can fire it.
+
+_Avoid_: procedure, workflow, command
+
+### Description
+
+The skill's machine-readable trigger, and the one **context pointer** a **model-invoked** skill is forced to keep loaded at all times. Its mere presence _is_ the invocation axis: keep it and the skill is model-invoked (and reachable by other skills); delete it and the skill is **user-invoked**, reachable only by the human. The source of a model-invoked skill's **context load**.
+
+_Avoid_: frontmatter, summary
+
+### Context Pointer
+
+A reference held in the agent's context that names some out-of-context material and encodes the condition for reaching it. The **description** is the top-level context pointer (context window → skill); pointers to disclosed files are the same object one level down. Its wording, not the target, decides _when_ the agent reaches — and _how reliably_. A must-have target behind a weakly worded pointer is a variance bug: fix the wording first, and inline the material only if sharpening fails.
+
+_Avoid_: link, reference, import
+
+### Context Load
+
+The cost a **model-invoked** skill imposes on the agent's context window — its **description**, always loaded, spending both tokens and attention. What **user-invoked** skills escape by having no description, and the brake on splitting into more model-invoked skills.
+
+_Avoid_: token cost, context bloat
+
+### Cognitive Load
+
+The cost a **user-invoked** skill imposes on the human — what they must hold in their head: which skills exist and when to reach for each (the human is the index). What **model-invocation** removes by being agent-discoverable, and the brake on splitting into more user-invoked skills. Not a cost to minimise: it is the price of human agency, the reason some skills stay user-invoked. Spend it where human judgement matters; remove it where it does not.
+
+_Avoid_: human index, burden, overhead
+
+### Router Skill
+
+A **user-invoked** skill whose job is to point at your other user-invoked skills — naming each and when to reach for it — so the human has one skill to remember instead of many. It can only hint, never fire them: user-invoked skills have no **description**, so nothing but the human can reach them. The cure for **cognitive load** when user-invoked skills multiply.
+
+_Avoid_: dispatcher, menu, registry, index, router procedure
+
+### Granularity
+
+How finely you divide skills. Finer division spends one of the two loads: more **model-invoked** skills spend **context load** (more descriptions crowding the window and competing for attention); more **user-invoked** skills spend **cognitive load** (more for the human to remember and reach for). Two cuts guide the division. By **invocation**, split off a model-invoked skill where you have a distinct **leading word** to trigger it — a trigger word you actually use in your prompts. By **sequence**, split a run of **steps** where a step's **post-completion steps** need hiding, since isolating it in its own context clears what follows. Beware the reverse: merging sequences exposes each step's post-completion steps to what follows, inviting premature completion.
+
+_Avoid_: chunking, modularity
+
+## Information Hierarchy
+
+How a skill's content is arranged, and how far down the ladder each piece sits.
+
+### Information Hierarchy
+
+A skill's content ranked by how immediately the agent needs it — a single ladder, produced by two cuts: in-file or behind a pointer, and step or reference. The rungs:
+
+- **Steps** — in-file, primary
+- **Reference**, in-file — secondary
+- **Reference**, disclosed — behind a **context pointer**
+
+A skill with no **steps** uses just the bottom two rungs — often a legitimately flat peer-set (e.g. every rule of a review on one rung), which is a fine arrangement, not a smell. The hierarchy is independent of invocation: a skill can be model- or user-invoked whether it is all steps, all reference, or both. When a skill has steps, in-file reference that should be disclosed buries them and turns attending to them into a coin-flip — a variance lever, not just a legibility one. Keep the top of the ladder legible; push down it whatever you can.
+
+_Avoid_: structure, organization, layout
+
+### Steps
+
+The ordered actions the agent performs — when a skill has them, the primary tier of its content, and the part that earns its place in SKILL.md. Not every skill has steps: a skill can be all steps (`tdd`), all **reference** (a review), or both, independent of invocation. Every step ends on a **completion criterion**, clear or vague.
+
+_Avoid_: workflow, instructions, choreography
+
+### Reference
+
+Material the agent refers to on demand — definitions, facts, parameters, examples, conditional instructions. When a skill has **steps** it is secondary to them; when a skill has none it is the entire content; or it lives outside any skill entirely — see **External Reference**. Reached via **context pointers**, and the prime candidate for **progressive disclosure**.
+
+_Avoid_: supporting material, docs, background
+
+### External Reference
+
+**Reference** that lives outside the skill system — a plain file, no **description**, no **steps**, not invocable — that any skill can point at. The home for shared reference that needn't fire on its own, and the only shared home two **user-invoked** skills can use, since neither has a description and so neither can fire the other.
+
+_Avoid_: doc, resource, knowledge base
+
+### Progressive Disclosure
+
+Moving **reference** down the ladder — out of SKILL.md and behind a **context pointer** — so the top stays legible. Not primarily a token optimisation; it is how the **information hierarchy** is protected. Licensed by **branching**: disclose what only some branches need, inline what every path needs, and if a pointer fires unreliably on must-have material, sharpen its wording, and pull it back inline only if that fails.
+
+_Avoid_: lazy loading, chunking
+
+### Co-location
+
+Keeping the material an agent needs at once in one place — a concept's definition, rules, and caveats under a single heading, not scattered across the file — so reading one part brings its neighbours with it. The within-file companion to the **Information Hierarchy**: the hierarchy ranks _how far down_ a piece sits; co-location decides _what sits beside it_ once there. There is no formula for the right format of a body of **reference**; the test is that a skill should read like documentation written for the agent, and grouped material reads that way where scattered material does not. Distinct from **Duplication**: that repeats one meaning in two places, where scattering fragments a single meaning across many.
+
+_Avoid_: grouping, clustering, cohesion
+
+### Sprawl
+
+_Failure mode._ A skill that is simply too long — too many lines in SKILL.md — independent of whether they are stale or repeated. Even an all-live, all-unique skill can sprawl. It costs readability (the agent wades through more before it can act, and attention thins across the excess), maintainability (every extra line is one more to keep **relevant**), and tokens. The cure is the **information hierarchy**: push **reference** down behind **context pointers**, and split by **branch** or sequence so each path carries only what it needs. Distinct from **sediment** (length from stale accumulation) and **duplication** (length from repeated meaning) — sprawl is length itself, whatever its cause.
+
+_Avoid_: bloat, length, size, verbosity
+
+## Steering
+
+The levers that shape the agent's runtime behaviour toward **Predictability**.
+
+### Branch
+
+A distinct way a skill can be invoked — a case the skill handles — so different runs take different paths through it. A skill with many steps may carry many branches; a linear one has none.
+
+_Avoid_: path, case, fork
+
+### Leading Word
+
+A compact concept — also called a _Leitwort_ — already living in the model's pretraining, that the agent thinks with while running the skill. It encodes a behavioural principle in the fewest possible tokens by invoking priors the model already holds (e.g. _lesson_, _proximal zone of development_, _fog of war_, _tracer bullets_). Repeated as a token, never as a sentence, it accumulates a distributed definition across the skill and anchors a whole region of behaviour. Coining your own works if you define it clearly, but a made-up word recruits no priors — you pay in definition tokens what a pretrained word gives free. Reach for an existing word first.
+
+A leading word serves **predictability** twice. In the body it anchors **execution** — the agent reaches for the same behaviour every time the concept appears, and inside flat reference it focuses attention on a class of thing to look for, recruiting the right checks each run. In the **description** it anchors **invocation** — and not only within the skill: when the same word lives in your prompts, your docs, and your codebase, the agent links that shared language to the skill and fires it more reliably. Word a description with the leading words you actually use when you want the skill.
+
+_Avoid_: keyword, term, motif
+
+### Completion Criterion
+
+The condition that tells the agent a unit of work is done — the target it judges against. Two properties make it a lever, not just a quality. Its **clarity** (can the agent tell done from not-done?) resists **premature completion** — a vague bound ("understanding reached") lets the agent declare done and slip to the next step; this axis needs _steps_ to bite, since premature completion is a between-steps failure. Its **demand** (how much it requires) sets **legwork** — "every modified model accounted for" forces thorough work where "produce a change list" does not — and this axis is _not_ step-bound: it can bind a body of flat reference too, which is how a skill with no steps still carries an exhaustiveness bar ("every rule applied"). The strongest criteria are both checkable and exhaustive.
+
+_Avoid_: done condition, exit condition, stopping rule
+
+### Legwork
+
+The work an agent does behind the scenes within a single step — reading files, exploring the codebase, making changes, digging up what it needs rather than offloading to the user. It lives below the step structure: never written as its own step, latent in the wording, controlled by the agent rather than the skill. The within-step counterpart to **post-completion steps**' across-step pull. Raised by a **leading word** (_comprehensive_, _thorough_) or a **completion criterion** that demands the work be exhaustive — including the demand axis applied to flat reference, which is what drives a skill of flat reference to cover all its rungs. Goes thin either when that demand is missing or when **premature completion** cuts the step short.
+
+_Avoid_: scope, effort, diligence, coverage
+
+### Post-Completion Steps
+
+The **steps** that follow the current step. Visible, they pull the agent forward into **premature completion** — the more it sees, the stronger the tug; the defence is to hide them by splitting the sequence of steps into two.
+
+_Avoid_: horizon, fog of war, lookahead
+
+### Premature Completion
+
+_Failure mode._ Ending the current step before it is genuinely done, because the agent's attention slips to being done rather than to the work. A between-steps failure: it needs **steps** to occur — a skill with no steps that quits early isn't premature completion but thin **legwork** under an unmet demand. A tug-of-war between two forces: visible **post-completion steps** (the pull forward) and the **completion criterion**'s clarity (the resistance — a sharp, checkable bar holds; a vague one gives way). Fuzziness is the necessary condition: a sharp bound resists the pull no matter how many later steps are visible, so a step that never rushes needs no defending. Two levers hold a step that does, but reach for them in order: **sharpen the bound first** — it is local and cheap. Only when the criterion is irreducibly fuzzy _and_ you actually observe the rush do you **hide the later steps** — and hiding only works across a real context boundary (a user-invoked hand-off or a subagent dispatch; an inline model-invoked call leaves the later steps in context and clears nothing). One cause of thin legwork, but distinct from it: legwork can be thin even when a step runs to full completion.
+
+_Avoid_: premature closure, the rush, rushing, shortcutting
+
+## Pruning
+
+Keeping a skill lean — each remedy paired with the failure it cures.
+
+### Single Source of Truth
+
+The desired state where each meaning lives in exactly one authoritative place, so a change to the skill's behaviour is a change in one place. **Duplication** is its violation.
+
+_Avoid_: home, canonical location
+
+### Duplication
+
+_Failure mode._ The same meaning given more than one **single source of truth**. It costs maintenance (change one place, you must change the others), costs tokens, and inflates prominence — repeating a meaning weights it on the ladder past its real rank. The accidental inverse of a **leading word**, which raises attention on purpose by repeating a token, never the meaning.
+
+_Avoid_: repetition, redundancy
+
+### Relevance
+
+Whether a line still bears on what the skill does — the lens for what to keep. A line loses relevance either by never bearing on the task (mere exposition, or a **branch** that should be disclosed) or by going stale: drifting out of date as the behaviour or world it describes changes. Shorter skills are easier to keep relevant, because each line is cheaper to check. Distinct from **no-op**: relevance asks whether a line bears on the task, not whether it changes behaviour.
+
+_Avoid_: load-bearing, staleness, freshness
+
+### Sediment
+
+_Failure mode._ Layers of old content that settle in a skill and are never cleared, because adding feels safe and removing feels risky — so stale and irrelevant lines accumulate and you must core down through them to find what is still live. The default fate of any skill without a pruning discipline; the slow erosion of **relevance**, as opposed to **duplication**'s repeated meaning.
+
+_Avoid_: accretion, bloat, cruft, rot
+
+### No-Op
+
+_Failure mode._ An instruction that changes nothing because the model already does it by default — you pay load to tell the agent what it would do anyway. The test: does a line change behaviour versus the default? A line can be perfectly **relevant** and still be a no-op. The same priors that make a **leading word** free make a no-op worthless.
+
+A leading word is a _technique_; No-Op is a _verdict_ on a line — and they cross. A leading word too weak to beat the default is a no-op (_be thorough_ when the agent is already thorough-ish), and the fix is a stronger word that passes the verdict (_relentless_), not a different technique. So the No-Op test — does it change behaviour versus the default? — is also how you grade whether a leading word is earning its repetitions. This is model-relative, not reader-relative: two people disagreeing over whether a line is a no-op disagree about the default, and settle it by running the skill, not by debate.
+
+_Avoid_: redundant instruction, restating the obvious, belaboring

--- a/skills/writing-great-skills/SKILL.md
+++ b/skills/writing-great-skills/SKILL.md
@@ -1,51 +1,95 @@
 ---
 name: writing-great-skills
-description: Write, review, or audit a skill or CLAUDE.md/AGENTS.md against the pointer, load, and pruning vocabulary in references/writing-for-agents.md. Hand-only — invoke with /writing-great-skills to draft or review a skill, or /writing-great-skills doctor to audit the loaded estate.
+description: Reference for writing and editing skills well — the vocabulary and principles that make a skill predictable — plus a doctor verb that audits the loaded skill and CLAUDE.md/AGENTS.md estate.
+disable-model-invocation: true
 ---
 
-# Writing great skills
+A skill exists to wrangle determinism out of a stochastic system. **Predictability** — the agent taking the same _process_ every run, not producing the same output — is the root virtue; every lever below serves it.
 
-User-invoked only — this skill doesn't trigger itself; reach for it by name when
-writing a skill, reviewing one, or auditing the estate.
+**Bold terms** are defined in [`GLOSSARY.md`](GLOSSARY.md); look them up there for the full meaning. Two levers this skill's own glossary doesn't carry — negation and the cache/environment distinction — live in [`references/writing-for-agents.md`](references/writing-for-agents.md); this file points there rather than re-teaching them.
 
-## Writing or reviewing a skill
+## Invocation
 
-Read [`references/writing-for-agents.md`](references/writing-for-agents.md) first; it's
-the vocabulary this skill applies. Then:
+Two choices, trading different costs:
 
-1. **Description first.** Front-load the trigger word, one trigger per branch, cut
-   identity the body already carries. If the skill only ever fires by hand, say so in
-   the description and write it for a human skimming a list, not for autonomous
-   matching.
-2. **Place every piece of content on the hierarchy.** In-file step (what runs, in
-   order), in-file reference (flat facts consulted on demand), or disclosed reference
-   (pushed to a sibling file, reached by a pointer). Run the branching test: if every
-   branch needs it, keep it in-file; if only some branches reach it, disclose it.
-3. **Give every step a completion criterion** that's checkable and demands real work,
-   not "understanding reached."
-4. **Reach for a leading word before writing three sentences of restatement.** Positive
-   phrasing first; a prohibition only as a hard guardrail, paired with its positive
-   target.
-5. **Prune before shipping.** One source of truth per meaning, no restating what the
-   environment already answers, no no-op sentences. If a sentence changes nothing when
-   deleted, delete the whole sentence.
+- A **model-invoked** skill keeps a **description**, so the agent can fire it autonomously _and_ other skills can reach it (you can still type its name too). It contributes to **context load** — the description sits in the window every turn. Mechanics: omit `disable-model-invocation`, and write a model-facing description with rich trigger phrasing ("Use when the user wants…, mentions…").
+- A **user-invoked** skill strips the description from the agent's reach: only you, typing its name, can invoke it — and no other skill can. Zero context load, but it spends **cognitive load**: _you_ are the index that must remember it exists. Mechanics: set `disable-model-invocation: true`; the `description` becomes human-facing — a one-line summary, trigger lists stripped.
+
+Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
+
+When user-invoked skills multiply past what you can remember, that piled-up cognitive load is cured by a **router skill**: one user-invoked skill that names the others and when to reach for each.
+
+## Writing the description
+
+A model-invoked **description** does two jobs — state what the skill is, and list the **branches** that should trigger it. Every word increases **context load**, so a description earns even harder pruning than the body:
+
+- **Front-load the skill's leading word** — the description is where it does its invocation work.
+- **One trigger per branch.** Synonyms that rename a single branch are **duplication** — "build features using TDD … asks for test-first development" is one branch written twice. Collapse them; keep only genuinely distinct branches.
+- **Cut identity that's already in the body.** Keep the description to triggers, plus any "when another skill needs…" reach clause.
+
+## Information hierarchy
+
+A skill is built from two content types — **steps** and **reference** — that mix freely: a skill can be all steps, all reference, or both. The core decision is which to use and where each sits on the **information hierarchy**, a ladder ranked by how immediately the agent needs the material:
+
+1. **In-skill step** — an ordered action in `SKILL.md`, the primary tier: what the agent does, in order. Each step ends on a **completion criterion**, the condition that tells the agent the work is done. Make it _checkable_ (can the agent tell done from not-done?) and, where it matters, _exhaustive_ ("every modified model accounted for", not "produce a change list") — a vague criterion invites **premature completion**.
+2. **In-skill reference** — a definition, rule, or fact in `SKILL.md`, consulted on demand. Often a legitimately flat peer-set (every rule of a review on one rung) — a fine arrangement, not a smell. _This skill is mostly reference._
+3. **External reference** — reference pushed out of `SKILL.md` into a separate file, reached by a **context pointer**, loaded only when the pointer fires. (Spans _disclosed_ reference — a sibling file like `GLOSSARY.md`, still part of the skill — through fully **external reference** that lives outside the skill system and any skill can point at.)
+
+A demanding completion criterion drives thorough **legwork** — the digging the agent does within the work — whether the skill has steps or not, since "every rule applied" binds flat reference just as "every step done" binds a sequence.
+
+Push too little down and the top bloats; push too much and you hide material the agent actually needs. That tension is the whole decision.
+
+**Progressive disclosure** is the move down the ladder — out of `SKILL.md` into a linked file — so the top stays legible. Mechanics: a linked `.md` file in the skill folder, named for what it holds (this skill discloses its full definitions to `GLOSSARY.md`, and its estate-audit steps to `references/doctor.md`). Some skills are used in more than one way, and each distinct way is a **branch** — different runs taking different paths through the skill. Branching is the cleanest disclosure test: inline what every branch needs, and push behind a pointer what only some branches reach. A **context pointer**'s _wording_, not its target, decides when and how reliably the agent reaches the material.
+
+Where the ladder decides _how far down_ a piece sits, **co-location** decides _what sits beside it_ once there: keep a concept's definition, rules, and caveats under one heading rather than scattered, so reading one part brings its neighbours with it.
+
+## When to split
+
+**Granularity** is how finely you divide skills, and each cut spends one of the two loads, so split only when the cut earns it. Two cuts:
+
+- **By invocation** — split off a **model-invoked** skill when you have a distinct **leading word** that should trigger it on its own, or another skill must reach it. You pay **context load** for the new always-loaded **description**, so that independent reach has to be worth it.
+- **By sequence** — split a run of **steps** when the steps still ahead (a step's **post-completion steps**) tempt the agent to rush the one in front of it (**premature completion**). Keeping them out of view encourages the agent to do more **legwork** on the current task.
+
+## Pruning
+
+Keep each meaning in a **single source of truth**: one authoritative place, so changing the behaviour is a one-place edit.
+
+Check every line for **relevance**: does it still bear on what the skill does?
+
+Then hunt **no-ops** sentence by sentence, not just line by line: run the no-op test on each sentence in isolation, and when one fails, delete the whole sentence rather than trim words from it. Be aggressive — most prose that fails should go, not be rewritten.
+
+## Leading words
+
+A **leading word** is a compact concept already living in the model's pretraining that the agent thinks with while running the skill (e.g. _lesson_, _fog of war_, _tracer bullets_). Repeated throughout the text (though not necessarily - a strong leading word might only be needed once), it accumulates a distributed definition and anchors a whole region of behaviour in the fewest tokens, by recruiting priors the model already holds.
+
+It serves predictability twice. In the body it anchors _execution_: the agent reaches for the same behaviour every time the word appears. In the description it anchors _invocation_: when the same word lives in your prompts, docs, and code, the agent links that shared language to the skill and fires it more reliably.
+
+Hunt for opportunities to refactor skills to use leading words. A triad spelled out at three sites (**duplication**), a description spending a sentence to gesture at one idea — each is a passage begging to **collapse** into a single token. Examples include:
+
+- "fast, deterministic, low-overhead" -> _tight_ — one quality restated across a phase — into a single pretrained word (a _tight_ loop).
+- "a loop you believe in" -> _red_ — converts a fuzzy gate into a binary observable state (the loop goes _red_ on the bug, or it doesn't).
+
+You win twice over: fewer tokens, _and_ a sharper hook for the agent to hang its thinking on. Assume every skill is carrying restatements that leading words retire — go find them.
+
+## Failure modes
+
+Use these to diagnose issues the user may be having with the skill.
+
+- **Premature completion** — ending a step before it's genuinely done, attention slipping to _being done_. Defence, in order: sharpen the completion criterion first (cheap, local); only if it is irreducibly fuzzy _and_ you observe the rush, hide the post-completion steps by splitting (the sequence cut).
+- **Duplication** — the same meaning in more than one place. Costs maintenance and tokens, and inflates a meaning's prominence on the ladder past its real rank.
+- **Sediment** — stale layers that settle because adding feels safe and removing feels risky. The default fate of any skill without a pruning discipline.
+- **Sprawl** — a skill simply too long, even when every line is live and unique. Hurts readability and maintainability and wastes tokens. The cure is the ladder: disclose **reference** behind pointers, and split by **branch** or sequence so each path carries only what it needs.
+- **No-op** — a line the model already obeys by default, so you pay load to say nothing. The test: does it change behaviour versus the default? A weak leading word (_be thorough_ when the agent is already thorough-ish) is a no-op; the fix is a stronger word (_relentless_), not a different technique.
 
 ## Doctor
 
-An estate audit verb, report-only — it never edits a skill or a `CLAUDE.md`/`AGENTS.md`,
-it reports findings for a human to act on. Invoke with `/writing-great-skills doctor`.
+An estate audit, applying every lever above outward instead of inward: not "is this one skill predictable" but "is the whole loaded estate." Report-only — it never edits a skill or a `CLAUDE.md`/`AGENTS.md`; it names findings for a human to act on.
 
-Six passes: measure the always-loaded surface (the `CLAUDE.md`/`AGENTS.md` import chain,
-every installed skill's description, chars and estimated tokens per component and in
-total); sweep descriptions for synonym-stuffed triggers, mechanism the body already
-carries, hand-only skills that read like autonomous triggers, and cross-skill trigger
-overlap; sweep the always-loaded chain for duplicated rules, conditional sections that
-belong behind a pointer, stacked negations, no-ops, and sediment; verify every finding
-against a direct grep or read before reporting it — a finding without quoted evidence is
-dropped; report ranked findings worst first, accuracy risks above token costs, with
-estimated recoverable tokens, fixes left as operator judgment calls; and refresh by
-re-fetching the upstream source and diffing it against the adapted reference, flagging
-drift for a human rewrite rather than auto-updating.
+- **Measure context load.** Walk the always-loaded surface — the `CLAUDE.md`/`AGENTS.md` import chain, every installed skill's **description** — and size each piece: chars, estimated tokens (chars ÷ 4), and a total. That total is the **context load** tax paid before the user's first word.
+- **Sweep descriptions** against the invocation and description-writing sections above: synonym-stuffed trigger lists (**duplication** of a branch), mechanism the body already carries, a **user-invoked** skill whose description still reads like an autonomous trigger, and trigger overlap between two skills' descriptions.
+- **Sweep the always-loaded chain** for the same failure modes a single skill is graded on: **duplication** across files, **reference** that should be **disclosed** instead of sitting in-file, stacked negation (see `references/writing-for-agents.md`), **no-op** sentences, and **sediment**.
+- **Verify before reporting.** A finding without a quoted grep or read result gets dropped — no reporting from memory of a prior pass.
+- **Report ranked findings**, worst first. Accuracy risks (drift that could misfire, overlapping triggers) outrank pure **context load** cost; give each a recoverable-token estimate where it's a cost finding. No fixes — every finding is an operator judgment call.
+- **Refresh** by re-fetching the upstream source behind `references/writing-for-agents.md` and diffing its substance against the adapted file. Flag drift for a human to rewrite by hand; never auto-update the adapted file.
 
-Full step detail, including exact file locations to walk and the refresh diff mechanics,
-is in [`references/doctor.md`](references/doctor.md).
+Full step-by-step mechanics — exact locations to walk, the refresh diff procedure — are disclosed to [`references/doctor.md`](references/doctor.md).

--- a/skills/writing-great-skills/SKILL.md
+++ b/skills/writing-great-skills/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: writing-great-skills
+description: Write, review, or audit a skill or CLAUDE.md/AGENTS.md against the pointer, load, and pruning vocabulary in references/writing-for-agents.md. Hand-only — invoke with /writing-great-skills to draft or review a skill, or /writing-great-skills doctor to audit the loaded estate.
+---
+
+# Writing great skills
+
+User-invoked only — this skill doesn't trigger itself; reach for it by name when
+writing a skill, reviewing one, or auditing the estate.
+
+## Writing or reviewing a skill
+
+Read [`references/writing-for-agents.md`](references/writing-for-agents.md) first; it's
+the vocabulary this skill applies. Then:
+
+1. **Description first.** Front-load the trigger word, one trigger per branch, cut
+   identity the body already carries. If the skill only ever fires by hand, say so in
+   the description and write it for a human skimming a list, not for autonomous
+   matching.
+2. **Place every piece of content on the hierarchy.** In-file step (what runs, in
+   order), in-file reference (flat facts consulted on demand), or disclosed reference
+   (pushed to a sibling file, reached by a pointer). Run the branching test: if every
+   branch needs it, keep it in-file; if only some branches reach it, disclose it.
+3. **Give every step a completion criterion** that's checkable and demands real work,
+   not "understanding reached."
+4. **Reach for a leading word before writing three sentences of restatement.** Positive
+   phrasing first; a prohibition only as a hard guardrail, paired with its positive
+   target.
+5. **Prune before shipping.** One source of truth per meaning, no restating what the
+   environment already answers, no no-op sentences. If a sentence changes nothing when
+   deleted, delete the whole sentence.
+
+## Doctor
+
+An estate audit verb, report-only — it never edits a skill or a `CLAUDE.md`/`AGENTS.md`,
+it reports findings for a human to act on. Invoke with `/writing-great-skills doctor`.
+
+Six passes: measure the always-loaded surface (the `CLAUDE.md`/`AGENTS.md` import chain,
+every installed skill's description, chars and estimated tokens per component and in
+total); sweep descriptions for synonym-stuffed triggers, mechanism the body already
+carries, hand-only skills that read like autonomous triggers, and cross-skill trigger
+overlap; sweep the always-loaded chain for duplicated rules, conditional sections that
+belong behind a pointer, stacked negations, no-ops, and sediment; verify every finding
+against a direct grep or read before reporting it — a finding without quoted evidence is
+dropped; report ranked findings worst first, accuracy risks above token costs, with
+estimated recoverable tokens, fixes left as operator judgment calls; and refresh by
+re-fetching the upstream source and diffing it against the adapted reference, flagging
+drift for a human rewrite rather than auto-updating.
+
+Full step detail, including exact file locations to walk and the refresh diff mechanics,
+is in [`references/doctor.md`](references/doctor.md).

--- a/skills/writing-great-skills/agents/openai.yaml
+++ b/skills/writing-great-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Writing Great Skills"
+  short_description: "Write, review, and audit skills against a shared writing-for-agents vocabulary"
+  default_prompt: "Use $writing-great-skills to draft or review a skill, or $writing-great-skills doctor to audit the loaded estate."

--- a/skills/writing-great-skills/references/doctor.md
+++ b/skills/writing-great-skills/references/doctor.md
@@ -1,0 +1,68 @@
+# Doctor procedure
+
+Report-only estate audit. Never edits a skill, a `CLAUDE.md`, or an `AGENTS.md` — every
+finding is a recommendation for a human to act on.
+
+## 1. Measure the always-loaded surface
+
+Walk every document the agent loads before or during session start, and size each one:
+
+* The global `CLAUDE.md`/`AGENTS.md`, following every `@import` line to its target file,
+  recursively.
+* The project `CLAUDE.md`/`AGENTS.md` in the current repo.
+* Every `SKILL.md` frontmatter `description` under `~/.claude/skills/` (follow symlinks
+  to the real file — an installed skill is usually a symlink into a checkout).
+* Any other file the import chain names as read at session start (a referenced profile
+  file, a shared instructions doc).
+
+For each component, report character count and estimated tokens (`chars / 4`). Sum to a
+total. This total is the tax every single turn pays before the user's first word.
+
+## 2. Sweep descriptions
+
+Check every `SKILL.md` description against `references/writing-for-agents.md`'s pointer
+rules:
+
+* **Synonym-stuffed trigger lists** — three phrasings of one branch instead of one
+  phrasing each of three branches.
+* **Mechanism or output detail the body already owns** — a description restating *how*
+  the skill works instead of *when* to reach for it.
+* **Hand-only skills missing the manual-invocation signal** — a skill whose body says
+  "user-invoked" or "invoke by name" but whose description still reads like an
+  autonomous trigger list (this repo's schema has no `disable-model-invocation` field;
+  the signal is in the wording).
+* **Trigger overlap between skills** — two descriptions matching the same phrase or
+  intent, risking the wrong skill firing.
+
+## 3. Sweep the always-loaded chain
+
+Read the full chain from step 1 and check for:
+
+* **Duplicated rules** — the same instruction stated in more than one always-loaded
+  file. Quote both locations.
+* **Conditional sections that belong behind a pointer** — a paragraph that only matters
+  for a rare case, sitting in-file instead of disclosed.
+* **Stacked negations** — prohibitions with no paired positive target.
+* **No-op sentences** — instructions the model already follows by default.
+* **Sediment** — stale material describing a world that's moved on (a tool no longer
+  used, a workflow that's been replaced).
+
+## 4. Evidence rule
+
+A finding without a quoted grep or read result gets dropped before it's reported. Verify
+every claim directly against the file; don't report from memory of a prior pass.
+
+## 5. Report
+
+Rank findings worst first. Accuracy risks (duplication that could drift, overlapping
+triggers that misfire) outrank pure token cost. For each finding: what it is, where
+(file, and quoted evidence), and the estimated recoverable tokens if it's a cost
+finding. No fixes — every finding is an operator judgment call, not an auto-apply diff.
+
+## 6. Refresh
+
+Re-fetch the upstream source (`https://raw.githubusercontent.com/mattpocock/skills/main/skills/productivity/writing-for-agents/SKILL.md` and its `SKILL-MECHANICS.md` sibling). Diff
+the substance — new recommendations, retracted ones, reworded ones that change meaning —
+against `references/writing-for-agents.md`. Flag drift for a human to rewrite by hand;
+never auto-update the adapted file. Once a human reconciles it, update the attribution
+line's fetch date at the top of `references/writing-for-agents.md`.

--- a/skills/writing-great-skills/references/doctor.md
+++ b/skills/writing-great-skills/references/doctor.md
@@ -20,17 +20,16 @@ total. This total is the tax every single turn pays before the user's first word
 
 ## 2. Sweep descriptions
 
-Check every `SKILL.md` description against `references/writing-for-agents.md`'s pointer
-rules:
+Check every `SKILL.md` description against the "Invocation" and "Writing the
+description" sections of this skill's own `SKILL.md` (terms defined in `GLOSSARY.md`):
 
 * **Synonym-stuffed trigger lists** — three phrasings of one branch instead of one
-  phrasing each of three branches.
+  phrasing each of three branches (**duplication** of a branch).
 * **Mechanism or output detail the body already owns** — a description restating *how*
   the skill works instead of *when* to reach for it.
-* **Hand-only skills missing the manual-invocation signal** — a skill whose body says
-  "user-invoked" or "invoke by name" but whose description still reads like an
-  autonomous trigger list (this repo's schema has no `disable-model-invocation` field;
-  the signal is in the wording).
+* **User-invoked skills missing the manual-invocation signal** — a skill with
+  `disable-model-invocation: true` whose description still reads like an autonomous
+  trigger list instead of a human-facing summary.
 * **Trigger overlap between skills** — two descriptions matching the same phrase or
   intent, risking the wrong skill firing.
 
@@ -42,7 +41,8 @@ Read the full chain from step 1 and check for:
   file. Quote both locations.
 * **Conditional sections that belong behind a pointer** — a paragraph that only matters
   for a rare case, sitting in-file instead of disclosed.
-* **Stacked negations** — prohibitions with no paired positive target.
+* **Stacked negations** — prohibitions with no paired positive target (see
+  `references/writing-for-agents.md`'s Negation section).
 * **No-op sentences** — instructions the model already follows by default.
 * **Sediment** — stale material describing a world that's moved on (a tool no longer
   used, a workflow that's been replaced).

--- a/skills/writing-great-skills/references/writing-for-agents.md
+++ b/skills/writing-great-skills/references/writing-for-agents.md
@@ -1,0 +1,148 @@
+# Writing for agents
+
+Adapted from Matt Pocock's writing-for-agents (github.com/mattpocock/skills), fetched 2026-08-06.
+
+Everything an agent reads before or during a task — a skill, a `CLAUDE.md`/`AGENTS.md`
+line, a disclosed reference file — is one document type with one job: make the agent
+take the same *process* on every run, not the same output. The rest of this file is the
+vocabulary for judging whether a document does that job.
+
+## Pointers
+
+A **pointer** is anything in the agent's always-loaded context that names material
+living outside it and states the condition for reaching it: a skill description, a
+`CLAUDE.md` line naming a doc, a "see references/x.md" sentence. The pointer's wording
+decides whether the agent reaches the material, not the material's quality — a critical
+doc behind a vague pointer is a bug in the pointer, not the doc. Sharpen the wording
+before inlining the material; inlining is the expensive fallback.
+
+A pointer has two jobs: say what the target is, and list the branches (distinct cases)
+that should send the agent there. Rules for writing one, in order of how much they cost
+to skip:
+
+* **Front-load the trigger word.** The word that should fire the pointer belongs at the
+  front, where it does its matching work, not buried mid-sentence.
+* **One trigger per branch.** Three synonyms for the same case are one branch written
+  three times — collapse them. Keep only branches that actually diverge.
+* **Cut identity the body already carries.** Don't restate in the pointer what the
+  target document says about itself in its own first line.
+
+## Two kinds of load
+
+Every document and pointer spends one of two budgets:
+
+* **Context load** — cost on the agent's window. Anything always loaded (a skill
+  description, a `CLAUDE.md` line) pays this on every single turn, whether or not it
+  fires that turn.
+* **Cognitive load** — cost on the human, who has to remember the document exists and
+  when to reach for it. Not a cost to eliminate; it's the price of leaving a judgment
+  call to a person. Spend it where the human's judgment matters, cut it everywhere else.
+
+Content behind a pointer trades context load for the pointer's own (small) footprint.
+Content with no pointer at all rides entirely on the human remembering it.
+
+## Information hierarchy
+
+Rank every piece of content by how urgently the agent needs it:
+
+1. **In-file step** — the ordered actions, inline. What runs first.
+2. **In-file reference** — rules, definitions, a flat list consulted as needed. Still
+   loaded every time, but not part of the sequence.
+3. **Disclosed reference** — pushed to a separate file, reached only through a pointer
+   that fires on demand. Ranges from a sibling file in the skill's own folder to a
+   fully external doc any skill can point at.
+
+**Progressive disclosure** is moving content down this ladder so the top stays scannable.
+Use the **branching test** to decide what moves: if every branch needs it, keep it
+in-file; if only some branches reach it, push it behind a pointer. Reference that should
+have been disclosed but sits in-file buries the steps around it — the agent's attention
+on "what do I do next" competes with "here's a fact you may not need."
+
+**Co-location** is the in-file version of the same instinct: keep a concept's definition,
+rules, and caveats under one heading instead of scattered across the document. A reader
+(or agent) hitting one part should get its neighbors for free. This is different from
+duplication — duplication repeats one meaning in two places; scattering spreads one
+meaning across many, with none of them complete.
+
+**Sprawl** is what happens when nothing gets disclosed and nothing gets pruned: the
+document is long *and* every line is technically relevant, so there's nothing to cut, but
+attention still thins across the length. The fix is always structural — disclose, or
+split — never "trim adjectives."
+
+## Completion criteria
+
+Every step needs a condition that tells the agent "this is done." Two properties matter:
+
+* **Clarity** — can done be told from not-done at a glance? A fuzzy bound ("understand
+  the codebase") invites **premature completion**, where the agent's attention slides
+  toward the *next* visible step before this one is actually finished. Fix the wording
+  first — sharpen the bound. Only split the sequence (hiding later steps behind a real
+  context boundary — a hand-off, a subagent call, not an inline function call) if the
+  bound is genuinely irreducible and you've actually observed the rushing.
+* **Demand** — how much work the criterion requires. "List every file touched" is
+  weaker than "confirm every touched file compiles." High-demand criteria drive legwork
+  — digging the agent does without being told to dig, because the bar forces it. This
+  applies to flat reference too: "every rule checked" is a demand bar on a rule list,
+  not just on a step sequence.
+
+## Splitting a document
+
+Splitting spends load, so only split when it earns it back:
+
+* **By sequence** — cut a long run of steps where later steps visible in the same file
+  tempt the agent to rush the current one. Splitting hides them behind a real boundary
+  and forces full attention on the step at hand. Don't do the reverse: merging two
+  sequences that were split for this reason reopens the premature-completion risk.
+* **By invocation** — skill-specific; the trigger is a genuinely separate leading word
+  the agent (or another skill) should be able to fire on its own. See the Doctor
+  section of this skill's SKILL.md for how this plays out with model- vs user-invoked
+  skills.
+
+## Leading words
+
+A **leading word** is an existing, pretrained concept (*tracer bullet*, *fog of war*,
+*tight loop*) that the model already has priors for. Using it as a token — never
+re-explained as a full sentence each time — recruits those priors for free; coining a
+new term instead means paying definition tokens the pretrained word would have given
+you at no cost.
+
+A leading word does two things: in the body, it anchors *execution* — the agent reaches
+for the same behavior every time the word shows up. In a pointer, it anchors
+*invocation* — when the same word appears in your prompts, your docs, and the codebase
+itself, the agent connects them and reaches the pointer more reliably.
+
+Hunt for restatements to collapse: if a document keeps re-describing the same triad or
+gesture in different words each time, that's a leading word waiting to be minted or
+borrowed. "Fast, deterministic, low-overhead" collapses to *tight*. A vague "a loop you
+trust" collapses to a binary *red/not-red* state.
+
+**Negation is the trap next to this lever.** Telling the agent what *not* to do puts the
+forbidden behavior directly in context and makes it more available, not less — "don't
+use em-dashes" activates em-dashes. State the positive target instead ("use short
+sentences and parens for asides") so the banned behavior never gets named. Keep a bare
+prohibition only as a hard guardrail with no honest positive phrasing, and even then
+pair it with the positive target so the agent has somewhere to put its attention.
+
+## Pruning
+
+* **Single source of truth.** Each meaning lives in exactly one place. Duplication —
+  the same meaning stated twice — costs upkeep (two places to update) and inflates that
+  meaning's apparent importance beyond what it deserves. Not the same as a leading word,
+  which repeats a *token* on purpose while the meaning stays singular.
+* **Cache vs. environment.** The environment — `package.json`, config files, `--help`
+  output, the directory layout — is already a source of truth. A document that restates
+  it is a cache, and a cache only earns its keep when the lookup it replaces is
+  expensive. Document the unwritten convention or the gotcha the environment can't
+  confess; skip the one-command lookup the agent can just run.
+* **Relevance and sediment.** Ask of every line: does it still bear on what this
+  document does? A line stops being relevant when it never mattered (padding, or a
+  branch that should have been disclosed) or when the world it describes moved on.
+  Without active pruning, stale material accumulates as **sediment** — nobody wants to
+  be the one to delete a line that might still matter, so it never gets deleted, and the
+  document thickens with dead weight.
+* **No-ops.** A no-op is an instruction the model would already follow by default —
+  stating it spends tokens to change nothing. Test it against actual behavior, not
+  intuition: run the document and see if removing the line changes anything. If it's a
+  no-op, delete the whole sentence, not just a few words from it. This test also catches
+  weak leading words: "be thorough" against a model that's already thorough-ish is a
+  no-op; the fix is a stronger word ("relentless"), not a longer sentence.

--- a/skills/writing-great-skills/references/writing-for-agents.md
+++ b/skills/writing-great-skills/references/writing-for-agents.md
@@ -1,148 +1,33 @@
-# Writing for agents
+# Writing for agents — negation and the cache/environment distinction
 
 Adapted from Matt Pocock's writing-for-agents (github.com/mattpocock/skills), fetched 2026-08-06.
 
-Everything an agent reads before or during a task — a skill, a `CLAUDE.md`/`AGENTS.md`
-line, a disclosed reference file — is one document type with one job: make the agent
-take the same *process* on every run, not the same output. The rest of this file is the
-vocabulary for judging whether a document does that job.
+This skill's own [`SKILL.md`](../SKILL.md) and [`GLOSSARY.md`](../GLOSSARY.md) already
+cover invocation, the two loads, the information hierarchy, completion criteria, leading
+words, and pruning's single-source-of-truth/relevance/sediment/no-op cluster — this file
+holds only the two upstream levers that aren't in either: negation, and the distinction
+between a cache and the environment it copies.
 
-## Pointers
+## Negation
 
-A **pointer** is anything in the agent's always-loaded context that names material
-living outside it and states the condition for reaching it: a skill description, a
-`CLAUDE.md` line naming a doc, a "see references/x.md" sentence. The pointer's wording
-decides whether the agent reaches the material, not the material's quality — a critical
-doc behind a vague pointer is a bug in the pointer, not the doc. Sharpen the wording
-before inlining the material; inlining is the expensive fallback.
+Telling the agent what *not* to do puts the forbidden behavior directly in context and
+makes it more available, not less — "don't use em-dashes" activates em-dashes. State the
+positive target instead ("use short sentences and parens for asides") so the banned
+behavior never gets named.
 
-A pointer has two jobs: say what the target is, and list the branches (distinct cases)
-that should send the agent there. Rules for writing one, in order of how much they cost
-to skip:
+Keep a bare prohibition only as a hard guardrail with no honest positive phrasing, and
+even then pair it with the positive target so the agent has somewhere to put its
+attention. A document with several stacked prohibitions and no positive counterpart for
+any of them is a document steering by what to avoid instead of what to do — flag it.
 
-* **Front-load the trigger word.** The word that should fire the pointer belongs at the
-  front, where it does its matching work, not buried mid-sentence.
-* **One trigger per branch.** Three synonyms for the same case are one branch written
-  three times — collapse them. Keep only branches that actually diverge.
-* **Cut identity the body already carries.** Don't restate in the pointer what the
-  target document says about itself in its own first line.
+## Cache vs. environment
 
-## Two kinds of load
+The environment — `package.json`, config files, `--help` output, the directory layout —
+is already a source of truth. A document that restates it is a cache, and a cache only
+earns its keep when the lookup it replaces is expensive. Document the unwritten
+convention or the gotcha the environment can't confess; skip the one-command lookup the
+agent can just run.
 
-Every document and pointer spends one of two budgets:
-
-* **Context load** — cost on the agent's window. Anything always loaded (a skill
-  description, a `CLAUDE.md` line) pays this on every single turn, whether or not it
-  fires that turn.
-* **Cognitive load** — cost on the human, who has to remember the document exists and
-  when to reach for it. Not a cost to eliminate; it's the price of leaving a judgment
-  call to a person. Spend it where the human's judgment matters, cut it everywhere else.
-
-Content behind a pointer trades context load for the pointer's own (small) footprint.
-Content with no pointer at all rides entirely on the human remembering it.
-
-## Information hierarchy
-
-Rank every piece of content by how urgently the agent needs it:
-
-1. **In-file step** — the ordered actions, inline. What runs first.
-2. **In-file reference** — rules, definitions, a flat list consulted as needed. Still
-   loaded every time, but not part of the sequence.
-3. **Disclosed reference** — pushed to a separate file, reached only through a pointer
-   that fires on demand. Ranges from a sibling file in the skill's own folder to a
-   fully external doc any skill can point at.
-
-**Progressive disclosure** is moving content down this ladder so the top stays scannable.
-Use the **branching test** to decide what moves: if every branch needs it, keep it
-in-file; if only some branches reach it, push it behind a pointer. Reference that should
-have been disclosed but sits in-file buries the steps around it — the agent's attention
-on "what do I do next" competes with "here's a fact you may not need."
-
-**Co-location** is the in-file version of the same instinct: keep a concept's definition,
-rules, and caveats under one heading instead of scattered across the document. A reader
-(or agent) hitting one part should get its neighbors for free. This is different from
-duplication — duplication repeats one meaning in two places; scattering spreads one
-meaning across many, with none of them complete.
-
-**Sprawl** is what happens when nothing gets disclosed and nothing gets pruned: the
-document is long *and* every line is technically relevant, so there's nothing to cut, but
-attention still thins across the length. The fix is always structural — disclose, or
-split — never "trim adjectives."
-
-## Completion criteria
-
-Every step needs a condition that tells the agent "this is done." Two properties matter:
-
-* **Clarity** — can done be told from not-done at a glance? A fuzzy bound ("understand
-  the codebase") invites **premature completion**, where the agent's attention slides
-  toward the *next* visible step before this one is actually finished. Fix the wording
-  first — sharpen the bound. Only split the sequence (hiding later steps behind a real
-  context boundary — a hand-off, a subagent call, not an inline function call) if the
-  bound is genuinely irreducible and you've actually observed the rushing.
-* **Demand** — how much work the criterion requires. "List every file touched" is
-  weaker than "confirm every touched file compiles." High-demand criteria drive legwork
-  — digging the agent does without being told to dig, because the bar forces it. This
-  applies to flat reference too: "every rule checked" is a demand bar on a rule list,
-  not just on a step sequence.
-
-## Splitting a document
-
-Splitting spends load, so only split when it earns it back:
-
-* **By sequence** — cut a long run of steps where later steps visible in the same file
-  tempt the agent to rush the current one. Splitting hides them behind a real boundary
-  and forces full attention on the step at hand. Don't do the reverse: merging two
-  sequences that were split for this reason reopens the premature-completion risk.
-* **By invocation** — skill-specific; the trigger is a genuinely separate leading word
-  the agent (or another skill) should be able to fire on its own. See the Doctor
-  section of this skill's SKILL.md for how this plays out with model- vs user-invoked
-  skills.
-
-## Leading words
-
-A **leading word** is an existing, pretrained concept (*tracer bullet*, *fog of war*,
-*tight loop*) that the model already has priors for. Using it as a token — never
-re-explained as a full sentence each time — recruits those priors for free; coining a
-new term instead means paying definition tokens the pretrained word would have given
-you at no cost.
-
-A leading word does two things: in the body, it anchors *execution* — the agent reaches
-for the same behavior every time the word shows up. In a pointer, it anchors
-*invocation* — when the same word appears in your prompts, your docs, and the codebase
-itself, the agent connects them and reaches the pointer more reliably.
-
-Hunt for restatements to collapse: if a document keeps re-describing the same triad or
-gesture in different words each time, that's a leading word waiting to be minted or
-borrowed. "Fast, deterministic, low-overhead" collapses to *tight*. A vague "a loop you
-trust" collapses to a binary *red/not-red* state.
-
-**Negation is the trap next to this lever.** Telling the agent what *not* to do puts the
-forbidden behavior directly in context and makes it more available, not less — "don't
-use em-dashes" activates em-dashes. State the positive target instead ("use short
-sentences and parens for asides") so the banned behavior never gets named. Keep a bare
-prohibition only as a hard guardrail with no honest positive phrasing, and even then
-pair it with the positive target so the agent has somewhere to put its attention.
-
-## Pruning
-
-* **Single source of truth.** Each meaning lives in exactly one place. Duplication —
-  the same meaning stated twice — costs upkeep (two places to update) and inflates that
-  meaning's apparent importance beyond what it deserves. Not the same as a leading word,
-  which repeats a *token* on purpose while the meaning stays singular.
-* **Cache vs. environment.** The environment — `package.json`, config files, `--help`
-  output, the directory layout — is already a source of truth. A document that restates
-  it is a cache, and a cache only earns its keep when the lookup it replaces is
-  expensive. Document the unwritten convention or the gotcha the environment can't
-  confess; skip the one-command lookup the agent can just run.
-* **Relevance and sediment.** Ask of every line: does it still bear on what this
-  document does? A line stops being relevant when it never mattered (padding, or a
-  branch that should have been disclosed) or when the world it describes moved on.
-  Without active pruning, stale material accumulates as **sediment** — nobody wants to
-  be the one to delete a line that might still matter, so it never gets deleted, and the
-  document thickens with dead weight.
-* **No-ops.** A no-op is an instruction the model would already follow by default —
-  stating it spends tokens to change nothing. Test it against actual behavior, not
-  intuition: run the document and see if removing the line changes anything. If it's a
-  no-op, delete the whole sentence, not just a few words from it. This test also catches
-  weak leading words: "be thorough" against a model that's already thorough-ish is a
-  no-op; the fix is a stronger word ("relentless"), not a longer sentence.
+A line that just repeats what `--help`, a manifest file, or a directory listing already
+says is not **relevance**'s failure mode (it may well still be true) — it's a cache with
+no expensive lookup behind it, and it should go.


### PR DESCRIPTION
Promotes writing-great-skills from the private dotfiles override to this repo as the canonical copy, and adds a doctor verb.

* SKILL.md and GLOSSARY.md are the existing override's prose, unchanged; frontmatter keeps disable-model-invocation: true (the skill stays hand-invoked, zero always-loaded cost).
* New doctor verb: a report-only estate audit that measures the always-loaded surface, sweeps descriptions and the instruction chain against the writing-for-agents recommendations, requires quoted evidence per finding, and ranks accuracy risks above token costs. Full mechanics disclosed to references/doctor.md.
* references/writing-for-agents.md holds only the two levers the skill body doesn't already teach (negation, cache vs environment), adapted in this repo's voice from Matt Pocock's writing-for-agents with attribution in NOTICE.
* validate.py accepts an optional disable-model-invocation: true; README gains the skill row.

What to check: SKILL.md and GLOSSARY.md read as your originals, and the doctor procedure matches how you'd want the audit re-run.

A follow-up dotfiles PR deletes the now-redundant override so the installed symlink points here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)