### PR TITLE
Support Codex parent orchestration

### DIFF
--- a/docs/orchestrate-spec.md
+++ b/docs/orchestrate-spec.md
@@ -73,3 +73,16 @@ empirically built model-capability table.
 - Routing table populated from benchmark results with a one-line rationale per
   cell and a "benchmarked on <date>, models <list>" provenance header.
 - Cold `/plan-review` run on the finished skill; blocking findings fixed.
+
+## Amendment — issue #24 (2026-08-08)
+
+Decision 1 remains the original locked Claude-parent decision. A Codex UI parent
+is now additionally supported through the `dispatch-codex.md` CLI-worker
+adapter: it dispatches and resumes only `codex exec` workers with persisted
+session identity, model, sandbox, and canonical working directory. Native Codex
+sub-agents are not used for delegated work. Its initial admissions are limited
+to bounded exploration (Luna), implementation and plan/spec writing (Terra),
+prototyping (Sol), default brainstorming (Terra), documentation and routine
+review (Luna); the unbenchmarked Codex-only areas are `NO_VALIDATED_ROUTE`.
+Codex-only routes do not fall back to Claude and remain single validated rungs:
+after one same-session retry, they stop with `NO_VALIDATED_ROUTE`.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -32,6 +32,7 @@ EXPECTED = {
     "ui-craft",
     "orchestrate",
     "writing-for-agents",
+    "handoff",
 }
 FORBIDDEN = (
     re.compile("/" + "Users/"),

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -56,7 +56,7 @@ Use this shape; omit empty sections rather than adding filler.
 
 ## Evidence and artifacts
 
-- [artifact or issue](absolute-or-canonical-link) — <status and why it matters>
+- [artifact or issue](https://example.com/artifact-or-issue) — <status and why it matters>
 
 ## Do not redo or assume
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -6,33 +6,39 @@ description: Flip the session into coordinator mode — the parent agent plans, 
 # Orchestrate — coordinator mode
 
 Invoking this skill flips the **whole session** into coordinator mode until the
-operator says otherwise. **Claude Code is the only supported parent** — if you
-are not Claude Code (e.g. this was invoked from the Codex harness), stop and
-tell the operator this skill has no Codex-parent mode; the dispatch mechanics
-below are Claude Code machinery. Codex models are reached via `codex exec`
-(continue an existing Codex session with `codex exec resume`).
+operator says otherwise. Detect the parent before dispatching:
+
+- **Claude Code parent:** use the Claude and Codex mechanics below.
+- **Codex UI parent:** read `references/dispatch-codex.md` before routing. In
+  this v0, every delegation uses its CLI-worker adapter; do not use native
+  `spawn_agent` for implementation or review.
 
 ## Codex headroom gate — run at invocation
 
 Before any routing, check whether the Codex side has budget left:
 
-1. Probe fresh: run a trivial one-word `codex exec` (cheapest Codex model,
-   `--sandbox read-only`), then parse the `rate_limits` event from the newest
-   rollout under `~/.codex/sessions/**/*.jsonl`. Headroom =
-   `100 − primary.used_percent`. Never trust a snapshot from an old session —
-   it may be days stale.
-2. If headroom ≤ 5%, or the probe itself fails with a rate-limit error, the
-   session runs **Claude-only**: drop every Codex route (Sol, Terra, Luna,
-   Spark) from routing and never reference Codex models in delegations for the
-   rest of the session. Tell the operator once, with the measured headroom and
-   `resets_at`.
-3. Same rule mid-session: if any later Codex delegation fails with a rate-limit
-   error, flip to Claude-only from that point on.
+1. Probe fresh with a trivial one-word worker run (cheapest available Codex
+   model, `read-only`). The Codex adapter binds headroom to that worker's
+   captured session ID: it finds the rollout whose `session_meta.payload.session_id`
+   matches and reads its latest `event_msg` token-count rate limits. Headroom =
+   `100 − primary.used_percent`; absent rate limits mean **unknown**, not
+   sufficient. Never inspect merely the newest rollout — it may be unrelated.
+2. If headroom is ≤ 5%, **unknown**, or the probe itself fails with a rate-limit
+   error, branch by parent:
+   - **Claude parent:** run **Claude-only**: drop every Codex route (Sol,
+     Terra, Luna, Spark) from routing and never reference Codex models in
+     delegations for the rest of the session.
+   - **Codex UI parent:** it has a Codex-only constraint, so stop dispatching.
+     Report the measured headroom, `resets_at` when present, or the rate-limit
+     / unknown-headroom blocker. Do not switch to Claude workers.
+3. Apply the same parent branch mid-session if a later Codex delegation is
+   rate-limited. Tell the operator once when the branch changes.
 
-Claude-only routing uses each row's Claude rungs. Two rows have no Claude rung:
-plan/spec writing routes to **Opus with a mandatory coordinator fail-safe
-review** of the spec (the table's polarity-error warning is the reason the
-review is not optional); prototyping routes straight to **Opus**.
+For a Claude parent, Claude-only routing uses each row's Claude rungs. Two rows
+have no Claude rung: plan/spec writing routes to **Opus with a mandatory
+coordinator fail-safe review** of the spec (the table's polarity-error warning
+is the reason the review is not optional); prototyping routes straight to
+**Opus**.
 
 ## The coordinator ruling (behavioral core)
 
@@ -65,7 +71,8 @@ review is not optional); prototyping routes straight to **Opus**.
 2. Read `references/routing-table.md` and pick the **cheapest model that clears
    the bar** for that area. Honor the table's bans (e.g. Luna for UI mockups,
    Haiku for unverified exploration citations) and the headroom gate above —
