### PR TITLE
Fix Wayfinder interview frontier cadence

### DIFF
--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -90,8 +90,9 @@ Apply exactly one ticket-type label:
   variants, iterate with the human, and finish with a locked visual spec linked from the
   ticket. That artifact also satisfies any later review gate that demands a locked design.
 - **`wayfinder:interview` (HITL):** Invoke `/scope`'s interview mode, plus a
-  domain-modelling skill when one is available; ask one question at a time. Never
-  answer the human's side of the exchange.
+  domain-modelling skill when one is available. Follow interview mode's design-tree
+  cadence: ask the whole currently answerable frontier in one numbered round, then
+  wait. Never answer the human's side of the exchange.
 - **`wayfinder:task` (HITL):** A prerequisite that genuinely needs the human in the loop.
   It earns a place only by unblocking a decision, not by delivering the destination — and
   it is never an execution errand: a prerequisite that must *change the world* before a


### PR DESCRIPTION
## What changed

Wayfinder now follows Scope interview mode’s design-tree cadence: ask the whole currently answerable frontier in one numbered round, then wait.

## Why

Wayfinder restated the cadence as “ask one question at a time,” contradicting the interview procedure it invokes. That made planning interviews unnecessarily serial and forced users to answer decisions one by one even when they were independent.

The valid one-question rule in Scope remains unchanged because it applies only when one framing answer is needed to choose a specialist workflow.

## Impact

Wayfinder interview tickets will batch independent product decisions while preserving sequential questions when one answer genuinely controls the next frontier.

## Validation

- Parsed Wayfinder and Scope frontmatter with Ruby’s bundled YAML parser.
- Audited the repository for interview-cadence wording and confirmed Wayfinder and Scope now agree.
- `quick_validate.py` could not start because its environment lacks PyYAML; no validation assertion failed.