### PR TITLE
docs(adr): resolve an ADR's home before the naming rule in consumers

### DIFF
--- a/profile/base.md
+++ b/profile/base.md
@@ -73,7 +73,8 @@ categories that don't apply.
   tradeoff if the native path is meaningfully worse.
 - **Ask before system-wide or hard-to-reverse changes** (global config, deleting
   files I didn't create, anything touching state outside the repo).
-- **Don't keep durable knowledge in agent memory.** Decisions go in `docs/adr/`,
+- **Don't keep durable knowledge in agent memory.** Decisions go in the repo's
+  decision record per the charter's ADR-home rule,
   work state goes on the tracker issue, environment facts go in the repo's
   `AGENTS.md`/`CLAUDE.md`. A private memory file I can't review or merge is the
   wrong home for anything that outlives the session.

--- a/skills/domain-modeling/SKILL.md
+++ b/skills/domain-modeling/SKILL.md
@@ -19,7 +19,9 @@ conflate them — a term is not a decision, and a decision is not a definition.
 
 ## File structure
 
-Most repos have a single context:
+Most repos have a single context (the `docs/adr/` trees below illustrate a repo
+with no existing decision record; resolve the ADR's home first, per
+[references/ADR-FORMAT.md](references/ADR-FORMAT.md)):
 
 ```
 /
@@ -49,8 +51,9 @@ map points to where each one lives:
 ```
 
 Create files lazily — only when you have something to write. If no
-`CONTEXT.md` exists, create one when the first term is resolved. If no
-`docs/adr/` exists, create it when the first ADR is needed.
+`CONTEXT.md` exists, create one when the first term is resolved. An ADR goes
+wherever the repo already records decisions ([references/ADR-FORMAT.md](references/ADR-FORMAT.md)),
+and a new `docs/adr/` is created only when that resolves to `docs/adr/`.
 
 ## During the session
 

--- a/skills/domain-modeling/references/ADR-FORMAT.md
+++ b/skills/domain-modeling/references/ADR-FORMAT.md
@@ -1,12 +1,17 @@
 # ADR Format
 
-ADRs live in `docs/adr/`. New records use
-`docs/adr/adr-<issue>-<slug>.md`, heading `# ADR <issue> — Title`, where
-`<issue>` is the id of the issue, ticket, or PR that originated the decision.
-Two records from one issue use distinct slugs — don't overwrite one decision's
-file with another's.
+Resolve the ADR's home before anything else: a decision goes wherever the repo
+already records decisions. A repo tracking design with OpenSpec records it in
+that change's `design.md` (no parallel `docs/adr/` tree, and the file-naming
+rule below does not apply there). A repo with an established `docs/adr/` tree
+keeps using it.
 
-Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+Only a repo with no existing home gets one: `docs/adr/adr-<issue>-<slug>.md`,
+heading `# ADR <issue> — Title`, where `<issue>` is the id of the issue,
+ticket, or PR that originated the decision. Two records from one issue use
+distinct slugs, so one decision's file never overwrites another's.
+
+Create the `docs/adr/` directory lazily, only when the first ADR needs it.
 
 ## Template
 
@@ -37,7 +42,7 @@ etc., with no issue id in the name. That format is legacy: keep those files
 and their links exactly as they are — never renumber or relink them — but
 never extend that numbering for a new ADR. Every new record uses the
 `adr-<issue>-<slug>.md` scheme above, even in a repo whose older ADRs are
-still numbered.
+still numbered, once `docs/adr/` is the resolved home.
 
 ## When to offer an ADR
 


### PR DESCRIPTION
Follow-up to #20. The charter now resolves an ADR's home from the repo's existing decision record, but three consumer files still named docs/adr/ unconditionally, and two are more specific than the charter so they win at ADR-writing time.

* domain-modeling references/ADR-FORMAT.md opens by resolving the home (OpenSpec design.md, established docs/adr/ tree, or a new docs/adr/ only when no home exists) before giving the naming rule.
* domain-modeling SKILL.md labels its docs/adr/ diagram as the no-existing-home case and defers the home question to ADR-FORMAT.md.
* profile/base.md points the durable-knowledge bullet at the charter's ADR-home rule instead of a literal path.

What to check: the two branches (OpenSpec vs docs/adr/) read consistently with the charter bullet in #20, including the identity/precedence clauses added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)