### PR TITLE
orchestrate: preflight the branch before dispatching subagents

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -62,6 +62,18 @@ is the reason the review is not optional); prototyping routes straight to
   sub-agent (or any task work), invoke the `spin-worktree` skill so worktrees
   land under its `~/worktrees/<repository>/<task>` convention, not ad-hoc
   paths next to the checkout.
+- **Branch-currency preflight, before the first dispatch of a session.** Run
+  `git fetch` and check `git rev-list --count HEAD..origin/main`. If it is
+  non-zero, either move the checkout or name the ref explicitly in every subagent
+  brief ("work against `origin/main`, not the current branch, via a throwaway
+  worktree or `git show` — never mutate the operator's checkout"). A subagent
+  cannot see what its parent's tree lacks, and it reports absence as fact with
+  honest file:line citations: on a checkout three commits behind, two independent
+  explorers concluded a shipped surface "does not exist in the app", and every
+  downstream conclusion built on that map was wrong. The same trap catches the
+  coordinator's own claims about tooling — a negative claim ("that label or flag
+  doesn't exist") needs a fetched checkout, a live `gh` query, and a grep
+  unnarrowed by file extension before it is asserted rather than hedged.
 
 ## Routing
 


### PR DESCRIPTION
Adds one coordinator rule to `/orchestrate`: before the first dispatch of a session, check whether the checkout is behind `origin/main`, and if it is, either move it or name the ref explicitly in every subagent brief.

**Why.** A coordinator session ran from a checkout three commits behind. Two independent exploration subagents reported, with honest and verifiable `file:line` citations, that a surface which had shipped in the app "does not exist" — because their parent's tree predated the port. The citations were accurate; the tree was stale. Every conclusion built on that map was wrong until a third agent was pointed at `origin/main`, and a bug-reproduction agent had already spent a full run against the wrong artifact before being redirected mid-flight.

A subagent cannot see what its parent's tree lacks, and it reports absence as fact. That makes this a preflight, not a review step.

The rule also covers the coordinator's own negative claims about tooling, which is the other half of how that session went wrong: a grep of a checkout 22 commits behind was used to tell the operator that a label they knew existed did not. A negative claim needs a fetched checkout, a live `gh` query, and a grep unnarrowed by file extension before it is asserted rather than hedged.

Docs only, one bullet in the coordinator ruling section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)