-   in Claude-only mode, Codex rungs are skipped as if absent from the table.
+   Claude-only mode skips Codex rungs as if absent from the table; Codex UI
+   mode follows only its adapter's admitted routes.
 3. **Never delegate to Fable** — it is the coordinator tier only.
 4. Every delegation is labeled with its model tier so the operator can see the
    route: Agent-tool dispatches prefix the `description` with the model name
@@ -75,14 +82,13 @@ review is not optional); prototyping routes straight to **Opus**.
 5. Mechanics: Claude models via the Agent tool with a `model` override — a
    read-only agent type (e.g. Explore) for read-tasks, `isolation: "worktree"`
    for write-tasks, so the harness enforces what the prompt asks. Codex models
-   via `codex exec -m <model> -c model_reasoning_effort=medium --sandbox
-   read-only|workspace-write --skip-git-repo-check -C <dir>` — `read-only` for
-   read-tasks; `workspace-write` only into an isolated worktree, never the
-   coordinator's own checkout. Effort stays medium; escalation changes the
-   model tier, not the effort dial. Belt-and-braces: read-task prompts still
-   carry an explicit "context is read-only — never modify, patch, or stash"
-   line (a benchmark run was invalidated by an agent leaving a patch applied
-   to a shared worktree — treat this as load-bearing).
+   use the parent-specific dispatch adapter. `read-only` is for read-tasks;
+   `workspace-write` only targets an isolated worktree, never the coordinator's
+   checkout. Effort stays medium; escalation changes the model tier, not the
+   effort dial. Belt-and-braces: read-task prompts still carry an explicit
+   "context is read-only — never modify, patch, or stash" line (a benchmark run
+   was invalidated by an agent leaving a patch applied to a shared worktree —
+   treat this as load-bearing).
 
 ## Verification and escalation
 
@@ -93,13 +99,14 @@ verification:
 1. **Retry once** in the *same* sub-agent session, carrying your specific
    findings ("test missing for the flag path") — its loaded context makes the
    retry cheap.
