### PR TITLE
Check the DCO before a push, not after the commits are public

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,13 @@ Keep each skill self-contained, concise, and portable:
 - Document optional upstream dependencies in the README rather than copying
   them when a reference can simply stay optional.
 - Run `python3 scripts/validate.py` before opening a pull request.
-- Install the publish guard once per clone, so validation runs before a push
-  instead of after the tree is already public:
+- Install the publish guard once per clone, so validation **and the DCO check**
+  run before a push instead of after the tree is already public:
   `ln -sfn ../../scripts/pre-push .git/hooks/pre-push`. It composes with a
-  global `core.hooksPath` dispatcher rather than replacing it.
+  global `core.hooksPath` dispatcher rather than replacing it. Installing it is
+  worth the one command: a missing `Signed-off-by` caught before a push is one
+  `git rebase --signoff`, while the same miss caught by CI afterwards means
+  rewriting commits other people may already have pulled.
 
 ## Developer Certificate of Origin
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,6 +1,8 @@
 #!/bin/sh
-# Refuse to publish a tree that fails validation, including its disclosure checks.
-# CI runs the same script, but only after the push has already made the tree public.
+# Refuse to publish a tree that fails validation, including its disclosure checks,
+# or commits that do not certify the DCO. CI runs both of the same scripts, but
+# only after the push has already made the commits public — and a missing
+# Signed-off-by cannot be fixed after that without rewriting published history.
 #
 # Install once per clone:
 #   ln -sfn ../../scripts/pre-push .git/hooks/pre-push
@@ -12,3 +14,28 @@ set -e
 
 repo="$(git rev-parse --show-toplevel)"
 python3 "$repo/scripts/validate.py"
+
+# Git feeds the hook one line per ref being pushed:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# Check exactly the commits this push would publish, so the failure lands while
+# the trailer can still be added with `git rebase --signoff`.
+# An all-zero sha is git's "nothing here" marker. Matched by shape rather than
+# by a 40-character literal, so this keeps working in a sha256 repository.
+is_zero() { case "$1" in *[!0]*) return 1 ;; *) return 0 ;; esac }
+
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    # A branch deletion pushes an all-zero local sha and publishes no commits.
+    is_zero "$local_sha" && continue
+    if is_zero "$remote_sha"; then
+        # New branch: the remote has no tip to diff against, so fall back to where
+        # this branch left the default one. If that is unknown (no origin/HEAD in
+        # this clone), skip rather than block a legitimate push — CI still checks.
+        default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo '')
+        [ -n "$default" ] || continue
+        base=$(git merge-base "$default" "$local_sha" 2>/dev/null || echo '')
+    else
+        base="$remote_sha"
+    fi
+    [ -n "$base" ] || continue
+    python3 "$repo/scripts/check_dco.py" "$base" "$local_sha"
+done


### PR DESCRIPTION
## Why

The publish guard already refuses to push a tree that fails validation, on the stated reasoning that CI runs the same script "only after the push has already made the tree public." That reasoning applies harder to the DCO check, and the guard wasn't doing it.

The difference matters. A validation failure is fixed by another commit. A missing `Signed-off-by` can only be fixed by rewriting commits — and once they're pushed, possibly commits other people have pulled. Catching it one second before the push costs a `git rebase --signoff`; catching it after costs a force-push and a conversation.

This is not hypothetical: a branch reached CI with five commits missing the trailer, which is what prompted the change.

## What changed

`scripts/pre-push` now reads the refs git feeds it on stdin and runs `check_dco.py` over exactly the commits the push would publish.

- A branch deletion (all-zero local sha) is a no-op — it publishes nothing.
- An empty range is a no-op.
- A new branch has no remote tip to diff against, so it diffs from where the branch left the default branch. If the clone has no `origin/HEAD` to resolve, it **skips rather than blocks** — CI is still the backstop, and a local guard that blocks legitimate pushes gets disabled by whoever it annoys.
- The zero-sha test matches by shape, not against a 40-character literal, so it keeps working in a sha256 repository.

`CONTRIBUTING.md` records that the guard now covers both checks, and why installing it is worth the one command.

## Verification

Run against real ranges, not reasoning:

| Case | Expected | Got |
|---|---|---|
| range with five unsigned commits | blocks | exit 1, naming each commit |
| empty range (same sha both sides) | allows | exit 0 |
| branch deletion (zero local sha) | allows | exit 0 |

This PR's own push went through the installed hook.