### PR TITLE
ui-craft: chrome ground-truth pre-flight + sibling-fidelity doctrine

### DIFF
--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -29,7 +29,11 @@ class, function signature, or module boundary, this is the wrong skill.
 For `lock`, `build`, and general design invocations only:
 
 3. Read the project's design system: tokens, theme, one representative
-   component or page. Use what's there when it works.
+   component or page. Use what's there when it works. **The shipped app wins
+   over any mock scaffold**: when a repo carries both an app stylesheet and a
+   `mockups/` theme, the app is chrome ground truth for every surface that
+   has shipped — `lock` mode's step-0 pre-flight (reference/lock.md) resolves
+   this and gates the round on a chrome fidelity check.
 4. Read the matching register reference: `reference/brand.md` when design IS
    the product (marketing, landing, portfolio), `reference/product.md` when
    design SERVES the product (app UI, dashboards, tools).

--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -141,6 +141,13 @@ substitutes for the other.
 - Inspect rendered output — source review alone never validates a visual
   artifact. Use `drive-local-webapp` for rendering; ask to install it if
   missing.
+- **Sibling exactness** ([reference/sibling-fidelity.md](reference/sibling-fidelity.md)):
+  any element with a sibling in a shipped surface uses the shipped values
+  exactly — geometry, type, alignment spines, chart furniture, and interaction
+  idioms alike — and fidelity is proven with a computed-style diff against the
+  running app, never by eyeball. Token bridges are verified by computed value
+  on the consuming element; mock-global base styles (body font/line-height)
+  are banned because they shift extracted chrome off its shipped pixels.
 - Keep `mockups/INDEX.md` as the surface ledger (one row per surface:
   Surface / Concept / Status / Issue / File). `locked` rows are binding
   precedent; `shipped` rows defer to the app itself. Every mode that touches

--- a/skills/ui-craft/reference/lock.md
+++ b/skills/ui-craft/reference/lock.md
@@ -15,6 +15,39 @@ agent cannot silently drift from: a ★ LOCKED mockup plus a lock manifest.
 
 ## Workflow
 