-2. **Second failure → escalate one tier** (per the table's escalation column):
-   fresh agent, original spec, plus a note on what the cheaper model botched.
-3. If the failing route is already the top of its ladder (the table's
-   escalation column names no higher tier), stop: surface both failed attempts
-   to the operator instead of improvising a further escalation.
-4. Never unbounded retries; never tier-skip straight to the top; never silently
-   absorb a deviation — surface it to the operator.
+2. **Claude parent:** second failure escalates one tier (per the table's
+   escalation column) in a fresh agent with the original spec and a note on
+   what the cheaper model botched. At the top of the ladder, stop and surface
+   both failed attempts.
+3. **Codex UI parent v0:** every admitted route is one validated rung. After
+   the same-session retry fails, stop with **NO_VALIDATED_ROUTE** and surface
+   both attempts. Never escalate Terra, Luna, or Sol to Sonnet or Opus.
+4. Never unbounded retries, tier-skips, or silent deviations.
 
 Watch-items the benchmark confirmed per model family: Claude models may report
 success from reasoning rather than a green run (demand command output) and can

--- a/skills/orchestrate/agents/openai.yaml
+++ b/skills/orchestrate/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Orchestrate"
-  short_description: "Coordinator mode: route all real work to benchmarked sub-agents"
-  default_prompt: "Use $orchestrate to act as a coordinator and delegate this work to routed sub-agents."
+  short_description: "Coordinator mode: route real work to benchmarked workers"
+  default_prompt: "Use $orchestrate to act as a coordinator and delegate this work to routed workers."

--- a/skills/orchestrate/references/dispatch-codex.md
+++ b/skills/orchestrate/references/dispatch-codex.md
@@ -1,0 +1,45 @@
+# Codex UI parent dispatch (v0)
+
+Use this adapter only when the interactive coordinator is a Codex UI parent.
+All delegated exploration, implementation, review, and follow-up work runs
+through the executable helper; do not use native `spawn_agent`. CLI workers are
+the validated path and let the coordinator enforce both `cwd` and sandbox.
+
+Run `skills/orchestrate/scripts/codex-worker.py start` for a new worker. Give
+read work a resolved repository or worktree path and `--sandbox read-only`.
+Give write work a resolved isolated worktree path, `--sandbox workspace-write`,
+and the coordinator checkout in `--control-checkout`; the helper rejects the
+control checkout. Persist one state file per worker. Use `resume` with that
+state file for retry findings and ordinary follow-ups; it restores the captured
+model, sandbox, and canonical cwd rather than taking replacements.
+
+On success the helper emits one public JSON object. Read its `final_message`
+field as the current worker's answer; do not infer an answer from its session or
+headroom metadata.
+
+The adapter reports session-bound headroom only when the matching persisted
+rollout contains rate limits. `unknown`, headroom at or below 5%, and rate-limit
+failures block a Codex UI parent: stop dispatching and report the blocker. It
+cannot switch to Claude workers. Infrastructure failures (including a missing
+rollout) are dispatch failures, not evidence that a model tier failed its task.
+
+## Codex-only admission routes
+
+These are the only validated initial routes in Codex-only mode:
+
+| Area | Initial route |
+|---|---|
+| Bounded exploration | Luna (`gpt-5.6-luna`) |
+| Hermetic implementation | Terra (`gpt-5.6-terra`) |
+| Plan / spec writing | Terra (`gpt-5.6-terra`) |
+| Prototyping | Sol (`gpt-5.6-sol`) |
+| Default brainstorming | Terra (`gpt-5.6-terra`) |
+| Documentation | Luna (`gpt-5.6-luna`) |
+| Routine review | Luna (`gpt-5.6-luna`) |
+
+Full-system exploration, novelty-as-deliverable brainstorming, and
+load-bearing or safety review are **NO_VALIDATED_ROUTE** until benchmarked.
+Do not invent an escalation for those admissions. Each admitted v0 route is one
+validated rung: retry once in the same worker session, then stop with
+**NO_VALIDATED_ROUTE**. Never escalate Terra, Luna, or Sol to Sonnet or Opus.
+Pass the exact parenthesized CLI model ID to the helper's `--model` argument.

--- a/skills/orchestrate/scripts/codex-worker.py
+++ b/skills/orchestrate/scripts/codex-worker.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Start and resume isolated Codex CLI workers for /orchestrate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> int:
+    print(f"codex-worker: {message}", file=sys.stderr)
+    return 1
+
+
+def resolved_directory(value: str) -> Path:
+    path = Path(value).resolve(strict=True)
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError("must be an existing directory")
+    return path
+
+
+def is_within(path: Path, directory: Path) -> bool:
+    """Return whether a resolved path is the directory or one of its descendants."""
+    return path == directory or directory in path.parents
+
+
+def parse_jsonl(output: str) -> tuple[list[dict[str, Any]], str | None]:
+    items: list[dict[str, Any]] = []
+    for number, line in enumerate(output.splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            return [], f"invalid JSONL on line {number}"
+        if not isinstance(item, dict):
+            return [], f"JSONL item on line {number} is not an object"
+        items.append(item)
+    return items, None
+
+
+def captured_thread_id(items: list[dict[str, Any]]) -> tuple[str | None, str | None]:
+    if any(
+        item.get("type") == "item.completed"
+        and isinstance(item.get("item"), dict)
+        and item["item"].get("type") == "error"
+        for item in items
+    ):
+        return None, "Codex reported an error item"
+    ids = {
+        item["thread_id"]
+        for item in items
+        if item.get("type") == "thread.started"
+        and isinstance(item.get("thread_id"), str)
+        and item["thread_id"]
+    }
+    if len(ids) != 1:
+        return None, "missing or ambiguous thread ID in Codex JSONL"
+    return ids.pop(), None
+
+
+def final_agent_message(items: list[dict[str, Any]]) -> tuple[str | None, str | None]:
+    message = None
+    for entry in items:
+        item = entry.get("item")
+        if (
+            entry.get("type") == "item.completed"
+            and isinstance(item, dict)
+            and item.get("type") == "agent_message"
+            and isinstance(item.get("text"), str)
+        ):
+            message = item["text"]
+    if message is None:
+        return None, "missing completed agent message in Codex JSONL"
+    return message, None
+
+
+def latest_rate_limits(session_id: str) -> dict[str, Any] | None:
+    root = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "sessions"
+    matches: list[Path] = []
+    for rollout in root.rglob("*.jsonl") if root.exists() else ():
+        try:
+            entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if error is None and any(
+            entry.get("type") == "session_meta"
+            and isinstance(entry.get("payload"), dict)
+            and entry["payload"].get("session_id") == session_id
+            for entry in entries
+        ):
+            matches.append(rollout)
+    if not matches:
+        return None
+    rollout = max(matches, key=lambda path: path.stat().st_mtime_ns)
+    entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
+    if error:
+        return None
+    rate_limits = None
+    for entry in entries:
+        payload = entry.get("payload")
+        if (
+            entry.get("type") == "event_msg"
+            and isinstance(payload, dict)
+            and payload.get("type") == "token_count"
+        ):
+            candidate = payload.get("rate_limits")
+            rate_limits = candidate if isinstance(candidate, dict) else None
+    return rate_limits
+
+
+def headroom(rate_limits: dict[str, Any] | None) -> int | float | None:
+    if not rate_limits:
+        return None
+    primary = rate_limits.get("primary")
+    if not isinstance(primary, dict):
+        return None
+    used_percent = primary.get("used_percent")
+    if not isinstance(used_percent, (int, float)):
+        return None
+    return 100 - used_percent
+
+
+def write_state(
+    path: Path,
+    session_id: str,
+    model: str,
+    sandbox: str,
+    cwd: Path,
+    control_checkout: Path | None,
+) -> None:
+    state: dict[str, str] = {
+        "session_id": session_id,
+        "model": model,
+        "sandbox": sandbox,
+        "cwd": str(cwd),
+    }
+    if control_checkout is not None:
+        state["control_checkout"] = str(control_checkout)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_worker(
+    command: list[str],
+    cwd: Path,
+) -> tuple[subprocess.CompletedProcess[str], list[dict[str, Any]] | None, str | None]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode:
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        return result, None, None
+    items, error = parse_jsonl(result.stdout)
+    return result, items, error
+
+
+def emit(
+    session_id: str,
+    model: str,
+    sandbox: str,
+    cwd: Path,
+    final_message: str,
+) -> None:
+    limits = latest_rate_limits(session_id)
+    remaining = headroom(limits)
+    print(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "model": model,
+                "sandbox": sandbox,
+                "cwd": str(cwd),
+                "final_message": final_message,
+                "headroom": remaining,
+                "headroom_status": "known" if remaining is not None else "unknown",
+            }
+        )
+    )
+
+
+def start(args: argparse.Namespace) -> int:
+    cwd = args.cwd
+    if args.sandbox == "workspace-write":
+        if args.control_checkout is None:
+            return fail("workspace-write requires --control-checkout")
+        if is_within(cwd, args.control_checkout):
+            return fail("workspace-write refuses the control checkout")
+    command = [
+        args.codex,
+        "exec",
+        "-m",
+        args.model,
+        "-c",
+        "model_reasoning_effort=medium",
+        "--sandbox",
+        args.sandbox,
+        "--skip-git-repo-check",
+        "-C",
+        str(cwd),
+        "--json",
+        args.prompt,
+    ]
+    result, items, error = run_worker(command, cwd)
+    if result.returncode:
+        return result.returncode
+    if error:
+        return fail(error)
+    session_id, error = captured_thread_id(items or [])
+    if error:
+        return fail(error)
+    message, error = final_agent_message(items or [])
+    if error:
+        return fail(error)
+    write_state(
+        args.state,
+        session_id or "",
+        args.model,
+        args.sandbox,
+        cwd,
+        args.control_checkout,
+    )
+    emit(session_id or "", args.model, args.sandbox, cwd, message or "")
+    return 0
+
+
+def resume(args: argparse.Namespace) -> int:
+    try:
+        state = json.loads(args.state.read_text(encoding="utf-8"))
+        session_id, model, sandbox, cwd = (
+            state[key] for key in ("session_id", "model", "sandbox", "cwd")
+        )
+    except (OSError, json.JSONDecodeError, KeyError, ValueError):
+        return fail("state file is malformed or incomplete")
+    if not all(isinstance(value, str) and value for value in (session_id, model, sandbox, cwd)):
+        return fail("state file is malformed or incomplete")
+    if sandbox not in {"read-only", "workspace-write"}:
+        return fail("state file has an invalid sandbox")
+    try:
+        canonical_cwd = resolved_directory(cwd)
+    except (OSError, argparse.ArgumentTypeError):
+        return fail("state file has an invalid cwd")
+    control_checkout = None
+    if sandbox == "workspace-write":
+        control = state.get("control_checkout")
+        if not isinstance(control, str) or not control:
+            return fail("state file is missing the control checkout")
+        try:
+            control_checkout = resolved_directory(control)
+        except (OSError, argparse.ArgumentTypeError):
+            return fail("state file has an invalid control checkout")
+        if is_within(canonical_cwd, control_checkout):
+            return fail("workspace-write refuses the control checkout")
+    command = [
+        args.codex,
+        "exec",
+        "resume",
+        session_id,
+        "-m",
+        model,
+        "-c",
+        f'sandbox_mode="{sandbox}"',
+        "--json",
+        args.prompt,
+    ]
+    result, items, error = run_worker(command, canonical_cwd)
+    if result.returncode:
+        return result.returncode
+    if error:
+        return fail(error)
+    returned_id, error = captured_thread_id(items or [])
+    if error:
+        return fail(error)
+    if returned_id != session_id:
+        return fail("resume returned a different thread ID")
+    message, error = final_agent_message(items or [])
+    if error:
+        return fail(error)
+    write_state(
+        args.state,
+        session_id,
+        model,
+        sandbox,
+        canonical_cwd,
+        control_checkout,
+    )
+    emit(session_id, model, sandbox, canonical_cwd, message or "")
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    commands = result.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--codex", default="codex")
+    common.add_argument("--state", type=Path, required=True)
+    common.add_argument("prompt")
+    start_parser = commands.add_parser("start", parents=[common])
+    start_parser.add_argument("--model", required=True)
+    start_parser.add_argument(
+        "--sandbox", choices=("read-only", "workspace-write"), required=True
+    )
+    start_parser.add_argument("--cwd", type=resolved_directory, required=True)
+    start_parser.add_argument("--control-checkout", type=resolved_directory)
+    start_parser.set_defaults(handler=start)
+    resume_parser = commands.add_parser("resume", parents=[common])
+    resume_parser.set_defaults(handler=resume)
+    return result
+
+
+if __name__ == "__main__":
+    arguments = parser().parse_args()
+    raise SystemExit(arguments.handler(arguments))

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import tempfile
@@ -11,6 +12,7 @@ from typing import Optional
 ROOT = Path(__file__).resolve().parents[1]
 CBM_SCRIPT = ROOT / "skills" / "cbm-onboard" / "scripts" / "cbm-onboard.sh"
 SPIN_SCRIPT = ROOT / "skills" / "spin-worktree" / "scripts" / "spin-worktree.py"
