### PR TITLE
docs(charter): resolve an ADR's home from the repo's existing record

### DIFF
--- a/profile/CHARTER.md
+++ b/profile/CHARTER.md
@@ -56,9 +56,11 @@ and enforced at review: a violation below is a blocking finding.
   security or adversarial input, or observed behavior grounds.
 - Domain terms come from **`CONTEXT.md`**; record load-bearing, hard-to-reverse
   decisions as **ADRs** — and don't re-litigate settled ones.
-- **ADR identity comes from the originating tracker item.** New records use
-  `docs/adr/adr-<issue>-<slug>.md` with heading `# ADR <issue> — Title`, where
-  `<issue>` is the id of the issue, ticket, or PR that originated the decision.
-  Two records from one issue use distinct slugs. Existing sequentially numbered
-  ADRs are legacy records: keep their names and links; do not add new ones in
-  that format.
+- **An ADR's home is wherever the repo already records decisions.** A repo
+  tracking design with OpenSpec records the decision in its change's
+  `design.md`; do not add a parallel `docs/adr/` tree beside it. A repo with no
+  existing home gets `docs/adr/adr-<issue>-<slug>.md`, heading
+  `# ADR <issue> — Title`, where `<issue>` is the id of the issue, ticket, or PR
+  that originated the decision. Two records from one issue use distinct slugs.
+  Existing sequentially numbered ADRs are legacy records: keep their names and
+  links; do not add new ones in that format.

--- a/profile/CHARTER.md
+++ b/profile/CHARTER.md
@@ -58,8 +58,12 @@ and enforced at review: a violation below is a blocking finding.
   decisions as **ADRs** — and don't re-litigate settled ones.
 - **An ADR's home is wherever the repo already records decisions.** A repo
   tracking design with OpenSpec records the decision in its change's
-  `design.md`; do not add a parallel `docs/adr/` tree beside it. A repo with no
-  existing home gets `docs/adr/adr-<issue>-<slug>.md`, heading
+  `design.md` under a `## ADR <issue> — Title` heading (the change already names
+  the work, so the issue id is the record's identity); do not add a parallel
+  `docs/adr/` tree beside it. An established `docs/adr/` tree wins over
+  OpenSpec: keep adding records where the history already is, rather than
+  forking it. A repo with no existing home
+  gets `docs/adr/adr-<issue>-<slug>.md`, heading
   `# ADR <issue> — Title`, where `<issue>` is the id of the issue, ticket, or PR
   that originated the decision. Two records from one issue use distinct slugs.
   Existing sequentially numbered ADRs are legacy records: keep their names and


### PR DESCRIPTION
The charter named `docs/adr/adr-<issue>-<slug>.md` unconditionally, so an agent recording a decision in a repo that already tracks design with OpenSpec creates a second, competing decision record beside the working one. That happened during a triage session on a repo whose decisions live in openspec change folders.

The rule now resolves the home first and applies the `docs/adr/` naming only to a repo that has none. Identity rules are unchanged.

Kept as one bullet so the "no existing home" condition has a single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)