### PR TITLE
ui-craft: close the gaps that let a dead-end, drifting view ship

### DIFF
--- a/skills/ui-craft/reference/audit.md
+++ b/skills/ui-craft/reference/audit.md
@@ -140,6 +140,14 @@ This is the check that catches drift no green gate notices.
 1. Render the ★ LOCKED mockup and the live surface **side by side** — same
    fixture (honoring the manifest's fixture obligations), same viewports and
    themes the manifest names.
+   **Every view/mode/tab is its own render, including the ones that hand off to
+   a sibling or shipped surface.** A named state (`dense`, `empty`, `selected`)
+   is not a view; a matrix of five states inside one view leaves the other views
+   unlooked-at. A real Diagnose audit rendered five states, all of them in the
+   comparison view, and so never once put the Glucose view on screen — where the
+   missing navigation would have been obvious at a glance. Landing on the
+   surface with no parameters counts as a view and gets its own render, since it
+   is what most readers actually see.
 2. Walk the manifest term by term:
    - `gate` terms: confirm a `LOCK:<surface>:<n>`-tagged assertion exists in
      the rendered gate AND holds. A gate term with no assertion is a finding

--- a/skills/ui-craft/reference/audit.md
+++ b/skills/ui-craft/reference/audit.md
@@ -148,6 +148,15 @@ This is the check that catches drift no green gate notices.
    missing navigation would have been obvious at a glance. Landing on the
    surface with no parameters counts as a view and gets its own render, since it
    is what most readers actually see.
+   **Chrome the views share is compared numerically against one reference view,
+   never by eye.** Rendering each view catches what is *missing* from one of
+   them; it does not catch a uniform offset, because nobody looks at two views
+   at once and 6px looks like nothing on its own. Pick the shipped or
+   longest-standing view as the reference, read the shared geometry off it —
+   rail row and padding, pane grid, pane header heights, first content baseline
+   — and diff every other view against those numbers. The same Diagnose surface
+   that lost its navigation later sat 6px low in two of its three views, through
+   an audit that had by then rendered all of them.
 2. Walk the manifest term by term:
    - `gate` terms: confirm a `LOCK:<surface>:<n>`-tagged assertion exists in
      the rendered gate AND holds. A gate term with no assertion is a finding

--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -48,6 +48,26 @@ Excluded from the inventory is **not** excluded from the page: the harness and
 every imported module are still **served**, because an unserved import throws
 before any listener registers.
 
+**Handlers are not the only source of stories.** The inventory finds everything
+the surface *does*; it cannot find what the surface must *keep true* while doing
+it. Those invariants own no handler, so a handler-complete ledger can still have
+none of them — and they fail silently, because each one is only visible by
+comparing two renders nobody compares. Add a story for each:
+
+- **Across views/modes**, chrome the reader keeps seeing does not move. Measure
+  every other view against one designated reference view, not against an
+  average, so the reference stays authoritative when they drift together.
+- **Across interaction**, nothing reflows that the interaction did not name.
+  A header that grows when its hover readout fills moves the content under the
+  pointer — reserve the space at rest and assert the resting and active
+  geometry are equal.
+- **Across data shape**, containers sized for live values do not resize per
+  value (counts, timestamps, currency).
+
+A real Diagnose surface shipped 6px low in two of its three views, and grew its
+chart header on first hover, with a handler-complete ledger where every story
+passed. Each story replayed one view, alone, where a uniform offset is invisible.
+
 Static reading produces the inventory. It never produces a story.
 
 ## 2. Exercise (live — this is the evidence)
@@ -73,7 +93,10 @@ Two further passes, folded in or run separately per proportionality:
 
 **Completeness check (mechanical, not judgment):** every inventoried handler maps
 to ≥1 story, and every story was observed live. A handler found in code but not
-reproducible in-browser becomes a QUESTION entry — never a silent skip.
+reproducible in-browser becomes a QUESTION entry — never a silent skip. Handler
+coverage is not ledger completeness: a surface with more than one view, or with
+any interaction that swaps content in place, also owes its invariant stories
+above. Record them with no handler named, since none exists.
 
 ## 3. The replay script (committed)
 

--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -99,6 +99,15 @@ Spec:
 - **Selector parity is a port obligation, not a script concern.** Replay-against-both
   only holds if the ported markup keeps the mock's selectors; a rename that
   breaks a replay selector is a **port defect**.
+- **Drive every story through the affordance a reader would use.** A story about
+  reaching, leaving, or returning to a state is only evidence if the replay gets
+  there the way a person does — clicking the control, typing in the field. Browser
+  history (`goBack`), a direct URL, or calling the surface's own API bypasses the
+  affordance, so the story passes on a surface that offers *no route at all*. A
+  shipped Diagnose view once lost its entire view switcher while its "returning to
+  an event view restores it" story stayed green, because the replay returned with
+  `goBack()`. When a story's verb is navigational, assert the control exists and is
+  visible, then use it.
 - Replay functions inherit `build.md`'s prove-red-once rule — proven against the
   **built app** (knock the feature out) or a **scratch copy** of the mock, never
   the ★ LOCKED mock in place. A transient edit to the contract artifact risks an

--- a/skills/ui-craft/reference/lock.md
+++ b/skills/ui-craft/reference/lock.md
@@ -187,3 +187,15 @@ Rules for writing terms:
   — an assertable term that goes unasserted is how drift ships.
 - Terms carried forward from a superseded lock are restated here, not
   referenced — the manifest must stand alone.
+- **A surface with more than one view/mode/tab owes two extra terms: which one
+  is the default, and what chrome persists across all of them.** Name the
+  switcher itself as persistent chrome. Both are the kind of thing a lock is
+  silent on because it felt obvious while the mock was open in front of you,
+  and silence is what a builder resolves in private.
+- **"Mounts <existing surface> unchanged" is not a term — it is a hole.** When
+  one view hands off to a sibling or shipped surface, say what the host keeps
+  on screen around it. Read literally, "unchanged" licenses dropping the
+  navigation that got the reader there, which is exactly how a real Diagnose
+  lock shipped a view you could enter and never leave. If a rail's contents
+  differ per view, spell out each view's contents rather than describing the
+  rail once from whichever view you happened to be designing.


### PR DESCRIPTION
Two rounds of the same locked surface in ciq-autotune, four defects, and every gate green through all of them. Each round exposed a different silence in these references.

## Round 1 — a view you could enter and never leave

Choosing Glucose rendered it with no view switcher at all, so Meals and Lows became unreachable without the browser Back button. Diagnose also opened on the wrong view. The lock manifest had been walked, the behavior ledger was frozen with every story `replayed-pass`, the rendered audit passed, CI passed.

**`lock.md`** — a multi-view surface owes two terms it did not have: which view is the default, and what chrome persists across all views (naming the switcher itself). And `"mounts <existing surface> unchanged"` is recorded as a hole rather than a term: read literally, it licenses dropping the navigation that got the reader there, which is exactly what the builder did. Rails whose contents differ per view now get spelled out per view, instead of described once from whichever view the designer had open.

**`behavior-sweep.md`** — navigational stories must be driven through the affordance. The story asserting "returning to an event view restores its comparison surface" replayed that return with `page.goBack()`, which passes whether or not any route back exists on screen.

**`audit.md`** — every view/mode/tab is its own render, including views that hand off to a sibling surface, and including the no-parameter landing. The audit rendered five states, all inside the comparison view, so the broken view was never once put on screen.

## Round 2 — the views drifted against each other

With all of the above fixed, the event views turned out to sit 6px below the shipped Glucose view, and to grow their chart header 2px on first hover — moving the chart under the pointer. Caught by a human holding two screenshots of the same pixels side by side, not by any gate.

**`audit.md`** — rendering each view catches what is *missing* from one of them; it does not catch a uniform offset, because nobody looks at two views at once and 6px looks like nothing on its own. Shared chrome is now compared numerically against one designated reference view.

**`behavior-sweep.md`** — the deeper fix. Its inventory is handler-driven, and these invariants own no handler, so the method structurally could not produce the story: a handler-complete ledger was still blind to them. Invariants are now a named second source of stories — across views, across interaction, across data shape — and the completeness check states plainly that handler coverage is not ledger completeness.

Fixes and re-settles: ConnorGriffin/ciq-autotune#686, ConnorGriffin/ciq-autotune#687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)