+### 0. Pre-flight — chrome ground truth (MANDATORY, before any concept work)
+
+A lock round dies at review when its chrome doesn't match the app the reviewer
+uses every day. Run these checks before the ledger, and do not fan out a
+single variant until the fidelity gate passes:
+
+1. **Resolve the material ground truth for chrome.** If any locked surface has
+   shipped — check `mockups/INDEX.md` for `shipped` rows and the log for port
+   commits — the RUNNING APP's own stylesheet is the material truth for
+   tokens, chrome, and component styling. The mock scaffold that *authored*
+   the design is a stale ancestor the moment the port lands: same design,
+   superseded values. Never source chrome from mockup lineage when a shipped
+   embodiment exists. (Lesson: ciq-autotune #660 burned three rounds on a
+   shell forked from `_theme.css` after #655 had re-materialized the same
+   lock onto the app's `--wk-*` layer — wrong ground, wrong radii, wrong
+   fonts, wrong button chrome, every round.)
+2. **Extract, never transcribe.** Materialize the app's token layer into
+   `mockups/_theme-app.css` by script/verbatim copy from the app's stylesheet
+   (both themes, plus the app's exact `body` ground and type rules), with a
+   header naming the source file and how to refresh it. Post-ship mocks link
+   this sheet; the legacy scaffold `_theme.css` serves only surfaces that
+   predate the port. When two token layers coexist, SCAFFOLD.md must name
+   which is ground truth — silence here is the defect that lets the next
+   round anchor wrong.
+3. **Round-zero fidelity gate.** Render the empty shell/chrome (no concept
+   content) and put it beside a screenshot of the running app. Chrome —
+   ground color, fonts, control sizes, radii, bar heights — must be
+   indistinguishable BEFORE variants are briefed; save the pair as evidence.
+   A reviewer should never have to argue the background color mid-round.
+4. **Chart medium check.** If the surface charts, the mock renders with the
+   app's shipping chart library at its shipping version from step one — a
+   hand-rolled SVG facsimile invalidates every judgment made on it.
+
 ### 1. Ledger
 
 Read `mockups/INDEX.md` (create if absent; one row per surface, columns

--- a/skills/ui-craft/reference/sibling-fidelity.md
+++ b/skills/ui-craft/reference/sibling-fidelity.md
@@ -43,6 +43,12 @@ computed-property mismatches caused by box-sizing differences when the rects
 match, and 0×0 rects for app elements that exist but aren't laid out in the
 probed tab (fall back to the app's source values for those).
 
+**The diff's blind spot is canvas.** Chart text (axis labels, ticks, legend,
+in-chart labels) is painted, not DOM — a computed-style diff cannot see it at
+all. Audit chart typography and furniture at the **option level**: diff the
+mock's chart config (family, sizes, tick visibility, positions) against the
+shipped chart source or a live `getOption()` dump, as its own audit step.
+
 ## Token bridges lie — verify resolution, not names
 
 A mock that bridges onto extracted app CSS via alias tokens

--- a/skills/ui-craft/reference/sibling-fidelity.md
+++ b/skills/ui-craft/reference/sibling-fidelity.md
@@ -1,0 +1,81 @@
+# Sibling fidelity — one panel, one app
+
+When a mock or new surface lives beside shipped surfaces, the bar is: moving
+between the shipped surface and the new one must feel like switching panes on a
+single dashboard. **Any element with a sibling in a shipped surface uses the
+shipped values exactly — steal, never approximate.** A 3px chip-height drift, a
+square corner where the app rounds, a mono axis label where the app uses the
+default face: each one breaks the one-app illusion, and the operator sees it
+even when the builder doesn't. Distilled from the #660 Verify round
+(ciq-autotune, 2026-08-12), where every rule below was learned as a correction.
+
+## Steal list (what "sibling" covers)
+
+Not just tokens and colors. Every one of these bit in practice:
+
+- **Geometry**: pane radius, paddings, gaps, row heights, full-bleed vs inset
+  hairlines, chrome icon pixel sizes.
+- **Alignment spines**: the shipped app aligns pane title, axis caption
+  (`mg/dL`) and axis labels on the plot's own left edge (a `--*-grid-left`
+  token shared by CSS and chart config). New panes join the spine, and the
+  chart grid uses the same number.
+- **Type**: rank (a pane title is caps-rank like every sibling pane, even when
+  it "feels like" a heading), family (axis labels in the app's default face,
+  not mono, when that is what the shipped chart does), line-height.
+- **Chart furniture**: axis scale rules (the shipped fixed clinical axis —
+  e.g. 40–300/60 — beats data-hugging bounds; comparable zoom across views is
+  the point), threshold-band treatment (fill + labeled knock-out rules, ported
+  mixes), tick visibility, legend position/scale/case.
+- **Interaction idioms**: hover is chrome too. If the app has a docked-readout
+  hover (crosshair only, numbers land in the pane header's swap line, no
+  floating tooltip), the mock ports that behavior — `showContent:false`,
+  `updateAxisPointer` → header paint, `globalout` clears — not a generic
+  tooltip.
+
+## Audit empirically, not by eyeball
+
+Run the shipped app and the mock in the same headless browser and **diff
+computed styles + bounding rects on shared selectors** (radius, padding, gap,
+font-size/family/weight, letter-spacing, line-height, colors, rect). Eyeballs
+miss 1–3px; the diff doesn't. Re-run the diff after edits — it is the fidelity
+gate, not a one-off. Two reporting artifacts to ignore: `width`/`height`
+computed-property mismatches caused by box-sizing differences when the rects
+match, and 0×0 rects for app elements that exist but aren't laid out in the
+probed tab (fall back to the app's source values for those).
+
+## Token bridges lie — verify resolution, not names
+
+A mock that bridges onto extracted app CSS via alias tokens
+(`--ck-r: var(--wk-radius)`) can silently resolve to nothing or to a wrong
+literal: the name may come from a retired lineage, or the real value may live
+in a **scoped** block (the app's workstation sets `--ck-r: 8px` inside `.dw`;
+the global `--wk-radius` is `0px`). Grep proving a name exists proves nothing.
+Verify every bridge token by **computed value on the element that uses it**,
+and port scoped token blocks as literals with a comment naming their source.
+
+## No mock-global base styles
+
+A `body { line-height / font-size }` in the mock leaks into chrome extracted
+from the app and shifts its pixel metrics (chip heights, footer text). Chrome
+inherits the app's own base; scope any interior typography to the surface's
+own containers.
+
+## Findings close by edit, not by note
+
+In a persona/critique sweep against a mock, a confirmed finding is closed by
+an edited file and a fresh render — finding → edit → screenshot, one at a
+time. Noting findings for later is the failure mode the sweep exists to kill.
+
+## Concrete traps (chart library)
+
+- ECharts 5.5 legend: custom `path://` icons collapse the legend layout (all
+  items stack at 0,0, clipped). Replicate line marks via inheritance instead:
+  plain string `data`, `itemStyle: { opacity: 0 }` to hide the symbol dot,
+  `lineStyle: { width: 'auto', type: 'inherit' }`.
+- ECharts value-axis charts whose x range spans 0: default `onZero` pins the
+  y-axis (and its name) to x=0, not the plot edge — set
+  `axisLine: { onZero: false }`.
+- A threshold band (`markArea`) covering the whole visible axis is a uniform
+  wash that reads as nothing; a fixed axis (above) keeps its edges in frame.
+- Aggregate bins keyed by bin start: extend the final segment to the bin's
+  end, or the series dies short of the axis edge with a cliff.


### PR DESCRIPTION
Three lessons from the ciq-autotune #660 Verify rounds, folded into ui-craft:

- **lock step-0 (mandatory pre-flight):** the shipped app is chrome ground truth once any locked surface has shipped — extract its tokens verbatim, gate the round on a shell-vs-app fidelity check, and require the shipping chart library for charting surfaces. (Three rounds died on a stale mock-scaffold theme before this rule.)
- **sibling-fidelity reference (new):** "one panel, one app" — any element with a sibling in a shipped surface steals the shipped values exactly (geometry, type, alignment spines, chart furniture, interaction idioms); fidelity is proven with a computed-style diff against the running app, token bridges are verified by computed value on the consuming element, and mock-global base styles are banned. Wired into SKILL.md's grounding rules.
- **canvas blind spot:** a computed-style diff cannot see chart-painted text; chart typography is audited at the option level (config vs shipped chart source / getOption dump) as its own step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)