### PR TITLE
Stop the handoff from being delivered twice

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -33,6 +33,7 @@ EXPECTED = {
     "orchestrate",
     "writing-for-agents",
     "handoff",
+    "preflight",
 }
 FORBIDDEN = (
     re.compile("/" + "Users/"),

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -68,6 +68,18 @@ Use this shape; omit empty sections rather than adding filler.
 - <relevant hazards, claims, dirty-worktree or authority limits>
 ```
 
+## Delivering it
+
+**The handoff is the artifact. Write it to a file and hand over the path — nothing else.**
+
+A handoff is written for the agent taking over, not for the person who asked for it. Asking to hand the work off means they are done reading. Summarizing the handoff back to them defeats the point: they read the same content twice, in the worse of the two formats, at the moment they were trying to stop.
+
+The delivering response is one line — the path, plus the single fact only they can act on if one exists (an unmerged PR, a pending authorization). No section recap, no highlights, no "the parts you'd want to know", no bulleted extract of the file. If something genuinely cannot wait for the next agent, it belongs *in* the first-action section, not in a parallel chat summary.
+
+This holds when the handoff is long and the urge to orient them is strongest. Length in the file is fine — it is written for a cold reader. Length in the response is not.
+
 ## Quality gate
 
 Before delivering, verify that the handoff names the first action, distinguishes fact from proposal, links every material artifact, records volatile state as checked, and tells the recipient what not to repeat. Remove chronological narration, speculative detail, and generic next steps.
+
+Then check the response itself: if it restates anything the file already says, cut it back to the path.

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -66,6 +66,17 @@ definitions below are the fallback.
    references — rather than reviewing the prose version. One measured review
    spent its first round correcting pinned literals and its second correcting
    the corrections, so the cost lands whether or not the demand is made early.
+
+   The same rule extends past executable literals to **facts**. A hand-typed
+   count, path, param name, version, or enumeration is an automatic first
+   objection: demand the generated-facts appendix — `command → output` pairs the
+   prose cites, which the `preflight` skill produces — rather than reviewing the
+   prose figures, because verifying a number by hand costs a round and re-costs
+   it every time the plan is edited. In one measured review of a load-bearing
+   process document, roughly half of sixty-two objections across ten rounds were
+   figures written from memory and wrong. A load-bearing plan that arrives with
+   no preflight at all is sent through it before the cold pass, not reviewed as
+   drafted.
 1. **Cold read + grounding pass.** Read the plan, then the code it touches.
    Verify claims before forming opinions. A literal in the plan — a regex, a
    shell fragment, a workflow expression, a query — is verified by executing

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: preflight
+description: Use when a plan, spec, work order, or process doc is drafted and about to enter review or execution — grounds its facts, spikes its first hour, and single-sources its rules so review rounds start deep instead of shallow.
+---
+
+# Preflight
+
+Run this on a draft **before** `plan-review`, not instead of it. Preflight edits
+the plan; review only objects to it.
+
+The premise is measured. One load-bearing process document took ten cold
+adversarial rounds and roughly sixty-two objections to reach a clean pass, and a
+post-mortem of those objections found four preventable classes:
+
+- **About half were hand-typed facts** — counts, paths, URL params, state
+  enumerations — written from memory and wrong.
+- **Fix rounds minted new contradictions**, because the same rule was restated in
+  several sections and a patch desynced them.
+- **Serial generalist panels each found one stratum**; the single parallel
+  specialized round found the most.
+- **The deepest bugs were only findable by executing the plan's first steps** — a
+  URL param the page silently ignored, a comparison instrument that could only
+  render one state, a fixture whose absence degraded quietly instead of failing.
+
+Three of the four are cheaper to prevent than to review. That's preflight: three
+moves, in order.
+
+## 1. Generated-facts appendix
+
+**Every count, path, URL param, enumeration, version, or config value the plan
+states must be produced by a command.** The appendix records `command → output`
+pairs; the plan's prose cites the appendix entry rather than repeating the
+figure from memory. A hand-typed fact is a defect, not a rounding error — the
+reviewer's job then becomes checking the command, which is cheap, instead of
+re-deriving the number, which is a round.
+
+- An enumeration needs the command that enumerates it — `grep -c` per event
+  type, an `ls` of the fixture directory, a `--help` dump, a schema query. "The
+  six states" is a claim; the command that prints six is the fact.
+- Re-run the appendix after any edit that touches a cited figure. A stale
+  appendix is worse than none, because it reads as grounded.
+- **A fact about *behavior* — what a param does, whether an endpoint honors a
+  flag — is not a grep.** It belongs to move 2. Do not let a grep that finds the
+  param's name stand in for evidence that anything reads it.
+
+## 2. First-hour spike
+
+Before any reviewer sees the draft, **execute the plan's opening steps against
+the real artifacts for thirty to sixty minutes.** Open the page and pass the
+param. List the network fetches. Run the instrument once, in each state it
+claims to compare. Delete the fixture and watch what the fallback actually does.
+
+The rule that catches the expensive class: **every claim of the form "X is
+addressable / served / discovered / honored by Y" gets one live probe.** Those
+claims are the ones that read as obviously true and are silently false, and no
+amount of reading finds them.
+
+Findings amend the plan before review starts. The scratch work is throwaway — a
+worktree, a scratchpad script, a curl log — and is never committed; the plan
+cites what the spike established, not the scratch.
+
+## 3. Single-source rules
+
+**Each rule or constraint is stated normatively in exactly one place.** Every
+other mention points at that place instead of restating it. This is what stops a
+fix round from minting a contradiction: a patch can only desync a rule that
+exists in two voices.
+
+Before the doc leaves preflight — **and again after every later fix round** —
+grep each rule that appears in two or more places and reconcile it down to one
+normative statement plus references. Late rounds are when this decays fastest,
+because that's when patches are landing under time pressure.
+
+## Hand-back
+
+Preflight ends by handing the grounded plan to `plan-review`, with the
+generated-facts appendix and the spike's findings attached.
+
+Recommend that review's **first** round be three to five **parallel specialized
+lenses** rather than one generalist pass — machinery-interaction, cold-executor
+simulation, inventory verification, and domain judgment. Serial generalist
+rounds each surface one stratum and then repeat each other; parallel lenses
+surface the strata at once, which is what a preflighted plan needs, since the
+shallow findings are already gone.

--- a/skills/preflight/agents/openai.yaml
+++ b/skills/preflight/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Preflight"
+  short_description: "Ground a draft's facts and rules before it enters review."
+  default_prompt: "Use $preflight to ground this draft's facts, spike its first hour, and single-source its rules before review."

--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -63,6 +63,7 @@ acting — it defines the flow.
 | Mode | Job | Reference |
 | --- | --- | --- |
 | `lock [surface]` | Explore grounded variants, converge, lock spec + manifest | [reference/lock.md](reference/lock.md) |
+| `behavior-sweep [surface]` | Sweep a locked mock's interactive behavior into a frozen behavior ledger + replay script (after `lock`, before `build`) | [reference/behavior-sweep.md](reference/behavior-sweep.md) |
 | `build [surface]` | Implement a locked spec; ship the fidelity ledger | [reference/build.md](reference/build.md) |
 | `critique [target]` | Heuristic scoring, slop verdict, persona walkthroughs | [reference/critique.md](reference/critique.md) |
 | `audit [target]` | Technical checks (a11y, contrast, responsive, detector) + lock-fidelity audit when a manifest exists | [reference/audit.md](reference/audit.md) |
@@ -72,8 +73,15 @@ acting — it defines the flow.
 | `init` / `document` | Project context setup / generate DESIGN.md | [reference/init.md](reference/init.md), [reference/document.md](reference/document.md) |
 
 No argument: recommend the 1–3 most useful modes from context (unlocked
-mockups → `lock`; open manifest without a ledger → `build`; never critiqued →
-`critique`), then list the table. Never auto-run a mode.
+mockups → `lock`; frozen manifest for a surface with interactive behavior and no
+behavior ledger → `behavior-sweep` **before** `build`; open manifest without a
+fidelity ledger → `build`; never critiqued → `critique`), then list the table.
+Never auto-run a mode.
+
+Three artifacts carry the word *ledger*; always qualify it. The **fidelity
+ledger** is one row per manifest term (`build`). The **behavior ledger** is
+`mockups/<surface>.behavior.md`, one entry per story (`behavior-sweep`). The
+**surface ledger** is `mockups/INDEX.md`, one row per surface.
 
 General design invocations with no mode match (e.g. "make this less bland",
 "fix the spacing") run under `critique`-then-fix using
@@ -100,12 +108,30 @@ equivalents, and follow the repo's sweep protocol when one exists. The
 `consensus` mode requires these repo personas and refuses to run on generic
 archetypes.
 
+**"The repo's sweep protocol" is not `behavior-sweep`.** That phrase means the
+repo's persona-driven QA pass — exploratory, judgment-led, run against a live
+app to find bugs. `behavior-sweep` is a mode of this skill: mechanical, run
+against a **locked mock** before any build, and its output is a contract. Neither
+substitutes for the other.
+
 ## Grounding rules (inherited from ui-mockups, apply everywhere)
 
 - Ground every artifact in the app's real tokens, shipping UI/chart library
   at its shipping version, and real data shape from a **safe, manufactured
   fixture** — never production, personal, health, credential, or customer
-  data.
+  data. **This is the shared default and it does not bend on convenience.**
+- **Real-data inversion — repo-scoped, opt-in.** Some repos invert the rule:
+  their build contracts must be grounded in the owner's *own real* data, because
+  a fixture cannot reveal what the surface does at real scale. That inversion
+  applies **only** where the repo's own `CLAUDE.md`/`AGENTS.md` declares an
+  operator-sanctioned real-data protocol (e.g. a read-only snapshot flow), and
+  only within that protocol's bounds. Absent that declaration, the manufactured
+  default above governs — no exceptions inferred from context or precedent.
+  Where the inversion does apply: renders of real personal/health data **never
+  commit and never attach to a PR** (a PR is a publish) without the operator's
+  exact authorizing sentence quoted in the record; committed and PR-attached
+  evidence uses labeled synthetic fixtures, and real-data renders stay local,
+  handed to the verifier with the pinned data.
 - Vary the concept, not the decoration; three variants that differ only in
   color are one design.
 - Inspect rendered output — source review alone never validates a visual

--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -1,0 +1,184 @@
+# Mode: behavior-sweep
+
+Sweep a locked surface's **interactive behavior** into a contract before anyone
+builds it. Runs after `lock`, before `build`, for any surface that has
+behavior — handlers, gestures, hover states, keyboard paths, resize response.
+
+The lock manifest describes what the surface *looks like*. It reliably fails to
+describe what the surface *does*: a drag that only works from an edge, a
+readout that latches on chart hover, an inspector that re-scopes with selection.
+Those behaviors are in the mock's code and nowhere in the manifest, so a build
+invents them. The behavior ledger closes that gap; the replay script keeps it
+closed.
+
+Root failure this mode exists to make impossible:
+
+> Something approximated the locked artifact instead of using it, and a checker
+> accepted the approximation.
+
+Input: the ★ LOCKED mockup(s), `mockups/<surface>.lock.md`, and every module the
+mock imports. `<surface>` is always the **basename of the lock manifest** —
+every artifact below inherits that one name. No agent picks a nickname.
+
+**Proportionality.** Sweep depth scales with the handler inventory: a surface
+whose inventory fits on one screen may fold the three passes below into a single
+sitting. The **ledger**, the **completeness check**, and the **QUESTION round**
+are never waived, at any size.
+
+## 1. Inventory (static — this is not evidence)
+
+Enumerate every behavior the mock registers:
+
+- `addEventListener` calls (click, mousedown/move/up, keydown, resize, …);
+- chart/graphics-library instance handlers (e.g. an ECharts `on()` /
+  `updateAxisPointer` / `globalout` set, zr events);
+- `ResizeObserver` / `IntersectionObserver` / `MutationObserver` registrations;
+- inline `on*=` attributes;
+- CSS that *encodes behavior* — `:hover`, `:focus`, `:active`, transitions.
+
+**Including handlers registered inside imported modules**, which the host HTML
+never shows. A chart module that installs four instance handlers when given an
+`onHover` callback is four inventory rows; missing them is how a latched readout
+gets reinvented.
+
+**Excluded by name:** mock-harness chrome — the theme toggle, the mock bar, the
+variant switcher — is not the surface's behavior and never enters the inventory
+or the contract. Name the excluded file(s) explicitly in the ledger header.
+Excluded from the inventory is **not** excluded from the page: the harness and
+every imported module are still **served**, because an unserved import throws
+before any listener registers.
+
+Static reading produces the inventory. It never produces a story.
+
+## 2. Exercise (live — this is the evidence)
+
+Drive the mock in a **real browser engine at the lock's viewport** — viewport set
+explicitly, never a driver default. Perform each behavior for real: hover every
+hoverable, drag from inside an element *and* from its edges, click every control,
+run every keyboard path (Esc, arrows, Tab), resize. Verify in a second engine
+when the behavior is rendering-sensitive.
+
+Two further passes, folded in or run separately per proportionality:
+
+- **Data pass.** Load the mock on *each* authorized fixture, including the
+  largest realistic shape the surface will actually see. Record what every
+  data-dependent visual *encodes* — clustering, scoping on selection, level
+  content, count shapes. A visual whose meaning disappears at real scale
+  (uniform glyphs, empty scoping) is a QUESTION, not a build call: a design rule
+  is missing and that is a lock conversation.
+- **Content pass.** For every information surface (detail panels, headers, meta
+  rows, tags) capture the mock's **actual rendered markup and text structure**.
+  The story links to markup, never to the lock term's prose — this is what makes
+  "built from the description" detectable at review time.
+
+**Completeness check (mechanical, not judgment):** every inventoried handler maps
+to ≥1 story, and every story was observed live. A handler found in code but not
+reproducible in-browser becomes a QUESTION entry — never a silent skip.
+
+## 3. The replay script (committed)
+
+Alongside the ledger, commit a replay script — `frontend/<surface>-behavior.replay.mjs`
+or the repo's equivalent path — that re-runs the sweep mechanically. Hand-driving
+is fine for discovery; a story enters the ledger only once its replay function
+passes against the mock.
+
+Spec:
+
+- **One exported async function per story**, `export const S12 = async (page) => { … }`.
+- Each function carries a `// LOCK:<surface>:<n>` tag for every lock term it
+  exercises, so manifest coverage stays greppable.
+- **Two openers, both in the script**: a *mock opener* (serves the mock root, its
+  theme CSS, vendored libraries, and a fixture stub) and an *app opener* (route
+  stubs, auth, navigation). Runnable against mock and app alike is the whole
+  point — the same function is what makes it evidence on both sides.
+- Both openers are **loud on unstubbed or missing requests**. A catch-all
+  `200 {}` renders a build that is missing an asset and still passes.
+- Both openers **assert the rendered state equals the requested one**, so state
+  addressability drift (a `?state=` param the mock silently ignores) is loud
+  rather than a quietly identical render.
+- **Selector parity is a port obligation, not a script concern.** Replay-against-both
+  only holds if the ported markup keeps the mock's selectors; a rename that
+  breaks a replay selector is a **port defect**.
+- Replay functions inherit `build.md`'s prove-red-once rule — proven against the
+  **built app** (knock the feature out) or a **scratch copy** of the mock, never
+  the ★ LOCKED mock in place. A transient edit to the contract artifact risks an
+  unrestored diff, which is the quiet deviation `resettle` exists to forbid.
+- **The script fails closed.** Missing browser dependencies (driver module,
+  vendored assets, executable) exit nonzero — never `skip`. A skipped run exits 0,
+  and a green step that executed zero stories is precisely the silent skip this
+  mode exists to prevent.
+- Wire the script into CI **explicitly**. Test globs discover `*.test.js`, not a
+  `.replay.mjs`; a browser job that hand-lists its files gets a hand-added step in
+  the same change.
+
+## 4. The behavior ledger
+
+One entry per story, in `mockups/<surface>.behavior.md`:
+
+```
+S12 · Dragging a window's edge resizes it; edges are full-height ±5px grab
+      zones; Esc clears the window.
+  element:  .brace .edge / #grip-a / #grip-b
+  source:   <mock file>:2446-2600 (installDrag)
+  lock:     terms 6, 7, 21
+  data:     any
+  evidence: replay fn S12 + screenshot ref
+  status:   (build phase fills: ported | replayed-pass | replayed-fail |
+             re-settle requested)
+```
+
+Sweep screenshots and clips live in `mockups/sweep/<surface>/`. Register both the
+ledger and that directory in `mockups/INDEX.md`, per resettle's
+INDEX-moves-with-the-lock rule.
+
+Entry types are exactly two: **STORY** (observed behavior) and **QUESTION** (a
+behavior or meaning gap the operator must rule on).
+
+**There is no waiver entry type.** A drop is always a dated, operator-sanctioned
+record, by one of exactly two paths:
+
+- a story that **cites a lock term** → `resettle`; the manifest row is the record
+  and the operator's exact authorizing sentence is that resettle's evidence;
+- a story with **no lock term** (the ledger's whole reason to exist — resettle
+  cannot run where there is no manifest row) → dropped only by an operator ruling
+  recorded **inline in the ledger** under a QUESTION entry, his exact sentence
+  quoted.
+
+Both paths carry the date and the sanction. A drop path that skips the record is
+exactly how a dropped term recurs.
+
+## 5. QUESTION round (one numbered round)
+
+Batch every QUESTION to the operator in **one numbered round** at the end of the
+sweep — behavior gaps, meaning-lost-at-scale findings, irreproducible handlers,
+and any fixture-set authorization the gate will need (shapes and in-band labeling
+authorized together; see the data defaults in SKILL.md's grounding rules).
+Answers are recorded inline under their QUESTION entries.
+
+## 6. Freeze
+
+Operator approval stamps a header line on the ledger:
+
+```
+★ FROZEN <date> · base <sha> · generator <sha> · window <start>..<end>
+  · fixtures <name: sha256-prefix, …>   (tripwire, not contract)
+```
+
+- The pinned **inputs** (generator commit, data window) are a **provenance
+  record** — where the bytes came from. In a live-data repo they are not
+  themselves reproducible.
+- The **transported bytes are the contract**: the builder hands the verifier the
+  exact fixture files by a retained path recorded in the ledger header. "Same
+  data" means the same bytes, not a re-run of the generator.
+- Fixture **hashes are a tripwire**, never the contract — they detect unintended
+  regeneration. A hash over data that grows daily is unreproducible tomorrow by
+  construction.
+
+A `behavior.md` without the `★ FROZEN` header is a sweep in progress, not a
+contract; building against it is a blocking finding. Regenerating any pinned
+fixture after freeze requires a recorded reason under the header.
+
+**Ledger + lock manifest together are the build contract.** The manifest alone is
+insufficient: behaviors and meanings its terms never encoded, plus terms no
+assertion ever exercised, are the two gaps. The ledger closes the first; behavior
+replay in `build` closes the second.

--- a/skills/ui-craft/reference/build.md
+++ b/skills/ui-craft/reference/build.md
@@ -54,6 +54,16 @@ the result looks: the description was never the artifact.
   route **in the same commit**, and at least one verification pass runs against
   the real app server rather than a disk-serving harness, which is structurally
   blind to a missing route.
+- **The port needs guards the mock never needed.** A mock is fed static, always
+  well-formed fixtures; the build is fed a response across a process boundary.
+  Wherever the ported code indexes or dereferences the payload unconditionally,
+  that is a trust boundary in the app and not in the mock — guard it, route the
+  failure into the surface's own error path, and mark it as a deviation. Do not
+  invent empty-state UI the manifest does not describe; the plain failure message
+  is the whole fix. **Judge reachability from the caller's failure path, not its
+  success path**: "the endpoint never returns that shape" is not the same claim as
+  "no caller can produce it", and an error handler that mounts the surface before
+  reporting the error produces it every time.
 
 ## While building
 
@@ -72,6 +82,13 @@ the result looks: the description was never the artifact.
   rendered gate, list the assertions the old file made; every one either
   reappears in the new file or is named as dropped (with why) in the PR.
   Silently dropped assertions are how locked terms become untested.
+- **"Its selectors are dead" is not "its coverage is duplicated."** A gate whose
+  selectors no longer match the surface is asserting nothing and looks safe to
+  delete — but that says only that the coverage is *already* gone, not that it
+  lives somewhere else. Before dropping it, take the **union of lock-term tags**
+  the other suite actually carries and diff it against the tags the deleted file
+  claimed. Terms in the difference are asserted by nothing, and the PR says so by
+  number. "Nearly every term" is how six of them go missing.
 
 ## The fidelity ledger
 
@@ -111,6 +128,13 @@ mock opener exercises the mock and proves nothing about the port.
   committed labeled-synthetic fixture set and the real-data run stays local; the
   two subsets must **union to the full ledger**, and the ledger records which run
   covers each story.
+- **A build that adds a data feed must teach the real-data generator about it.**
+  The committed script that rebuilds the local real-data payload is part of the
+  contract, not a convenience: when the port introduces an endpoint, that script
+  calls it **exactly as the app's own route calls it**, same arguments and all.
+  Otherwise every real-data artifact — the local replay, the real-data pairs, the
+  bytes handed to the verifier — is generated against a payload the app would
+  never serve, and passes while proving nothing about the feed.
 
 ## Paired renders
 
@@ -118,6 +142,19 @@ For every `eye` term and every state the manifest names: render the **locked
 mock** and the **built surface** side by side and attach the pairs to the PR as
 the charter's proof-of-match.
 
+- **Render the matrix early, not as the last step before the PR.** The pairs are
+  the only check that sees what the surface actually *looks* like; a behavior gate
+  can pass every story while the build draws in the wrong ink, because assertions
+  read structure and text, not colour and geometry. A token that resolves to the
+  empty string, a fallback palette, a rule scoped to a subtree the code reads from
+  the document root — all of these are invisible to a green replay and obvious in
+  the first pair. Render one pair as soon as the surface boots.
+- **A PR is a publish: real-data pairs never attach to one.** Where the data is
+  sensitive, PR-attached pairs render the labeled synthetic set only. Real-data
+  pairs are still made — they are the fidelity check that matters — but they stay
+  on the machine that made them and reach the verifier out of band with the pinned
+  payload. The commit rule alone does not cover this: an attachment is published
+  without ever being committed.
 - **Same data, not merely the same kind of data.** Both sides render identical
   bytes. Comparing a synthetic build render against a real-capture mock render is
   not a pair; it is two pictures.

--- a/skills/ui-craft/reference/build.md
+++ b/skills/ui-craft/reference/build.md
@@ -8,6 +8,11 @@ Input: the ★ LOCKED mockup(s) and `mockups/<surface>.lock.md`. If the
 manifest is missing, stop and create it first (run the manifest-extraction
 part of `lock` mode against the existing header — do not build from prose).
 
+Where the surface has interactive behavior, the input is **two** contracts: the
+manifest and the `★ FROZEN` behavior ledger from `behavior-sweep`. Building
+against an unfrozen (or absent) ledger is a blocking finding — check the header
+first. The manifest alone never encodes what the surface *does*.
+
 ## Before writing code
 
 1. Read the manifest, the mock headers, and the mock's **component CSS** —
@@ -20,6 +25,35 @@ part of `lock` mode against the existing header — do not build from prose).
 3. Read the fixture obligations. Build or extend fixtures until every locked
    visual feature actually renders under them. A tame fixture that leaves a
    ribbon invisible or a threshold untriggered cannot prove anything.
+4. **Pin the provenance.** Branch off a **freshly fetched** default branch and
+   record the base SHA in the ledger header, along with the paths + SHAs of
+   every source artifact (mock HTML, its module files, manifest, behavior
+   ledger, fixtures, comparator). A branch cut from a pre-squash tip produces a
+   conflicting PR that silently attaches no CI.
+
+## Port, don't reimplement
+
+The mock is code, not a picture. **Its own JS and CSS are ported** — imported
+outright, or adapted line-by-line with a **diff-to-mock** attached. Reimplementing
+a feature from a lock term's *description* is a blocking finding, however faithful
+the result looks: the description was never the artifact.
+
+- **The diff unit is `mock line-range → app file`, verbatim-first.** "Per ported
+  file" is undefined when the mock is a thousand inline lines plus a sibling
+  module. Every non-verbatim line is listed with why it changed.
+- **New code is limited to adapters**: real data → the shape the mock's module
+  already consumes, plus mounting and wiring into the app shell. If the mock's
+  code cannot run against real app data without redesign, that is a QUESTION back
+  to the operator — never a license to reimplement.
+- **Keep the mock's selectors.** The behavior replay script runs against mock and
+  app alike; a rename that breaks a replay selector is a port defect, not a script
+  defect.
+- Suspected data bugs surfaced by the sweep are verified against the real payload
+  and fixed in the adapter or backend — never papered over in the port.
+- If the app has no static asset mount, every new frontend file gets its serving
+  route **in the same commit**, and at least one verification pass runs against
+  the real app server rather than a disk-serving harness, which is structurally
+  blind to a missing route.
 
 ## While building
 
@@ -56,17 +90,71 @@ Statuses: `met`, `re-settle requested` (with the resettle recorded), or
 `blocked` (with why). There is no "partially" and no silent omission — a term
 absent from the ledger is a blocking gap.
 
+**There is no waiver.** A term that will not be built is dropped by one of the
+two dated paths in `behavior-sweep.md`: cites a lock term → `resettle` (the
+manifest row is the record); no lock term → an operator ruling recorded inline
+under a QUESTION entry, his exact sentence quoted. An unverified waiver in a PR
+body is how a dropped term recurs.
+
+## Behavior replay
+
+Where a behavior ledger exists, its committed replay script re-exercises **every
+STORY against the built app** — not against the mock; a run wired through the
+mock opener exercises the mock and proves nothing about the port.
+
+- Each story's ledger `status` moves to `ported` → `replayed-pass` /
+  `replayed-fail` / `re-settle requested`. **`replayed-fail` blocks.**
+- The script's fail-closed rule holds here: a green step that executed zero
+  stories is a failure, so confirm the run **reported its applicable story
+  count**, not merely that the step ran.
+- Where PHI or other sensitive data splits the runs, the CI gate replays a
+  committed labeled-synthetic fixture set and the real-data run stays local; the
+  two subsets must **union to the full ledger**, and the ledger records which run
+  covers each story.
+
 ## Paired renders
 
 For every `eye` term and every state the manifest names: render the **locked
-mock** and the **built surface** side by side, same fixture, same viewports,
-and attach the pairs to the PR as the charter's proof-of-match. A screenshot
-of the build alone proves nothing; the pair is what makes drift visible to a
-reviewer who can't execute the spec. Verify each pair actually exercises its
-term before attaching (fixture obligations again).
+mock** and the **built surface** side by side and attach the pairs to the PR as
+the charter's proof-of-match.
+
+- **Same data, not merely the same kind of data.** Both sides render identical
+  bytes. Comparing a synthetic build render against a real-capture mock render is
+  not a pair; it is two pictures.
+- **The pairs cover every state and viewport the lock's own terms enumerate** —
+  all of them, in both themes — not one convenient state. This is the only
+  accepted fidelity evidence.
+- **Any harness, comparator, or screenshot rig loads the app's real CSS.**
+  Re-declaring theme tokens from memory is a blocking finding: it puts wrong
+  colors into the "proof" and can mask a real token bug in the shipped build.
+- Verify each pair actually exercises its term before attaching (fixture
+  obligations again).
+- Drive the build into each enumerated state deliberately. If the mock is
+  state-addressable by URL and the app is not, the port carries an equivalent
+  hook (or a `goto<State>(page)` export per state in the replay script) — without
+  it the comparator renders two of the matrix's pairs and reports a full sweep.
 
 ## Review handoff
 
-Give the cross-reviewer the manifest, the ledger, and the paired renders —
-their checklist is the manifest, not the diff. "Does render N match mock N on
-terms X, Y, Z" is an answerable question; "read this HTML comment" was not.
+- **The verifier is a freshly spawned session** that did not author the port and
+  has **no access to the builder's transcript or working notes**. Hand it only
+  the contract artifacts — manifest, frozen behavior ledger, replay script, the
+  pinned data files, the renders, the diff-to-mock set — and instruct it to
+  distrust the port. A verifier sharing the builder's context is a self-graded
+  table with extra steps, whatever its model tier.
+- **The builder's session may not mark any status beyond `ported`.** Statuses are
+  recorded by the verifier from raw script output. A self-graded fidelity table
+  is an index into evidence, never evidence.
+- **Craft and eye judgment route to the top model tier**, or the coordinator's own
+  eyes **when the coordinator did not drive the port** (otherwise the verifier's
+  or the operator's). Mid-tier polish grades are not accepted for craft.
+- **Every `eye` term gets its own named judgment entry** in the PR evidence,
+  written by the eye reviewer. An eye term is *never* satisfied by gate
+  assertions passing.
+- An eye term defined over a **gesture in progress** is viewed **live in-browser**;
+  static pairs cannot evidence it.
+- Their checklist is the manifest and the ledger, not the diff. "Does render N
+  match mock N on terms X, Y, Z" is an answerable question.
+- **Surface the evidence unprompted** — pairs, replay output, judgment entries,
+  diffs-to-mock go in the PR. Evidence withheld until demanded is a process
+  violation.

--- a/skills/ui-craft/reference/resettle.md
+++ b/skills/ui-craft/reference/resettle.md
@@ -18,8 +18,14 @@ time; it may never *apply* one on its own judgment.
      verbatim strings if they moved;
    - sibling locked artifacts the term appears in (the other form factor's
      mock, a copy spec) so the locked set stays self-consistent;
+   - the surface's **behavior ledger** (`mockups/<surface>.behavior.md`) if any
+     story cites the term — rewrite the entry and record the reason under its
+     `★ FROZEN` header, since the freeze pins a contract that would otherwise go
+     silently stale. A mid-build resettle that leaves the frozen ledger untouched
+     is incomplete;
    - `mockups/INDEX.md` if the surface's status or files changed (columns
-     Surface / Concept / Status / Issue / File).
+     Surface / Concept / Status / Issue / File) — it registers the behavior
+     ledger and the sweep-evidence directory `mockups/sweep/<surface>/` too.
 3. If the term had a `LOCK:` assertion, update the assertion in the same
    change and prove the new one can fail.
 4. If a build is in flight, update its fidelity ledger row from


### PR DESCRIPTION
A handoff is written for the agent taking over. It gets delivered to the person who just asked to stop reading — and today the skill says nothing about that, so the natural move is to write the file and then summarize it back into the chat.

That hands them the same content a second time, in the worse of the two formats, at the exact moment they were trying to put the work down. It also quietly punishes a good handoff: the longer and more thorough the file, the longer the redundant recap tends to be.

This adds a delivery rule. The file is the artifact; the response is the path, plus at most the single thing only they can act on themselves (an unmerged PR, a pending authorization). Anything that genuinely can't wait for the next agent belongs in the first-action section, not in a parallel chat summary. The quality gate now ends by checking the response too, not just the file.

Found the hard way: a session-ending handoff got written correctly and then recapped in chat section by section.