+CODEX_WORKER = ROOT / "skills" / "orchestrate" / "scripts" / "codex-worker.py"
 BEGIN_IGNORE = "# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
 BEGIN_HOOK = "# >>> cbm-onboard managed reindex >>>"
 
@@ -205,6 +207,362 @@ class SpinWorktreeTests(unittest.TestCase):
         self.assertTrue(
             (self.scratch / "worktrees" / "repo" / "local-topic" / ".git").exists()
         )
+
+
+class CodexWorkerTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.scratch = Path(self.temporary.name)
+        self.control = self.scratch / "control"
+        self.worktree = self.scratch / "worktree"
+        self.control.mkdir()
+        self.worktree.mkdir()
+        self.state = self.scratch / "worker-state.json"
+        self.codex_home = self.scratch / "codex-home"
+        self.binary = self.scratch / "fake-codex"
+        self.arguments = self.scratch / "arguments.json"
+        self.child_cwd = self.scratch / "child-cwd"
+        self.binary.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, pathlib, sys\n"
+            "pathlib.Path(os.environ['FAKE_CODEX_ARGUMENTS']).write_text(json.dumps(sys.argv[1:]))\n"
+            "if os.environ.get('FAKE_CODEX_CWD'):\n"
+            "    pathlib.Path(os.environ['FAKE_CODEX_CWD']).write_text(os.getcwd())\n"
+            "sys.stdout.write(os.environ.get('FAKE_CODEX_OUTPUT', ''))\n"
+            "sys.exit(int(os.environ.get('FAKE_CODEX_EXIT', '0')))\n",
+            encoding="utf-8",
+        )
+        self.binary.chmod(0o755)
+        self.environment = os.environ.copy()
+        self.environment["CODEX_HOME"] = str(self.codex_home)
+        self.environment["FAKE_CODEX_ARGUMENTS"] = str(self.arguments)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def worker(self, *arguments: str):
+        return run(
+            ["python3", str(CODEX_WORKER), *arguments],
+            cwd=ROOT,
+            env=self.environment,
+        )
+
+    def start(
+        self,
+        output: str,
+        *,
+        sandbox: str = "read-only",
+        final_message: Optional[str] = "worker answer",
+    ):
+        if final_message is not None:
+            output += json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": final_message},
+                }
+            ) + "\n"
+        self.environment["FAKE_CODEX_OUTPUT"] = output
+        arguments = [
+            "start",
+            "--codex",
+            str(self.binary),
+            "--state",
+            str(self.state),
+            "--model",
+            "Terra",
+            "--sandbox",
+            sandbox,
+            "--cwd",
+            str(self.worktree),
+        ]
+        if sandbox == "workspace-write":
+            arguments.extend(["--control-checkout", str(self.control)])
+        return self.worker(*arguments, "do the work")
+
+    def rollout(self, name: str, session_id: str, *events: dict):
+        path = self.codex_home / "sessions" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        entries = [
+            {"type": "session_meta", "payload": {"session_id": session_id}},
+            *events,
+        ]
+        path.write_text(
+            "".join(json.dumps(entry) + "\n" for entry in entries), encoding="utf-8"
+        )
+
+    def test_start_persists_worker_state_and_uses_canonical_cwd(self):
+        result = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(self.state.read_text(encoding="utf-8")),
+            {
+                "session_id": "worker-1",
+                "model": "Terra",
+                "sandbox": "read-only",
+                "cwd": str(self.worktree.resolve()),
+            },
+        )
+        arguments = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertIn("--sandbox", arguments)
+        self.assertIn(str(self.worktree.resolve()), arguments)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["final_message"], "worker answer")
+        self.assertEqual(payload["headroom_status"], "unknown")
+
+    def test_resume_reapplies_persisted_model_and_sandbox(self):
+        started = self.start(
+            '{"type":"thread.started","thread_id":"worker-1"}\n',
+            sandbox="workspace-write",
+        )
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.environment["FAKE_CODEX_OUTPUT"] = (
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+            '{"type":"item.completed","item":{"type":"agent_message",'
+            '"text":"resume answer"}}\n'
+        )
+
+        result = self.worker(
+            "resume",
+            "--codex",
+            str(self.binary),
+            "--state",
+            str(self.state),
+            "continue with the failing test",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(self.arguments.read_text(encoding="utf-8")),
+            [
+                "exec",
+                "resume",
+                "worker-1",
+                "-m",
+                "Terra",
+                "-c",
+                'sandbox_mode="workspace-write"',
+                "--json",
+                "continue with the failing test",
+            ],
+        )
+        self.assertEqual(json.loads(result.stdout)["final_message"], "resume answer")
+
+    def test_resume_runs_the_codex_process_in_the_persisted_worktree(self):
+        started = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.environment["FAKE_CODEX_CWD"] = str(self.child_cwd)
+        self.environment["FAKE_CODEX_OUTPUT"] = (
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+            '{"type":"item.completed","item":{"type":"agent_message",'
+            '"text":"resume answer"}}\n'
+        )
+
+        result = self.worker(
+            "resume",
+            "--codex",
+            str(self.binary),
+            "--state",
+            str(self.state),
+            "continue with the failing test",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self.child_cwd.read_text(encoding="utf-8"), str(self.worktree.resolve())
+        )
+
+    def test_error_item_fails_even_when_codex_exits_zero(self):
+        result = self.start(
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+            '{"type":"item.completed","item":{"type":"error"}}\n'
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("reported an error item", result.stderr)
+        self.assertFalse(self.state.exists())
+
+    def test_start_fails_without_a_completed_agent_message(self):
+        result = self.start(
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+            '{"type":"item.completed","item":{"type":"reasoning"}}\n',
+            final_message=None,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing completed agent message", result.stderr)
+        self.assertFalse(self.state.exists())
+
+    def test_preserves_a_nonzero_codex_exit_status(self):
+        self.environment["FAKE_CODEX_EXIT"] = "7"
+
+        result = self.start("worker failed\n", final_message=None)
+
+        self.assertEqual(result.returncode, 7)
+        self.assertEqual(result.stdout, "worker failed\n")
+        self.assertFalse(self.state.exists())
+
+    def test_headroom_uses_the_matching_session_rollout(self):
+        token_count = {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "rate_limits": {"primary": {"used_percent": 40}},
+            },
+        }
+        self.rollout("matching.jsonl", "worker-1", token_count)
+        self.rollout(
+            "unrelated.jsonl",
+            "other-worker",
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "rate_limits": {"primary": {"used_percent": 99}},
+                },
+            },
+        )
+
+        result = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["headroom"], 60)
+        self.assertEqual(payload["headroom_status"], "known")
+
+    def test_missing_rate_limits_reports_unknown(self):
+        self.rollout(
+            "matching.jsonl",
+            "worker-1",
+            {"type": "event_msg", "payload": {"type": "token_count"}},
+        )
+
+        result = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertIsNone(payload["headroom"])
+        self.assertEqual(payload["headroom_status"], "unknown")
+
+    def test_malformed_missing_and_ambiguous_thread_ids_fail_closed(self):
+        cases = {
+            "malformed": "not json\n",
+            "missing": '{"type":"item.completed","item":{"type":"agent_message"}}\n',
+            "ambiguous": (
+                '{"type":"thread.started","thread_id":"one"}\n'
+                '{"type":"thread.started","thread_id":"two"}\n'
+            ),
+        }
+        for name, output in cases.items():
+            with self.subTest(name=name):
+                if self.state.exists():
+                    self.state.unlink()
+                result = self.start(output)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(self.state.exists())
+
+    def test_workspace_write_rejects_the_control_checkout(self):
+        self.environment["FAKE_CODEX_OUTPUT"] = (
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+        )
+        result = self.worker(
+            "start",
+            "--codex",
+            str(self.binary),
+            "--state",
+            str(self.state),
+            "--model",
+            "Terra",
+            "--sandbox",
+            "workspace-write",
+            "--cwd",
+            str(self.control),
+            "--control-checkout",
+            str(self.control),
+            "do the work",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refuses the control checkout", result.stderr)
+        self.assertFalse(self.arguments.exists())
+
+    def test_workspace_write_rejects_a_path_inside_the_control_checkout(self):
+        nested = self.control / "nested"
+        nested.mkdir()
+        self.environment["FAKE_CODEX_OUTPUT"] = (
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+        )
+
+        result = self.worker(
+            "start",
+            "--codex",
+            str(self.binary),
+            "--state",
+            str(self.state),
+            "--model",
+            "Terra",
+            "--sandbox",
+            "workspace-write",
+            "--cwd",
+            str(nested),
+            "--control-checkout",
+            str(self.control),
+            "do the work",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refuses the control checkout", result.stderr)
+        self.assertFalse(self.arguments.exists())
+
+    def test_resume_rejects_a_persisted_path_inside_the_control_checkout(self):
+        nested = self.control / "nested"
+        nested.mkdir()
+        self.state.write_text(
+            json.dumps(
+                {
+                    "session_id": "worker-1",
+                    "model": "Terra",
+                    "sandbox": "workspace-write",
+                    "cwd": str(nested),
+                    "control_checkout": str(self.control),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.worker(
+            "resume",
+            "--codex",
+            str(self.binary),
+            "--state",
+            str(self.state),
+            "continue with the failing test",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refuses the control checkout", result.stderr)
+        self.assertFalse(self.arguments.exists())
+
+
+class OrchestrateCodexPolicyTests(unittest.TestCase):
+    def test_codex_headroom_and_single_rung_policy_are_explicit(self):
+        skill = (ROOT / "skills" / "orchestrate" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        dispatch = (
+            ROOT / "skills" / "orchestrate" / "references" / "dispatch-codex.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("If headroom is ≤ 5%, **unknown**", skill)
+        self.assertIn("Codex UI parent:** it has a Codex-only constraint", skill)
+        self.assertIn("Do not switch to Claude workers.", skill)
+        self.assertIn("stop with **NO_VALIDATED_ROUTE**", skill)
+        self.assertIn("Never escalate Terra, Luna, or Sol to Sonnet or Opus.", skill)
+        for model in ("gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"):
+            self.assertIn(model, dispatch)
+        self.assertIn("cannot switch to Claude workers", dispatch)
+        self.assertIn("headroom at or below 5%", dispatch)
+        self.assertIn("Each admitted v0 route is one", dispatch)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #24
Closes #27

## What changed

`$orchestrate` can now remain interactive in the Codex UI while routed work runs through isolated Codex CLI workers. Worker identity, model, sandbox, worktree, final answer, and headroom survive follow-ups.

Codex-only routes fail closed when no benchmarked route exists and never switch into Claude.

The handoff validator baseline is repaired so this branch can pass the public skill checks.

## Why

The previous skill stopped when invoked from Codex. Direct native sub-agents also do not expose the isolation controls used by the existing benchmarked workflow.

## What to check

- Invoke `$orchestrate` from Codex and start a read-only Luna worker.
- Resume that worker and confirm the model, sandbox, and worktree stay unchanged.
- Confirm an unavailable or exhausted Codex route reports `NO_VALIDATED_ROUTE`.
- Confirm the validation and behavior suites pass.

## Validation

- `python3 scripts/validate.py`
- `python3 -m unittest tests.test_behavior`
- Two independent Luna review passes; no blocking findings.

Follow-ups: #25, #26