### PR TITLE
feat(pr-body): add pr body skill, scorer, and gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 *.capture.json
 .DS_Store
 __pycache__/
+bench/fixtures/pr-body/
+bench/results/pr-body/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 | [`persona-review`](skills/persona-review/SKILL.md) | Convene a panel of persistent reviewer personas to review a document and synthesize a verdict | Private data repo for persona memory; GitHub CLI for mining real-colleague profiles; parallel-agent support recommended |
 | [`orchestrate`](skills/orchestrate/SKILL.md) | Flip the session into coordinator mode: delegate all real work to sub-agents routed by an empirically benchmarked model capability table | Codex CLI for GPT-tier sub-agents; table re-benchmarked per its bundled procedure |
 | [`wayfinder`](skills/wayfinder/SKILL.md) | Chart a large, foggy effort as a GitHub map of decision tickets, then hand clear subtrees to implementation | GitHub CLI; composes with `research`, `scope`'s interview mode, `ui-craft` |
+| [`pr-body`](skills/pr-body/SKILL.md) | Write a PR body and score it before the PR opens, or audit an existing one, against a deterministic linter and a voice judge | A PreToolUse hook that hard-denies `gh pr create` until the body is scored, installed separately from `hooks/` |
 | [`research`](skills/research/SKILL.md) | Investigate a question against primary sources and capture findings as Markdown in the repo | — |
 | [`prototype`](skills/prototype/SKILL.md) | Build a throwaway prototype — a terminal app for logic questions or switchable UI variants in the real app | — |
 | [`tdd`](skills/tdd/SKILL.md) | Test-driven development through public interfaces, red-green-refactor | — |

--- a/bench/pr_body_bench.py
+++ b/bench/pr_body_bench.py
@@ -1,24 +1,48 @@
 #!/usr/bin/env python3
-"""Measure whether the pr-body skill's prose teaches a model to write a passing body.
+"""Measure whether the pr-body skill's prose teaches a model to write a passing body,
+and whether the deny-and-fix loop (the hook's real workflow) closes the gap.
 
-Two arms run the same 8 real diffs through the same model: `with-skill` puts
-`skills/pr-body/SKILL.md` in the prompt, `without-skill` gets only the diff.
-Each resulting body is scored by `pr_body_lint.py` itself (the judge; no LLM
-rubric), so this measures whether the prose teaches, as distinct from the
-pr-body-gate hook that enforces compliance after the fact.
+The first eval measured only a first draft with the whole of SKILL.md in context, and
+found nothing (+8% against a +/-17% noise band). This version asks two sharper
+questions:
+
+Experiment A: which slice of SKILL.md's ~1600 words teaches. Four arms run the same
+diffs through the same model:
+  none    - the diff only
+  example - only the worked example block (the fenced ```markdown body, plus the
+            paragraph that follows it)
+  rules   - only "## The shape" and "## Textures to cut"
+  full    - all of SKILL.md
+Slices are extracted from SKILL.md at runtime by heading (see build_skill_slices());
+if a heading has moved, extraction raises rather than shipping an empty slice.
+
+Experiment B: for each arm, after the first draft, score with pr_body_lint.py; on a
+fail, send the model its own body plus the findings and ask for a corrected body, to a
+maximum of 3 rounds. This is the deny-and-fix loop the hook actually runs.
+
+Experiment C: a --retry-modes flag varies what the retry prompt includes.
+  fix-text   - each finding's rule name and its fix text (what the hook sends)
+  rule-names - only the rule names that fired, no fix text
+If rule-names converges as fast as fix-text, the fix wording is decoration.
 
 Usage:
-  python3 bench/pr_body_bench.py run --models claude-sonnet-5 --repeats 2
+  python3 bench/pr_body_bench.py slices
+  python3 bench/pr_body_bench.py run --models claude-sonnet-5 --repeats 8
+  python3 bench/pr_body_bench.py run --retry-modes fix-text,rule-names --repeats 4
   python3 bench/pr_body_bench.py score
 
-Fixtures live in bench/fixtures/pr-body/ and results in bench/results/pr-body/,
-both gitignored: the diffs and the bodies written about them come from a private
-estate. Point --diffs at your own. Aggregate numbers from the run behind this
-skill are in docs/pr-body-measurement.md.
+Fixtures live in bench/fixtures/pr-body/ and results in bench/results/pr-body/, both
+gitignored: the diffs and the bodies written about them come from a private estate.
+Point --diffs at your own.
 
-`run` is resumable: it skips (arm, diff, model, repeat) combinations already
-present in the target jsonl, and appends new results one at a time so an
+`run` is resumable: it skips (arm, retry_mode, diff, model, repeat) combinations
+already present in the target jsonl, and appends new results one at a time so an
 interrupted run loses nothing already written.
+
+CAVEAT, load-bearing and not to be missed: a linter pass is a weak proxy for a good
+body. On the operator's hand-labeled set of 25 real bodies, the linter caught 4 of the
+12 rejected ones. A high loop-pass rate here means the countable defects are gone, not
+that the body is good.
 """
 
 from __future__ import annotations
@@ -29,6 +53,7 @@ import importlib.util
 import json
 import math
 import pathlib
+import re
 import shutil
 import statistics
 import subprocess
@@ -44,17 +69,16 @@ FIXTURES = ROOT / "fixtures" / "pr-body"
 SKILL_MD = REPO_ROOT / "skills" / "pr-body" / "SKILL.md"
 LINT_SCRIPT = REPO_ROOT / "skills" / "pr-body" / "scripts" / "pr_body_lint.py"
 
-ARMS = ("with-skill", "without-skill")
+ARMS = ("none", "example", "rules", "full")
+RETRY_MODES = ("fix-text", "rule-names")
+MAX_ROUNDS = 3
 
-# ai-disclosure-missing is the one rule SKILL.md teaches that the raw diff
-# does not mention at all. Excluded from the without-skill arm's pass/fail
-# rate: that arm was never told the requirement exists, so counting it there
-# would manufacture a difference that reflects what the prompt withheld, not
-# what the skill's prose teaches.
-UNTAUGHT_RULES_BY_ARM = {
-    "without-skill": {"ai-disclosure-missing"},
-    "with-skill": set(),
-}
+CAVEAT = (
+    "CAVEAT: a linter pass is a weak proxy for a good body. On the operator's "
+    "hand-labeled set of 25 real bodies, the linter caught 4 of the 12 rejected "
+    "ones. A high loop-pass rate means the countable defects are gone, not that "
+    "the body is good."
+)
 
 
 def _load_lint():
@@ -65,6 +89,103 @@ def _load_lint():
 
 
 LINT = _load_lint()
+
+
+# --- SKILL.md slice extraction --------------------------------------------------
+
+HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.*)$", re.MULTILINE)
+FENCED_MARKDOWN_RE = re.compile(r"```markdown\n.*?\n```", re.DOTALL)
+
+
+class SkillExtractionError(RuntimeError):
+    """SKILL.md no longer has the structure a slice extractor expects.
+
+    Raised instead of returning an empty slice, so a moved heading fails the
+    run loudly rather than silently shipping a blank prompt for that arm.
+    """
+
+
+def _headings(text: str) -> list[tuple[int, int, str]]:
+    return [
+        (match.start(), match.end(), match.group(2).strip())
+        for match in HEADING_RE.finditer(text)
+    ]
+
+
+def _section_body(text: str, heading_title: str) -> str:
+    """Text between a heading line (matched by title, case-insensitive) and the
+    next heading of any level, or end of document."""
+    headings = _headings(text)
+    matches = [
+        (start, line_end) for start, line_end, title in headings
+        if title.lower() == heading_title.lower()
+    ]
+    if not matches:
+        raise SkillExtractionError(
+            f"heading {heading_title!r} not found in {SKILL_MD}; extraction target moved"
+        )
+    start, line_end = matches[0]
+    later_starts = [s for s, _, _ in headings if s > start]
+    end = later_starts[0] if later_starts else len(text)
+    body = text[line_end:end].strip()
+    if not body:
+        raise SkillExtractionError(
+            f"heading {heading_title!r} has no body text in {SKILL_MD}"
+        )
+    return body
+
+
+def _example_slice(text: str) -> str:
+    """The worked example: the fenced ```markdown block, plus the paragraph that
+    immediately follows it (the "No headings. No reason..." sentence group)."""
+    match = FENCED_MARKDOWN_RE.search(text)
+    if match is None:
+        raise SkillExtractionError(
+            f"no fenced ```markdown example block found in {SKILL_MD}; extraction target moved"
+        )
+    fence = match.group(0)
+    rest = text[match.end():]
+    paragraph_match = re.match(r"[ \t]*\n+([^\n].*?)(?:\n[ \t]*\n|\Z)", rest, re.DOTALL)
+    if paragraph_match is None:
+        raise SkillExtractionError(
+            f"no paragraph follows the fenced example block in {SKILL_MD}; extraction target moved"
+        )
+    sentence = paragraph_match.group(1).strip()
+    return f"{fence}\n\n{sentence}"
+
+
+def _rules_slice(text: str) -> str:
+    """"The shape" numbered list plus the "Textures to cut" list, nothing else."""
+    shape = _section_body(text, "The shape")
+    cuts = _section_body(text, "Textures to cut")
+    return f"{shape}\n\n{cuts}"
+
+
+def build_skill_slices(skill_text: str | None = None) -> dict[str, str]:
+    text = skill_text if skill_text is not None else SKILL_MD.read_text(encoding="utf-8")
+    slices = {
+        "none": "",
+        "example": _example_slice(text),
+        "rules": _rules_slice(text),
+        "full": text,
+    }
+    for name in ("example", "rules", "full"):
+        assert slices[name].strip(), f"{name!r} slice extracted empty from {SKILL_MD}"
+    return slices
+
+
+# ai-disclosure-missing is the one rule SKILL.md states as an explicit requirement
+# (in the intro example's closing line and in the rules table); "rules" never
+# mentions it and "none" never mentions it either, so scoring those two arms
+# against that rule would manufacture a difference that reflects what the prompt
+# withheld, not what the slice teaches. "example" is left in scope because the
+# example body it hands the model ends with that exact disclosure sentence.
+UNTAUGHT_RULES_BY_ARM = {
+    "none": {"ai-disclosure-missing"},
+    "example": set(),
+    "rules": {"ai-disclosure-missing"},
+    "full": set(),
+}
 
 
 def scratch_project() -> pathlib.Path:
@@ -86,12 +207,40 @@ Write the PR body text for this change: the text that would be passed to
 explanation of what you are about to do, no code fence around the body."""
 
 
-def build_prompt(diff_text: str, arm: str) -> str:
+RETRY_TEMPLATE = """Here is the pull-request body you wrote:
+
+{body}
+
+A linter found these problems with it:
+
+{findings}
+
+Write a corrected version of the body. Reply with the body text only. No
+preamble, no explanation, no code fence around the body."""
+
+
+def build_prompt(diff_text: str, arm: str, skill_slices: dict[str, str]) -> str:
     prompt = PROMPT_TEMPLATE.format(diff=diff_text)
-    if arm == "with-skill":
-        skill_text = SKILL_MD.read_text(encoding="utf-8")
-        prompt = f"{skill_text}\n\n---\n\n{prompt}"
+    slice_text = skill_slices[arm]
+    if slice_text:
+        prompt = f"{slice_text}\n\n---\n\n{prompt}"
     return prompt
+
+
+def _findings_block(findings: list[dict], retry_mode: str) -> str:
+    lines = []
+    for finding in findings:
+        if retry_mode == "rule-names":
+            lines.append(f"- {finding['rule']} ({finding['severity']})")
+        else:
+            lines.append(f"- {finding['rule']} ({finding['severity']}): {finding['fix']}")
+    return "\n".join(lines)
+
+
+def build_retry_prompt(previous_body: str, findings: list[dict], retry_mode: str) -> str:
+    return RETRY_TEMPLATE.format(
+        body=previous_body, findings=_findings_block(findings, retry_mode)
+    )
 
 
 def score_body(body: str) -> dict:
@@ -100,6 +249,7 @@ def score_body(body: str) -> dict:
     return {
         "chars": len(body),
         "verdict": result["verdict"],
+        "findings": findings,
         "rules_fired": sorted({f["rule"] for f in findings}),
         "blocking_rules_fired": sorted(
             {f["rule"] for f in findings if f["severity"] == "block"}
@@ -107,35 +257,88 @@ def score_body(body: str) -> dict:
     }
 
 
-def one_run(project: pathlib.Path, model: str, arm: str, diff_path: pathlib.Path) -> dict:
-    diff_text = diff_path.read_text(encoding="utf-8")
-    prompt = build_prompt(diff_text, arm)
-    row = {"arm": arm, "diff": diff_path.name, "model": model}
+def call_claude(project: pathlib.Path, model: str, prompt: str) -> dict:
     cmd = [
         "claude", "-p", "--model", model,
         "--setting-sources", "project",
         "--output-format", "json",
     ]
-    # Prompt goes on stdin, never argv: the with-skill arm starts with SKILL.md's
-    # `---` frontmatter, which argv parsing reads as a flag.
+    # Prompt goes on stdin, never argv: SKILL.md's frontmatter starts with `---`,
+    # which argv parsing would read as a flag.
     proc = subprocess.run(cmd, cwd=project, input=prompt,
                           capture_output=True, text=True, timeout=900)
     if proc.returncode != 0:
-        row["error"] = proc.stderr.strip()[:400]
-        return row
+        return {"error": proc.stderr.strip()[:400]}
     try:
         payload = json.loads(proc.stdout)
     except json.JSONDecodeError as error:
-        row["error"] = f"non-JSON output: {error}"
+        return {"error": f"non-JSON output: {error}"}
+    return {
+        "body": payload.get("result", ""),
+        "output_tokens": payload.get("usage", {}).get("output_tokens") or 0,
+    }
+
+
+def one_run(
+    project: pathlib.Path,
+    model: str,
+    arm: str,
+    diff_path: pathlib.Path,
+    retry_mode: str,
+    skill_slices: dict[str, str],
+) -> dict:
+    """First draft, then up to MAX_ROUNDS deny-and-fix rounds.
+
+    Each retry_mode regenerates its own first draft rather than sharing one
+    across modes, so requesting both fix-text and rule-names in one --retry-modes
+    run doubles the round-0 calls. Kept simple deliberately: round 0 is cheap
+    relative to the retry rounds, and every row stays self-contained.
+    """
+    diff_text = diff_path.read_text(encoding="utf-8")
+    row = {
+        "arm": arm, "retry_mode": retry_mode, "diff": diff_path.name,
+        "model": model, "rounds": [],
+    }
+    prompt = build_prompt(diff_text, arm, skill_slices)
+    result = call_claude(project, model, prompt)
+    if "error" in result:
+        row["error"] = result["error"]
         return row
-    body = payload.get("result", "")
-    row["body"] = body
-    row["output_tokens"] = payload.get("usage", {}).get("output_tokens")
-    row.update(score_body(body))
+
+    body = result["body"]
+    total_output_tokens = result["output_tokens"]
+    round_index = 0
+    rounds_to_pass = None
+    while True:
+        scored = score_body(body)
+        row["rounds"].append({
+            "round": round_index,
+            "body": body,
+            "chars": scored["chars"],
+            "verdict": scored["verdict"],
+            "rules_fired": scored["rules_fired"],
+            "blocking_rules_fired": scored["blocking_rules_fired"],
+        })
+        if scored["verdict"] == "pass":
+            rounds_to_pass = round_index
+            break
+        if round_index >= MAX_ROUNDS:
+            break
+        retry_prompt = build_retry_prompt(body, scored["findings"], retry_mode)
+        retry_result = call_claude(project, model, retry_prompt)
+        if "error" in retry_result:
+            row["error"] = retry_result["error"]
+            break
+        body = retry_result["body"]
+        total_output_tokens += retry_result["output_tokens"]
+        round_index += 1
+
+    row["rounds_to_pass"] = rounds_to_pass
+    row["output_tokens_total"] = total_output_tokens
     return row
 
 
-def _completed_keys(path: pathlib.Path) -> set[tuple[str, str, str, int]]:
+def _completed_keys(path: pathlib.Path) -> set[tuple[str, str, str, int, str]]:
     if not path.exists():
         return set()
     keys = set()
@@ -145,8 +348,18 @@ def _completed_keys(path: pathlib.Path) -> set[tuple[str, str, str, int]]:
         row = json.loads(line)
         if not {"arm", "diff", "model"} <= row.keys():
             continue
-        keys.add((row["arm"], row["diff"], row["model"], row.get("repeat", 0)))
+        keys.add((
+            row["arm"], row["diff"], row["model"],
+            row.get("repeat", 0), row.get("retry_mode", "fix-text"),
+        ))
     return keys
+
+
+def cmd_slices(args: argparse.Namespace) -> int:
+    slices = build_skill_slices()
+    for arm in ARMS:
+        print(f"{arm:<8} {len(slices[arm]):>6} chars")
+    return 0
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -164,18 +377,33 @@ def cmd_run(args: argparse.Namespace) -> int:
         if arm not in ARMS:
             print(f"unknown arm {arm!r}, must be one of {ARMS}", file=sys.stderr)
             return 1
+    retry_modes = args.retry_modes.split(",")
+    for retry_mode in retry_modes:
+        if retry_mode not in RETRY_MODES:
+            print(f"unknown retry mode {retry_mode!r}, must be one of {RETRY_MODES}", file=sys.stderr)
+            return 1
+
+    try:
+        skill_slices = build_skill_slices()
+    except SkillExtractionError as error:
+        print(f"SKILL.md slice extraction failed: {error}", file=sys.stderr)
+        return 1
+    print("slice sizes:", file=sys.stderr)
+    for arm in ARMS:
+        print(f"  {arm:<8} {len(skill_slices[arm]):>6} chars", file=sys.stderr)
 
     RESULTS.mkdir(parents=True, exist_ok=True)
     out = RESULTS / f"{args.tag}.jsonl"
     done_keys = _completed_keys(out)
 
     jobs = [
-        (model, arm, diff, repeat)
+        (model, arm, diff, repeat, retry_mode)
         for model in models
         for arm in arms
         for diff in diffs
         for repeat in range(args.repeats)
-        if (arm, diff.name, model, repeat) not in done_keys
+        for retry_mode in retry_modes
+        if (arm, diff.name, model, repeat, retry_mode) not in done_keys
     ]
     if not jobs:
         print(f"all {len(done_keys)} runs already recorded in {out}; nothing to do", file=sys.stderr)
@@ -186,21 +414,29 @@ def cmd_run(args: argparse.Namespace) -> int:
     try:
         with out.open("a") as fh, concurrent.futures.ThreadPoolExecutor(args.jobs) as pool:
             futures = {
-                pool.submit(one_run, project, model, arm, diff): (model, arm, diff, repeat)
-                for model, arm, diff, repeat in jobs
+                pool.submit(one_run, project, model, arm, diff, retry_mode, skill_slices):
+                    (model, arm, diff, repeat, retry_mode)
+                for model, arm, diff, repeat, retry_mode in jobs
             }
             completed = 0
             for fut in concurrent.futures.as_completed(futures):
-                model, arm, diff, repeat = futures[fut]
+                model, arm, diff, repeat, retry_mode = futures[fut]
                 try:
                     row = fut.result()
                 except Exception as exc:  # noqa: BLE001 - one job's crash must not lose the rest
-                    row = {"arm": arm, "diff": diff.name, "model": model, "error": repr(exc)[:400]}
+                    row = {
+                        "arm": arm, "diff": diff.name, "model": model,
+                        "retry_mode": retry_mode, "rounds": [],
+                        "error": repr(exc)[:400],
+                    }
                 row["repeat"] = repeat
                 fh.write(json.dumps(row) + "\n")
                 fh.flush()
                 completed += 1
-                print(f"{completed}/{total} {model} {arm} {diff.name} rep{repeat}", file=sys.stderr)
+                print(
+                    f"{completed}/{total} {model} {arm} {retry_mode} {diff.name} rep{repeat}",
+                    file=sys.stderr,
+                )
     finally:
         shutil.rmtree(project, ignore_errors=True)
 
@@ -208,25 +444,98 @@ def cmd_run(args: argparse.Namespace) -> int:
     return 0
 
 
-def _adjusted_blocking(row: dict) -> list[str]:
-    untaught = UNTAUGHT_RULES_BY_ARM.get(row["arm"], set())
-    return [rule for rule in row["blocking_rules_fired"] if rule not in untaught]
+# --- scoring / aggregation --------------------------------------------------
+
+def _adjusted_blocking(rules_fired: list[str], arm: str) -> list[str]:
+    untaught = UNTAUGHT_RULES_BY_ARM.get(arm, set())
+    return [rule for rule in rules_fired if rule not in untaught]
+
+
+# Cross-arm comparison excludes every rule ANY arm fails to teach, not each arm's
+# own set. Per-arm exclusion scores the arms against different rulebooks: it
+# credits an arm for never being told a rule while charging the arm that was.
+# That alone reversed `full`'s ranking on this bench's first run.
+COMPARABLE_UNTAUGHT = set().union(*UNTAUGHT_RULES_BY_ARM.values())
+
+
+def _comparable_blocking(rules_fired: list[str]) -> list[str]:
+    return [rule for rule in rules_fired if rule not in COMPARABLE_UNTAUGHT]
+
+
+def _fully_errored(row: dict) -> bool:
+    """The first draft itself never came back; nothing in this row is usable."""
+    return not row.get("rounds")
+
+
+def _partial(row: dict) -> bool:
+    """A draft exists but a later retry call errored before a pass or 3 rounds."""
+    return bool(row.get("error")) and bool(row.get("rounds"))
+
+
+def _single_se(p: float, n: int) -> float:
+    return math.sqrt(p * (1 - p) / n) if n else 0.0
 
 
 def _pooled_se(p1: float, n1: int, p2: float, n2: int) -> float:
     return math.sqrt(p1 * (1 - p1) / n1 + p2 * (1 - p2) / n2)
 
 
-def _bucket(rows: list[dict]) -> dict:
-    bucket = {"n": 0, "raw_pass": 0, "adj_pass": 0, "chars": [], "rule_fires": {}}
+def _bucket_first_draft(rows: list[dict], arm: str) -> dict:
+    bucket = {"n": 0, "raw_pass": 0, "adj_pass": 0, "cmp_pass": 0, "chars": [], "rule_fires": {}}
     for row in rows:
+        first = row["rounds"][0]
         bucket["n"] += 1
-        bucket["raw_pass"] += 1 if row["verdict"] == "pass" else 0
-        bucket["adj_pass"] += 1 if not _adjusted_blocking(row) else 0
-        bucket["chars"].append(row["chars"])
-        for rule in row["rules_fired"]:
+        bucket["raw_pass"] += 1 if first["verdict"] == "pass" else 0
+        adjusted = _adjusted_blocking(first["blocking_rules_fired"], arm)
+        bucket["adj_pass"] += 1 if not adjusted else 0
+        bucket["cmp_pass"] += 1 if not _comparable_blocking(first["blocking_rules_fired"]) else 0
+        bucket["chars"].append(first["chars"])
+        for rule in first["rules_fired"]:
             bucket["rule_fires"][rule] = bucket["rule_fires"].get(rule, 0) + 1
     return bucket
+
+
+def _bucket_loop(rows: list[dict]) -> dict:
+    """Rows here have already been filtered to non-partial, non-fully-errored."""
+    bucket = {
+        "n": 0, "raw_pass": 0, "chars": [], "rounds_to_pass": [], "never_in_3": 0,
+        "rule_fires_final": {},
+    }
+    for row in rows:
+        last = row["rounds"][-1]
+        bucket["n"] += 1
+        bucket["raw_pass"] += 1 if last["verdict"] == "pass" else 0
+        bucket["chars"].append(last["chars"])
+        rtp = row.get("rounds_to_pass")
+        bucket["rounds_to_pass"].append(rtp)
+        if rtp is None:
+            bucket["never_in_3"] += 1
+        for rule in last["rules_fired"]:
+            bucket["rule_fires_final"][rule] = bucket["rule_fires_final"].get(rule, 0) + 1
+    return bucket
+
+
+def _report_two_sample(label: str, p1: float, n1: int, p2: float, n2: int) -> None:
+    delta = p1 - p2
+    se = _pooled_se(p1, n1, p2, n2)
+    band = 1.96 * se
+    n_total = n1 + n2
+    if se == 0:
+        if delta == 0:
+            verdict = "the effect is not measurable at this sample size (both arms unanimous, SE=0)"
+        else:
+            verdict = (
+                f"full separation at n={n_total} (both arms unanimous, pooled SE=0); "
+                "treat as provisional, not settled, until n grows"
+            )
+    elif abs(delta) < band:
+        verdict = "the effect is not measurable at this sample size"
+    else:
+        verdict = "clears the noise band"
+    print(
+        f"{label}: delta {delta:+.0%}, n={n_total} "
+        f"(pooled SE={se:.0%}, 95% band +/-{band:.0%}) -> {verdict}"
+    )
 
 
 def cmd_score(args: argparse.Namespace) -> int:
@@ -236,96 +545,169 @@ def cmd_score(args: argparse.Namespace) -> int:
         return 1
 
     rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
-    errored = [row for row in rows if "error" in row]
-    scored = [row for row in rows if "error" not in row]
+    fully_errored = [row for row in rows if _fully_errored(row)]
+    partial = [row for row in rows if not _fully_errored(row) and _partial(row)]
+    usable = [row for row in rows if not _fully_errored(row)]
+    completed = [row for row in usable if not _partial(row)]
 
-    buckets = {arm: _bucket([row for row in scored if row["arm"] == arm]) for arm in ARMS}
-
-    print(f"scored {len(scored)} runs, {len(errored)} errored (excluded from all rates below)")
-    print()
     print(
-        "ai-disclosure-missing is excluded from the without-skill arm's pass/fail "
-        "rate below: that arm was never told the disclosure requirement exists, "
-        "so scoring it against that rule would manufacture a difference that "
-        "reflects what the prompt withheld, not what the skill's prose teaches. "
-        "It IS counted for with-skill, since SKILL.md states the requirement."
+        f"{len(rows)} runs total: {len(usable)} produced at least a first draft, "
+        f"{len(fully_errored)} errored before any draft (excluded from everything), "
+        f"{len(partial)} errored mid-loop after a draft (first draft counted below, "
+        "loop-completion metrics excluded)."
     )
     print()
+    print(CAVEAT)
+    print()
 
+    fix_text_rows = [row for row in completed if row.get("retry_mode", "fix-text") == "fix-text"]
+    fix_text_usable = [row for row in usable if row.get("retry_mode", "fix-text") == "fix-text"]
+
+    print("=== Experiment A: first-draft pass rate per arm ===")
+    print(
+        "Like-for-like: every arm scored on the same rules, excluding any rule some\n"
+        "arm was never taught (" + ", ".join(sorted(COMPARABLE_UNTAUGHT)) + "). Scoring each\n"
+        "arm against only its own taught rules compares them to different rulebooks."
+    )
+    print()
+    first_draft_buckets = {
+        arm: _bucket_first_draft([r for r in usable if r["arm"] == arm], arm) for arm in ARMS
+    }
     for arm in ARMS:
-        b = buckets[arm]
+        b = first_draft_buckets[arm]
         if b["n"] == 0:
             print(f"{arm}: no runs")
             continue
-        rate = b["adj_pass"] / b["n"]
+        rate = b["cmp_pass"] / b["n"]
+        band = 1.96 * _single_se(rate, b["n"])
         print(
-            f"{arm}: {b['adj_pass']}/{b['n']} pass ({rate:.0%}), "
-            f"median body length {statistics.median(b['chars']):.0f} chars"
+            f"{arm}: {b['cmp_pass']}/{b['n']} pass ({rate:.0%} +/-{band:.0%}, n={b['n']}), "
+            f"median length {statistics.median(b['chars']):.0f} chars"
         )
-
-    without = buckets["without-skill"]
-    if without["n"]:
-        raw_denied = without["n"] - without["raw_pass"]
-        print()
-        print(
-            f"gate counterfactual: {raw_denied}/{without['n']} without-skill bodies "
-            "would have been denied outright by the pr-body-gate hook (raw scorer "
-            "verdict, ai-disclosure-missing included, since the hook does not know "
-            "or care what the author was told). This is what the gate buys on its "
-            "own, independent of whether the skill's prose teaches anything."
-        )
-
-    with_skill = buckets["with-skill"]
     print()
-    if with_skill["n"] and without["n"]:
-        p1 = with_skill["adj_pass"] / with_skill["n"]
-        p2 = without["adj_pass"] / without["n"]
-        delta = p1 - p2
-        se = _pooled_se(p1, with_skill["n"], p2, without["n"])
-        n_total = with_skill["n"] + without["n"]
-        print(
-            f"delta (with-skill minus without-skill): {delta:+.0%}, "
-            f"n_with-skill={with_skill['n']} n_without-skill={without['n']}"
-        )
-        if se == 0:
-            if delta == 0:
-                print("The skill shows no measurable effect at this sample size.")
-            else:
-                print(
-                    f"Full separation at n_with-skill={with_skill['n']} "
-                    f"n_without-skill={without['n']} (both arms are unanimous, so "
-                    "the pooled standard error is 0). Treat as provisional evidence, "
-                    "not a settled result, until the sample size grows."
-                )
-        elif abs(delta) < 1.96 * se:
-            print(
-                f"That delta is within noise for n={n_total} (pooled SE={se:.0%}, "
-                f"95% band is +/-{1.96 * se:.0%}). The skill shows no measurable "
-                "effect at this sample size."
-            )
-        else:
-            print(
-                f"That delta clears the noise band for n={n_total} "
-                f"(pooled SE={se:.0%}, 95% band is +/-{1.96 * se:.0%})."
-            )
+    baseline = first_draft_buckets["none"]
+    if baseline["n"]:
+        p2 = baseline["cmp_pass"] / baseline["n"]
+        for arm in ("example", "rules", "full"):
+            b = first_draft_buckets[arm]
+            if b["n"] == 0:
+                continue
+            p1 = b["cmp_pass"] / b["n"]
+            _report_two_sample(f"{arm} vs none (first draft)", p1, b["n"], p2, baseline["n"])
     else:
-        print("delta: not computable, one or both arms have zero runs")
+        print("delta: not computable, no runs for arm 'none'")
 
     print()
-    print("per-rule fire rate (raw, unadjusted):")
-    all_rules = sorted(set(with_skill["rule_fires"]) | set(without["rule_fires"]))
-    if not all_rules:
-        print("  (no rules fired in either arm)")
-    for rule in all_rules:
-        w = with_skill["rule_fires"].get(rule, 0) / with_skill["n"] if with_skill["n"] else 0.0
-        wo = without["rule_fires"].get(rule, 0) / without["n"] if without["n"] else 0.0
-        print(f"  {rule:<24} with-skill {w:>4.0%}   without-skill {wo:>4.0%}")
+    print("per-rule fire rate at first draft (raw, unadjusted, pooled across arms):")
+    all_first_rules: dict[str, int] = {}
+    total_first_n = 0
+    for arm in ARMS:
+        b = first_draft_buckets[arm]
+        total_first_n += b["n"]
+        for rule, count in b["rule_fires"].items():
+            all_first_rules[rule] = all_first_rules.get(rule, 0) + count
+    if not all_first_rules or total_first_n == 0:
+        print("  (no rules fired, or no runs)")
+    for rule in sorted(all_first_rules):
+        rate = all_first_rules[rule] / total_first_n
+        print(f"  {rule:<24} {rate:>4.0%}  (n={total_first_n})")
 
-    if errored:
+    print()
+    print("=== Experiment B: the deny-and-fix loop (retry_mode=fix-text) ===")
+    print()
+    if not fix_text_rows:
+        print("no completed fix-text loop runs to score")
+    else:
+        loop_buckets = {arm: _bucket_loop([r for r in fix_text_rows if r["arm"] == arm]) for arm in ARMS}
+        for arm in ARMS:
+            b = loop_buckets[arm]
+            if b["n"] == 0:
+                print(f"{arm}: no completed loop runs")
+                continue
+            rate = b["raw_pass"] / b["n"]
+            band = 1.96 * _single_se(rate, b["n"])
+            never_rate = b["never_in_3"] / b["n"]
+            never_band = 1.96 * _single_se(never_rate, b["n"])
+            finite = [r for r in b["rounds_to_pass"] if r is not None]
+            median_rounds = statistics.median(finite) if finite else "n/a"
+            print(
+                f"{arm}: final pass {b['raw_pass']}/{b['n']} ({rate:.0%} +/-{band:.0%}, n={b['n']}), "
+                f"never-pass-in-3 {b['never_in_3']}/{b['n']} ({never_rate:.0%} +/-{never_band:.0%}), "
+                f"median rounds-to-pass (of those that pass) {median_rounds}, "
+                f"median final length {statistics.median(b['chars']):.0f} chars"
+            )
+            counts = {}
+            for r in b["rounds_to_pass"]:
+                key = "never" if r is None else str(r)
+                counts[key] = counts.get(key, 0) + 1
+            dist = ", ".join(f"{k}:{v}" for k, v in sorted(counts.items()))
+            print(f"  rounds_to_pass distribution: {dist}")
+
         print()
-        print(f"{len(errored)} runs errored and were excluded:")
-        for row in errored[:10]:
-            print(f"  {row.get('arm')} {row.get('diff')} {row.get('model')}: {row.get('error')}")
+        print("median body length, first draft vs final (fix-text only):")
+        for arm in ARMS:
+            b = loop_buckets[arm]
+            fb = first_draft_buckets[arm]
+            if b["n"] == 0 or fb["n"] == 0:
+                continue
+            print(
+                f"  {arm:<8} first {statistics.median(fb['chars']):>6.0f} chars -> "
+                f"final {statistics.median(b['chars']):>6.0f} chars"
+            )
+
+        print()
+        print("per-rule fire rate, first draft vs final (fix-text, pooled across arms):")
+        first_pool: dict[str, int] = {}
+        final_pool: dict[str, int] = {}
+        n_pool = len(fix_text_rows)
+        for row in fix_text_rows:
+            for rule in row["rounds"][0]["rules_fired"]:
+                first_pool[rule] = first_pool.get(rule, 0) + 1
+            for rule in row["rounds"][-1]["rules_fired"]:
+                final_pool[rule] = final_pool.get(rule, 0) + 1
+        all_rules = sorted(set(first_pool) | set(final_pool))
+        if not all_rules:
+            print("  (no rules fired)")
+        for rule in all_rules:
+            first_rate = first_pool.get(rule, 0) / n_pool if n_pool else 0.0
+            final_rate = final_pool.get(rule, 0) / n_pool if n_pool else 0.0
+            flag = ""
+            if final_pool.get(rule, 0) > 0 and final_rate >= 0.20:
+                flag = "  <-- SURVIVES THE LOOP: told exactly what is wrong and still fires; likely a defect in this rule or its fix text"
+            print(f"  {rule:<24} first {first_rate:>4.0%}  final {final_rate:>4.0%}{flag}")
+
+    print()
+    print("=== Experiment C: fix-text vs rule-names on rounds-to-pass ===")
+    print()
+    rule_names_rows = [row for row in completed if row.get("retry_mode") == "rule-names"]
+    if not rule_names_rows:
+        print("no rule-names runs recorded; run with --retry-modes fix-text,rule-names to compare")
+    else:
+        for label, subset in (("fix-text", fix_text_rows), ("rule-names", rule_names_rows)):
+            n = len(subset)
+            converged = sum(1 for r in subset if r.get("rounds_to_pass") is not None)
+            rate = converged / n if n else 0.0
+            band = 1.96 * _single_se(rate, n)
+            finite = [r["rounds_to_pass"] for r in subset if r.get("rounds_to_pass") is not None]
+            median_rounds = statistics.median(finite) if finite else "n/a"
+            print(
+                f"{label}: converged-in-3 {converged}/{n} ({rate:.0%} +/-{band:.0%}, n={n}), "
+                f"median rounds-to-pass (of those that pass) {median_rounds}"
+            )
+        n1, n2 = len(fix_text_rows), len(rule_names_rows)
+        if n1 and n2:
+            p1 = sum(1 for r in fix_text_rows if r.get("rounds_to_pass") is not None) / n1
+            p2 = sum(1 for r in rule_names_rows if r.get("rounds_to_pass") is not None) / n2
+            _report_two_sample("fix-text vs rule-names (converged-in-3)", p1, n1, p2, n2)
+            if abs(p1 - p2) < 1.96 * _pooled_se(p1, n1, p2, n2):
+                print(
+                    "rule-names converges as fast as fix-text within noise: the fix "
+                    "text is not shown to be earning its keep at this sample size."
+                )
+
+    if not fix_text_usable and not rule_names_rows:
+        print()
+        print("(nothing scored yet; run 'run' first)")
 
     return 0
 
@@ -334,9 +716,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    r = sub.add_parser("run", help="generate PR bodies with and without SKILL.md in context")
+    sl = sub.add_parser("slices", help="print each arm's slice character count and exit")
+    sl.set_defaults(func=cmd_slices)
+
+    r = sub.add_parser("run", help="generate PR bodies across arms, then run the deny-and-fix loop")
     r.add_argument("--models", default="claude-sonnet-5")
     r.add_argument("--arms", default=",".join(ARMS))
+    r.add_argument("--retry-modes", default="fix-text")
     r.add_argument(
         "--diffs",
         help="comma-separated fixture filenames, default all under bench/fixtures/pr-body",

--- a/bench/pr_body_bench.py
+++ b/bench/pr_body_bench.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Measure whether the pr-body skill's prose teaches a model to write a passing body.
+
+Two arms run the same 8 real diffs through the same model: `with-skill` puts
+`skills/pr-body/SKILL.md` in the prompt, `without-skill` gets only the diff.
+Each resulting body is scored by `pr_body_lint.py` itself (the judge; no LLM
+rubric), so this measures whether the prose teaches, as distinct from the
+pr-body-gate hook that enforces compliance after the fact.
+
+Usage:
+  python3 bench/pr_body_bench.py run --models claude-sonnet-5 --repeats 2
+  python3 bench/pr_body_bench.py score
+
+Fixtures live in bench/fixtures/pr-body/ and results in bench/results/pr-body/,
+both gitignored: the diffs and the bodies written about them come from a private
+estate. Point --diffs at your own. Aggregate numbers from the run behind this
+skill are in docs/pr-body-measurement.md.
+
+`run` is resumable: it skips (arm, diff, model, repeat) combinations already
+present in the target jsonl, and appends new results one at a time so an
+interrupted run loses nothing already written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import importlib.util
+import json
+import math
+import pathlib
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parent
+# Own subdirectory: bench/results/ is shared with bench.py, whose tag names
+# (v1, v2, shipped) would otherwise collide with these.
+RESULTS = ROOT / "results" / "pr-body"
+FIXTURES = ROOT / "fixtures" / "pr-body"
+SKILL_MD = REPO_ROOT / "skills" / "pr-body" / "SKILL.md"
+LINT_SCRIPT = REPO_ROOT / "skills" / "pr-body" / "scripts" / "pr_body_lint.py"
+
+ARMS = ("with-skill", "without-skill")
+
+# ai-disclosure-missing is the one rule SKILL.md teaches that the raw diff
+# does not mention at all. Excluded from the without-skill arm's pass/fail
+# rate: that arm was never told the requirement exists, so counting it there
+# would manufacture a difference that reflects what the prompt withheld, not
+# what the skill's prose teaches.
+UNTAUGHT_RULES_BY_ARM = {
+    "without-skill": {"ai-disclosure-missing"},
+    "with-skill": set(),
+}
+
+
+def _load_lint():
+    spec = importlib.util.spec_from_file_location("pr_body_lint", LINT_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+LINT = _load_lint()
+
+
+def scratch_project() -> pathlib.Path:
+    """A project dir with no CLAUDE.md, hooks, or output style to bias the model."""
+    d = pathlib.Path(tempfile.mkdtemp(prefix="pr-body-bench-"))
+    (d / ".claude").mkdir()
+    (d / ".claude" / "settings.json").write_text("{}\n")
+    return d
+
+
+PROMPT_TEMPLATE = """Here is a diff for a pull request.
+
+```diff
+{diff}
+```
+
+Write the PR body text for this change: the text that would be passed to
+`gh pr create --body-file`. Reply with the body text only. No preamble, no
+explanation of what you are about to do, no code fence around the body."""
+
+
+def build_prompt(diff_text: str, arm: str) -> str:
+    prompt = PROMPT_TEMPLATE.format(diff=diff_text)
+    if arm == "with-skill":
+        skill_text = SKILL_MD.read_text(encoding="utf-8")
+        prompt = f"{skill_text}\n\n---\n\n{prompt}"
+    return prompt
+
+
+def score_body(body: str) -> dict:
+    result = LINT.lint(body)
+    findings = result["findings"]
+    return {
+        "chars": len(body),
+        "verdict": result["verdict"],
+        "rules_fired": sorted({f["rule"] for f in findings}),
+        "blocking_rules_fired": sorted(
+            {f["rule"] for f in findings if f["severity"] == "block"}
+        ),
+    }
+
+
+def one_run(project: pathlib.Path, model: str, arm: str, diff_path: pathlib.Path) -> dict:
+    diff_text = diff_path.read_text(encoding="utf-8")
+    prompt = build_prompt(diff_text, arm)
+    row = {"arm": arm, "diff": diff_path.name, "model": model}
+    cmd = [
+        "claude", "-p", "--model", model,
+        "--setting-sources", "project",
+        "--output-format", "json",
+    ]
+    # Prompt goes on stdin, never argv: the with-skill arm starts with SKILL.md's
+    # `---` frontmatter, which argv parsing reads as a flag.
+    proc = subprocess.run(cmd, cwd=project, input=prompt,
+                          capture_output=True, text=True, timeout=900)
+    if proc.returncode != 0:
+        row["error"] = proc.stderr.strip()[:400]
+        return row
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as error:
+        row["error"] = f"non-JSON output: {error}"
+        return row
+    body = payload.get("result", "")
+    row["body"] = body
+    row["output_tokens"] = payload.get("usage", {}).get("output_tokens")
+    row.update(score_body(body))
+    return row
+
+
+def _completed_keys(path: pathlib.Path) -> set[tuple[str, str, str, int]]:
+    if not path.exists():
+        return set()
+    keys = set()
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not {"arm", "diff", "model"} <= row.keys():
+            continue
+        keys.add((row["arm"], row["diff"], row["model"], row.get("repeat", 0)))
+    return keys
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    diffs = sorted(FIXTURES.glob("*.diff"))
+    if args.diffs:
+        wanted = set(args.diffs.split(","))
+        diffs = [d for d in diffs if d.name in wanted]
+    if not diffs:
+        print(f"no fixtures found under {FIXTURES}", file=sys.stderr)
+        return 1
+
+    models = args.models.split(",")
+    arms = args.arms.split(",")
+    for arm in arms:
+        if arm not in ARMS:
+            print(f"unknown arm {arm!r}, must be one of {ARMS}", file=sys.stderr)
+            return 1
+
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    out = RESULTS / f"{args.tag}.jsonl"
+    done_keys = _completed_keys(out)
+
+    jobs = [
+        (model, arm, diff, repeat)
+        for model in models
+        for arm in arms
+        for diff in diffs
+        for repeat in range(args.repeats)
+        if (arm, diff.name, model, repeat) not in done_keys
+    ]
+    if not jobs:
+        print(f"all {len(done_keys)} runs already recorded in {out}; nothing to do", file=sys.stderr)
+        return 0
+
+    project = scratch_project()
+    total = len(jobs)
+    try:
+        with out.open("a") as fh, concurrent.futures.ThreadPoolExecutor(args.jobs) as pool:
+            futures = {
+                pool.submit(one_run, project, model, arm, diff): (model, arm, diff, repeat)
+                for model, arm, diff, repeat in jobs
+            }
+            completed = 0
+            for fut in concurrent.futures.as_completed(futures):
+                model, arm, diff, repeat = futures[fut]
+                try:
+                    row = fut.result()
+                except Exception as exc:  # noqa: BLE001 - one job's crash must not lose the rest
+                    row = {"arm": arm, "diff": diff.name, "model": model, "error": repr(exc)[:400]}
+                row["repeat"] = repeat
+                fh.write(json.dumps(row) + "\n")
+                fh.flush()
+                completed += 1
+                print(f"{completed}/{total} {model} {arm} {diff.name} rep{repeat}", file=sys.stderr)
+    finally:
+        shutil.rmtree(project, ignore_errors=True)
+
+    print(out)
+    return 0
+
+
+def _adjusted_blocking(row: dict) -> list[str]:
+    untaught = UNTAUGHT_RULES_BY_ARM.get(row["arm"], set())
+    return [rule for rule in row["blocking_rules_fired"] if rule not in untaught]
+
+
+def _pooled_se(p1: float, n1: int, p2: float, n2: int) -> float:
+    return math.sqrt(p1 * (1 - p1) / n1 + p2 * (1 - p2) / n2)
+
+
+def _bucket(rows: list[dict]) -> dict:
+    bucket = {"n": 0, "raw_pass": 0, "adj_pass": 0, "chars": [], "rule_fires": {}}
+    for row in rows:
+        bucket["n"] += 1
+        bucket["raw_pass"] += 1 if row["verdict"] == "pass" else 0
+        bucket["adj_pass"] += 1 if not _adjusted_blocking(row) else 0
+        bucket["chars"].append(row["chars"])
+        for rule in row["rules_fired"]:
+            bucket["rule_fires"][rule] = bucket["rule_fires"].get(rule, 0) + 1
+    return bucket
+
+
+def cmd_score(args: argparse.Namespace) -> int:
+    path = RESULTS / f"{args.tag}.jsonl"
+    if not path.exists():
+        print(f"no results at {path}", file=sys.stderr)
+        return 1
+
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    errored = [row for row in rows if "error" in row]
+    scored = [row for row in rows if "error" not in row]
+
+    buckets = {arm: _bucket([row for row in scored if row["arm"] == arm]) for arm in ARMS}
+
+    print(f"scored {len(scored)} runs, {len(errored)} errored (excluded from all rates below)")
+    print()
+    print(
+        "ai-disclosure-missing is excluded from the without-skill arm's pass/fail "
+        "rate below: that arm was never told the disclosure requirement exists, "
+        "so scoring it against that rule would manufacture a difference that "
+        "reflects what the prompt withheld, not what the skill's prose teaches. "
+        "It IS counted for with-skill, since SKILL.md states the requirement."
+    )
+    print()
+
+    for arm in ARMS:
+        b = buckets[arm]
+        if b["n"] == 0:
+            print(f"{arm}: no runs")
+            continue
+        rate = b["adj_pass"] / b["n"]
+        print(
+            f"{arm}: {b['adj_pass']}/{b['n']} pass ({rate:.0%}), "
+            f"median body length {statistics.median(b['chars']):.0f} chars"
+        )
+
+    without = buckets["without-skill"]
+    if without["n"]:
+        raw_denied = without["n"] - without["raw_pass"]
+        print()
+        print(
+            f"gate counterfactual: {raw_denied}/{without['n']} without-skill bodies "
+            "would have been denied outright by the pr-body-gate hook (raw scorer "
+            "verdict, ai-disclosure-missing included, since the hook does not know "
+            "or care what the author was told). This is what the gate buys on its "
+            "own, independent of whether the skill's prose teaches anything."
+        )
+
+    with_skill = buckets["with-skill"]
+    print()
+    if with_skill["n"] and without["n"]:
+        p1 = with_skill["adj_pass"] / with_skill["n"]
+        p2 = without["adj_pass"] / without["n"]
+        delta = p1 - p2
+        se = _pooled_se(p1, with_skill["n"], p2, without["n"])
+        n_total = with_skill["n"] + without["n"]
+        print(
+            f"delta (with-skill minus without-skill): {delta:+.0%}, "
+            f"n_with-skill={with_skill['n']} n_without-skill={without['n']}"
+        )
+        if se == 0:
+            if delta == 0:
+                print("The skill shows no measurable effect at this sample size.")
+            else:
+                print(
+                    f"Full separation at n_with-skill={with_skill['n']} "
+                    f"n_without-skill={without['n']} (both arms are unanimous, so "
+                    "the pooled standard error is 0). Treat as provisional evidence, "
+                    "not a settled result, until the sample size grows."
+                )
+        elif abs(delta) < 1.96 * se:
+            print(
+                f"That delta is within noise for n={n_total} (pooled SE={se:.0%}, "
+                f"95% band is +/-{1.96 * se:.0%}). The skill shows no measurable "
+                "effect at this sample size."
+            )
+        else:
+            print(
+                f"That delta clears the noise band for n={n_total} "
+                f"(pooled SE={se:.0%}, 95% band is +/-{1.96 * se:.0%})."
+            )
+    else:
+        print("delta: not computable, one or both arms have zero runs")
+
+    print()
+    print("per-rule fire rate (raw, unadjusted):")
+    all_rules = sorted(set(with_skill["rule_fires"]) | set(without["rule_fires"]))
+    if not all_rules:
+        print("  (no rules fired in either arm)")
+    for rule in all_rules:
+        w = with_skill["rule_fires"].get(rule, 0) / with_skill["n"] if with_skill["n"] else 0.0
+        wo = without["rule_fires"].get(rule, 0) / without["n"] if without["n"] else 0.0
+        print(f"  {rule:<24} with-skill {w:>4.0%}   without-skill {wo:>4.0%}")
+
+    if errored:
+        print()
+        print(f"{len(errored)} runs errored and were excluded:")
+        for row in errored[:10]:
+            print(f"  {row.get('arm')} {row.get('diff')} {row.get('model')}: {row.get('error')}")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("run", help="generate PR bodies with and without SKILL.md in context")
+    r.add_argument("--models", default="claude-sonnet-5")
+    r.add_argument("--arms", default=",".join(ARMS))
+    r.add_argument(
+        "--diffs",
+        help="comma-separated fixture filenames, default all under bench/fixtures/pr-body",
+    )
+    r.add_argument("--repeats", type=int, default=1)
+    r.add_argument("--jobs", type=int, default=4)
+    r.add_argument("--tag", default="pr-body-latest")
+    r.set_defaults(func=cmd_run)
+
+    s = sub.add_parser("score", help="score a run's jsonl with pr_body_lint.py")
+    s.add_argument("--tag", default="pr-body-latest")
+    s.set_defaults(func=cmd_score)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/pr-body-measurement.md
+++ b/docs/pr-body-measurement.md
@@ -60,7 +60,48 @@ the author of all 25.
 That last line is why the gate checks a receipt from a judge rather than a lint
 exit code.
 
-## 3. Does the skill's prose teach?
+## 3. What actually works: the loop
+
+256 runs, 4 arms, 8 real diffs, up to 3 deny-and-fix rounds each. The arms differ
+only in how much of `SKILL.md` the model gets.
+
+Every arm converges. Including the one given nothing.
+
+| arm | prompt size | first draft | after the loop | median rounds |
+| --- | --- | --- | --- | --- |
+| none | 0 chars | 59% | 100% | 1 |
+| example | 452 chars | 86% | 97% | 1 |
+| rules | 2,550 chars | 97% | 100% | 1 |
+| full | 9,482 chars | 94% | 100% | 0 |
+
+First-draft rates are like-for-like: every arm scored on the same rules,
+excluding the disclosure rule that two arms are never taught. Scoring each arm
+against only its own taught rules compares them to different rulebooks, and on
+the first run of this bench that alone reversed where `full` ranked.
+
+Three findings.
+
+**The loop is the mechanism.** A model handed no guidance writes a failing body
+59% of the time and a passing one after a single round of being told what is
+wrong. Guidance moves the first draft; the loop moves the outcome. This is the
+argument for enforcing at the tool call rather than shipping a document.
+
+**The rules lists carry all of the teaching.** 2,550 characters reach 97%. The
+full 9,482-character skill reaches 94%, and the difference is inside noise. About
+7,000 characters buy nothing measurable on this metric. The worked example alone,
+452 characters, reaches 86% by itself.
+
+The remaining bulk of `SKILL.md` is workflow documentation, the verbs, the gate,
+and the limits. This experiment does not measure those and cannot, so the finding
+is that the prose does not teach a first draft, not that it should be deleted.
+
+**The fix text is decoration.** Sending bare rule names converges as fast as
+sending the written fix instructions, 100% against 99%, inside noise. The model
+does not need to be told how to fix an em dash, only that there is one. The fix
+text stays because a human reading `audit` output benefits from it, not because
+it changes a model's behavior.
+
+## 4. Does the skill's prose teach on its own?
 
 128 runs, one model, 8 real diffs, 8 repeats per arm. `with-skill` gets
 `SKILL.md` in the prompt; `without-skill` gets only the diff. Every output scored

--- a/docs/pr-body-measurement.md
+++ b/docs/pr-body-measurement.md
@@ -1,0 +1,89 @@
+# What the pr-body gate is worth
+
+Three measurements behind `skills/pr-body`. Two of them refuted rules that were
+already written and about to ship.
+
+The inputs are one engineer's 242 merged pull requests across a private
+enterprise estate, so the raw corpus, the eval fixtures and the eval outputs are
+not in this repo. Only the aggregate numbers are. `bench/pr_body_bench.py`
+reproduces the third measurement against any set of diffs you point it at.
+
+## 1. The corpus, and three rules that died in it
+
+242 merged PRs, 2024-03 to 2026-08, split into a human-written era (through
+2025-12) and an AI-written era (2026 onward). Rates below are AI-era vs
+human-era.
+
+| signal | AI-era | human-era | verdict |
+| --- | --- | --- | --- |
+| em dash | 26% | 0% | shipped |
+| emoji | 29% | 0% | shipped |
+| file path in prose | 24% | 2% | shipped |
+| reviewer instruction | 13% | 0% | shipped, as preference |
+| method narration | 7% | 0% | shipped |
+| checkbox list | 18% | 0% | **refused** |
+| markdown header | 79% | 83% | **refused** |
+| AI vocabulary wordlist | 1% | 1% | **refused** |
+
+Markdown headers are not a tell. The repos ship
+`.github/pull_request_template.md`, so a header rule would have flagged the
+human-written era hardest. The Freeburg suppression study across 12 models
+reaches the same place from the other direction: headers and bullets vanish the
+moment a model is told to drop markdown, so they are near-pure
+instruction-following.
+
+Wordlists ("comprehensive", "leverage", "robust", "seamlessly") hit 1% in both
+eras. The published detection literature is against the approach as a class.
+
+Checkboxes were the instructive one. A clean 18% / 0% split, and still not a
+defect: they carry real information when a template ships them, when they record
+testing done, and when they list post-merge steps. A corpus rate alone cannot
+justify a rule, because a clean discriminator can just as easily be a good
+practice someone started using.
+
+## 2. Hand labels, which inverted the assumed ground truth
+
+25 bodies sampled across both eras, shuffled, dates hidden, labeled pass/fail by
+the author of all 25.
+
+* **The era proxy runs backwards.** AI-era bodies pass at 69%, human-era at 33%.
+  A regression test treating "AI-era" as "bad" would have tuned the linter in the
+  wrong direction while reporting green.
+* **Length does not separate.** Passing bodies span 80 to 2242 characters,
+  failing ones 0 to 1703. The best single threshold reaches 72% against a 50%
+  baseline, and earns all of it at the bottom end. A length ceiling was built,
+  measured, and deleted.
+* **The linter sees a third of it.** 4 of 12 rejected bodies, all empty or
+  near-empty. Every miss was a phrasing judgment: pretentious, juvenile, too much
+  prose for not enough action, too many parentheses.
+
+That last line is why the gate checks a receipt from a judge rather than a lint
+exit code.
+
+## 3. Does the skill's prose teach?
+
+128 runs, one model, 8 real diffs, 8 repeats per arm. `with-skill` gets
+`SKILL.md` in the prompt; `without-skill` gets only the diff. Every output scored
+by `pr_body_lint.py`.
+
+| | with-skill | without-skill |
+| --- | --- | --- |
+| pass rate | 61% (39/64) | 53% (34/64) |
+| median length | 380 chars | 634 chars |
+| em dash fires | 5% | 45% |
+| disclosure line missing | 38% | 100% |
+
+**The headline delta is noise.** +8% against a pooled 95% band of ±17%. On
+overall pass rate, the prose shows no measurable effect at this sample size.
+
+Two numbers underneath it are not noise. Em dashes drop from 45% to 5%, so a
+concrete, mechanical rule does transfer. And the disclosure line, which `SKILL.md`
+states outright, is still missing from 38% of bodies written with `SKILL.md` in
+context.
+
+That 38% is the argument for the whole design. The instruction is present,
+unambiguous, and one sentence long, and the model drops it more than a third of
+the time. Advice does not hold. The gate is what holds.
+
+For reference, 64 of 64 unaided bodies would have been denied outright by the
+hook.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -14,6 +14,7 @@ SKILLS = ROOT / "skills"
 EXPECTED = {
     "drive-local-webapp",
     "code-review",
+    "pr-body",
     "say-less",
     "cbm-onboard",
     "ci-design",

--- a/skills/pr-body/SKILL.md
+++ b/skills/pr-body/SKILL.md
@@ -184,6 +184,12 @@ a lint exit code) is what the hook checks. A body that passes the linter has
 been checked for countable defects only. Do not read a pass as a verdict that
 the body is good.
 
+A denial is not a setback. Measured over 256 runs, a body that fails the linter
+passes after one round of fixing, and an author given no guidance at all
+converges as fast as one given the whole of this file. Fix the findings and move
+on; do not rewrite from scratch. Measurements:
+[docs/pr-body-measurement.md](../../docs/pr-body-measurement.md).
+
 ## Rules the scorer implements
 
 `scripts/pr_body_lint.py` is the only rule engine. A rule named here and absent

--- a/skills/pr-body/SKILL.md
+++ b/skills/pr-body/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: pr-body
+description: Write a pull-request body and score it before the PR is opened, or audit an existing PR's body against the same rubric. Use when about to run gh pr create, when a PR body needs writing or rewriting, or when asked whether a PR description is any good. Invoked as /pr-body write <body-file> or /pr-body audit <pr>.
+---
+
+# PR body
+
+The body is for whoever merges the change. It carries facts about the change in
+the system's own terms. The diff already carries the files.
+
+Start from a real one. A Pulumi PR that grows a GHES appliance data volume:
+
+```markdown
+Grows the appliance data volume from 2 TB to 4 TB. It has been
+running near capacity.
+
+* Volume size 2000 to 4000 GiB.
+* Resources: 1 to update.
+
+EBS expands online. The filesystem grows on the next boot.
+
+This PR was written in part with the assistance of generative AI.
+```
+
+No headings. No reason the author does not actually know. No advice for the
+reviewer. Nothing that rates the change. Everything below is that example,
+generalized.
+
+## The shape
+
+1. **Open with the action, and put the situation behind it.** "Grows the volume
+   from 2 TB to 4 TB. It has been running near capacity." The situation is
+   support for the action, not a runway to it.
+2. **Never invent the motivation.** Write only what you know. "Before the next
+   release cycle" is an assumption dressed as a fact, and a reviewer who knows
+   the schedule will spot it. If nobody told you why, the body says what
+   changed and stops.
+3. **Flat bullets, at the level of behavior.** No `Summary` / `Changes` /
+   `Testing` scaffolding you invented. If the repo ships a PR template, fill its
+   sections; if it does not, the body has no headings.
+4. **One bullet per genuinely distinct fact.** Three bullets that restate each
+   other are one fact and two lines of padding. Never a bullet per file.
+5. **Evidence is the raw number, not the method.** `Resources: 1 to update`
+   beats a sentence about running preview against dev and prd. The reader wants
+   the result; the method is the author's business.
+6. **Risk is the one place prose belongs, and only the mechanism half.** "EBS
+   expands online, no downtime." State how the system behaves. Do not rate the
+   change.
+7. **Say nothing to the reviewer.** No "worth checking", no "please review the
+   IAM change". Telling a reviewer where to look is telling them where not to.
+8. **Length follows the facts.** One line when there is no risk and no context
+   worth stating. Longer when a change carries three genuine risks. There is no
+   target and no ceiling. A body is as long as the true statements about the
+   change and no longer.
+
+## Textures to cut
+
+* **Verdict clauses.** "This is a low-risk change", "no downtime is expected",
+  "improves maintainability", "should have no impact". These rate the change
+  instead of describing it, and every one of them is a claim the reader cannot
+  check. Banned as a class, not as a wordlist.
+* **Parenthetical asides.** One per body at most. Past that they read as an
+  author arguing with themselves.
+* **Inline code spans and symbol names.** Name the behavior. A function name in
+  prose sends the reader to the diff to find out what the sentence meant.
+* **Paragraphs where bullets serve.** If it is a list of facts, make it a list.
+* **Prose volume with no action behind it.** Three paragraphs on a two-line
+  change is the most common failure in the labeled set.
+* **Pretentious or juvenile phrasing.** Write the plain sentence.
+* **An em dash** (use parens or two sentences), **emoji**, `-` bullets, and
+  capitalized host or resource names.
+
+## Before and after
+
+Invented motivation, and the action buried:
+
+> As part of our ongoing capacity work ahead of the Q3 release, and because the
+> appliance has been under pressure for some time, this PR increases the data
+> volume.
+
+Becomes:
+
+> Grows the appliance data volume from 2 TB to 4 TB. It has been running near
+> capacity.
+
+Invented scaffolding, and a bullet per file:
+
+> ## Summary
+> ## Changes
+> * `pulumi/volumes.go`: change size
+> * `pulumi/Pulumi.prd.yaml`: bump config
+> ## Testing
+> Ran preview.
+
+Becomes:
+
+> Grows the appliance data volume from 2 TB to 4 TB.
+>
+> * Resources: 1 to update.
+
+Verdict and method narration, replaced by mechanism and number:
+
+> This is a low-risk change and should have no impact. I verified it with
+> pulumi preview against dev and prd.
+
+Becomes:
+
+> EBS expands online. The filesystem grows on the next boot.
+>
+> * Resources: 1 to update.
+
+## Verbs
+
+### write
+
+Score a body file, run the judge, and write a receipt on pass. This is the path
+the hook requires.
+
+1. Write the body to a file. The hook only reads `--body-file`, so the file has
+   to exist anyway.
+2. Run the scorer against it, with the target repo so it can read the repo's PR
+   template:
+
+   ```sh
+   python3 <pr-body-skill-directory>/scripts/pr_body_lint.py \
+     --body-file <path> --repo <repo-root> --json
+   ```
+
+3. Fix every blocking finding. Each one carries fix text written as an
+   instruction; apply it to the body, do not argue with it. A warning is a
+   judgment call the author owns.
+4. Run the voice judge over the fixed body: [references/judge.md](references/judge.md).
+   Give it the body and the diff (`git diff <base>...HEAD`), which the judge
+   needs to see a fact the change makes load-bearing that the body never
+   mentions. The judge returns a verdict plus line-level rewrites, some of them
+   lines to add. Apply the rewrites you accept, then re-run the scorer, because
+   a rewrite can reintroduce a rule finding.
+5. On a clean scorer pass and a judge pass, write the receipt: the sha256 of the
+   body file's exact bytes, at
+   `~/.local/state/pr-body/receipts/<sha256>.json`. Then open the PR with
+   `--body-file` pointing at the same file.
+
+Editing the file after step 5 changes its hash and voids the receipt. Run the
+write verb again.
+
+### audit
+
+Score an existing PR's body and report. Never modify it.
+
+1. Pull the body to a file: `gh pr view <pr> --json body -q .body`.
+2. Run the scorer against it, with `--repo` pointed at a checkout of the target
+   repo.
+3. Run the judge over the same body, with `gh pr diff <pr>` as the diff.
+4. Report the scorer findings by rule with their line numbers, then the judge's
+   rewrites. No receipt is written, because the audit did not author the body.
+
+## The gate
+
+A PreToolUse hook on `Bash` matches `gh pr create` and `gh pr edit`, hashes the
+`--body-file` it was handed, and hard-denies when no receipt matches that hash.
+It also denies the invocation forms it cannot read (inline `--body`, heredocs),
+which is what forces `--body-file` in the first place.
+
+**There is no bypass.** No environment variable, no marker line, no flag. An
+agent that reaches the deny has one move: fix the body and run the write verb.
+The escape that does exist is uninstalling the hook from `~/.claude/hooks/`,
+which a human can do and an agent must not.
+
+The hook fails closed. An internal error, a malformed payload, or an unreadable
+body file all deny. The asymmetry that justifies it: a human can uninstall the
+hook, an agent cannot, so a broken gate costs a human one edit and costs an
+agent nothing it should have had.
+
+## What the gate cannot see
+
+The deterministic scorer catches roughly a third of what the operator rejects.
+On the hand-labeled set of 25 real bodies it caught 4 of the 12 rejected ones,
+and all 4 were empty or near-empty. Every miss was a voice judgment:
+pretentious phrasing, too much prose for not enough action, too many
+parentheses, too many code references.
+
+That is the whole reason the judge exists, and the reason a receipt (rather than
+a lint exit code) is what the hook checks. A body that passes the linter has
+been checked for countable defects only. Do not read a pass as a verdict that
+the body is good.
+
+## Rules the scorer implements
+
+`scripts/pr_body_lint.py` is the only rule engine. A rule named here and absent
+there is decorative. Grounds and fix text for each:
+[references/rubric.md](references/rubric.md).
+
+| Rule | Fires on | Severity |
+| --- | --- | --- |
+| `empty-body` | a body with no non-whitespace content | blocks |
+| `ai-disclosure-missing` | no line disclosing AI assistance | blocks |
+| `empty-template-section` | a heading with nothing under it | blocks |
+| `vacuous-opener` | a first line like "Fix bug", "Phase 1", "Cleanup" | blocks |
+| `oversized-input` | input past the scorer's robustness cap | blocks |
+| `em-dash` | an em dash in prose | blocks |
+| `emoji` | an emoji codepoint in prose | blocks |
+| `path-in-prose` | a file path outside code formatting | blocks |
+| `method-narration` | "verified with", "I ran", "tested by running" | blocks |
+| `verdict-clause` | a clause rating the change instead of describing it | blocks |
+| `reviewer-instruction` | "please review", "worth checking", "take a look at" | blocks |
+| `bullet-per-file` | most bullets in a list of 3 or more lead with a filename | blocks |
+| `symbol-in-prose` | an identifier or function name outside code formatting | warns |
+
+Two behaviors of the scorer are worth knowing before arguing with a finding.
+Lines matching the repo's `.github/pull_request_template.md`, and the AI
+disclosure line, are treated as scaffolding and exempt from the prose rules.
+Below 40 characters of prose the density rules (em dash, emoji, paths,
+narration, verdicts, reviewer asks, bullet-per-file, symbols) do not run at all;
+the structural rules run at every length.

--- a/skills/pr-body/agents/openai.yaml
+++ b/skills/pr-body/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Body"
+  short_description: "Write a PR body and score it before the PR opens, or audit an existing one"
+  default_prompt: "Use $pr-body to write this pull-request body, score it, and write the receipt before opening the PR."

--- a/skills/pr-body/references/judge.md
+++ b/skills/pr-body/references/judge.md
@@ -1,0 +1,277 @@
+# The voice judge
+
+The linter already ran. It checked countable defects and found none, which on
+the operator's labeled set means very little: it caught 4 of 12 rejected bodies
+and all 4 were empty or near-empty. Everything that decided the other 8 was
+phrasing. That is what this pass is for.
+
+The judge reads voice. It does not re-check rules, re-count characters, or
+verify that the change is correct.
+
+It reads the body **and the diff**. The diff is not there to be reviewed. It is
+there for one question the body cannot answer on its own: does the change do
+something the body never mentions? That is the eighth texture below, and it is
+the only one the diff is used for.
+
+## Output
+
+A verdict and line-level rewrites. Never a score on its own, and never a note
+that the body "could be tightened" without saying which line and to what.
+
+```json
+{
+  "verdict": "rewrite",
+  "rewrites": [
+    {
+      "line": 1,
+      "was": "This PR undertakes a comprehensive overhaul of the volume sizing story.",
+      "now": "Grows the appliance data volume from 2 TB to 4 TB."
+    },
+    {
+      "line": 3,
+      "was": "",
+      "now": "* Capacity alarm threshold follows the new size, 1600 to 3200 GiB."
+    }
+  ]
+}
+```
+
+An entry with an empty `was` is an added line, and `line` is the line it follows
+(0 for the top of the body). Every other entry replaces the line it names.
+
+`pass` carries an empty `rewrites` list. A `rewrite` verdict with no rewrites is
+malformed output, not a soft fail.
+
+## Bias toward passing
+
+Pass unless a specific line is wrong and you can write the line that replaces
+it. If the honest reaction is "this reads a bit long", that is a pass.
+
+The tradeoff is deliberate and it is asymmetric. A false deny costs the operator
+a rewrite cycle on a body that was already fine, on a change that is otherwise
+ready to merge. A false pass costs one mediocre PR description. The second is
+cheaper, so the judge takes that side of the error.
+
+Two consequences worth stating outright. One genuine parenthesis is not a
+finding, and one long-ish paragraph is not a finding. A finding needs a pattern
+the reader would notice, or a single sentence that is plainly wrong.
+
+## What to look for
+
+Eight textures, each drawn from the operator's own annotations on real bodies.
+Examples first; the rules underneath them are short on purpose, because the quiz
+that produced these preferences showed examples carry voice where abstract rules
+do not.
+
+### Invented motivation
+
+The author is claiming to know something they do not. The most reliable single
+finding in the set, and the one worth being least lenient about.
+
+> Grows the data volume ahead of the next release cycle, so capacity is in place
+> before traffic picks up.
+
+Becomes:
+
+> Grows the data volume from 2 TB to 4 TB. It has been running near capacity.
+
+If the ticket said why, that reason is a fact and belongs. If nobody said, the
+body says what changed and stops. Tells: "in preparation for", "ahead of", "so
+that the team can", "as part of our ongoing".
+
+### Verdict clauses that rate rather than describe
+
+The linter catches the stock phrasings. The class is wider than the list, and
+new phrasings are exactly what the judge is for.
+
+> The blast radius here is quite contained and reviewers can be confident this
+> lands cleanly.
+
+Becomes:
+
+> One resource updates. EBS expands online.
+
+Test: could the reader check this sentence against the system? A mechanism can
+be checked. A rating cannot.
+
+### Parenthetical density
+
+> Grows the volume (currently 2 TB, provisioned in 2023) to 4 TB (the next size
+> that clears the projected growth curve), with no change to the snapshot
+> schedule (which already runs nightly).
+
+Becomes:
+
+> Grows the volume from 2 TB to 4 TB. The nightly snapshot schedule is
+> unchanged.
+
+One parenthesis in a body is fine. Three in a sentence is an author negotiating
+with themselves in public.
+
+### Inline-code and symbol density
+
+> Updates `volumeSize` in `NewApplianceStack()` so `pulumi up` produces the
+> larger `aws.ebs.Volume`.
+
+Becomes:
+
+> Grows the appliance data volume to 4 TB.
+
+Every backticked symbol sends the reader to the diff to find out what the
+sentence meant. Name the behavior instead. A symbol earns its place when the
+symbol itself is the fact the reader needs (a config key they will set, a flag
+they will pass).
+
+### Paragraphs where bullets belong
+
+> This change updates the volume size, and it also raises the alarm threshold so
+> the new capacity is reflected, and the runbook has been updated to match, plus
+> the dashboard query needed a small change to pick up the new dimension.
+
+Becomes:
+
+> * Volume grows from 2 TB to 4 TB.
+> * Capacity alarm threshold follows the new size.
+> * Runbook and dashboard query updated to match.
+
+A list of facts is a list. Prose is for the one place it earns its keep, which
+is the risk mechanism.
+
+### Prose volume with no action behind it
+
+The most common annotation on the labeled set: "too much prose for not enough
+action". Weigh the word count against the number of distinct facts, not against
+the diff.
+
+> This pull request represents an incremental step in our capacity management
+> approach for the appliance fleet. Storage pressure has been an ongoing area of
+> attention, and this change addresses it directly by adjusting the provisioned
+> capacity of the data volume upward, bringing it into line with observed usage
+> patterns and giving headroom for the foreseeable future.
+
+Becomes:
+
+> Grows the appliance data volume from 2 TB to 4 TB. It has been running near
+> capacity.
+
+Three sentences carrying one fact is a rewrite. So is a five-bullet list where
+two bullets restate the other three.
+
+### Pretentious or juvenile phrasing
+
+Both directions of the same failure, and both appear in the labels.
+
+Pretentious:
+
+> This change harmonizes the storage posture of the appliance tier with the
+> realities of its consumption profile.
+
+Juvenile:
+
+> Turns out the disk was basically full! Bumped it up so we should be good now.
+
+Both become:
+
+> Grows the appliance data volume from 2 TB to 4 TB. It has been running near
+> capacity.
+
+### A load-bearing fact the body omits
+
+The only texture that needs the diff, and the only one that catches underfill.
+The labeled set rejects short bodies as well as long ones (a 77-char body
+annotated "way too thin", among others), and no length threshold separates them:
+an 80-char body passed and an 82-char one failed. The defect is never the size.
+It is that the change did a second thing and the body mentions only the first.
+
+Body:
+
+> Grows the appliance data volume from 2 TB to 4 TB. It has been running near
+> capacity.
+
+Diff: the volume grows, **and** the capacity alarm threshold moves from 1600 to
+3200 GiB.
+
+Add:
+
+> * Capacity alarm threshold follows the new size, 1600 to 3200 GiB.
+
+Fires on exactly two shapes:
+
+* The change does something a reader of the body would not expect from the body.
+* A second distinct thing changed, and only the first is mentioned.
+
+Hard boundary, because this is the one rule that could turn the judge into a
+code reviewer. It does not fire on style, correctness, scope, test coverage, or
+whether the change is a good idea. Those stay on the list below, diff or no diff.
+
+The rewrite is always the missing fact, written out as the line to add. Never
+"add more detail", never "expand on the rationale". If you cannot state the
+missing fact in one line, there is no finding.
+
+The fact has to be load-bearing, not merely present in the diff. A renamed local
+variable is in the diff and belongs nowhere near the body. The test is whether a
+reviewer who read only the body would be surprised by what they find.
+
+## Not the judge's business
+
+Do not raise any of these. The rest of the system owns them, and a judge that
+wanders into them produces findings the author cannot act on.
+
+* Length, in either direction. There is no target and no ceiling, and the judge
+  never asks for more words. It asks for one named missing fact, or for nothing.
+  A body of one true line that omits nothing is a pass.
+* Markdown headers, and any section the repo's PR template supplies.
+* Checkboxes. Legitimate when the template ships them, when they record testing
+  done, and when they list post-merge steps to verify.
+* The AI disclosure line. Boilerplate, not authored prose.
+* Anything the linter already reported. It ran first.
+* Whether the change itself is correct, well-scoped, or a good idea. Having the
+  diff does not change this. The diff answers one question only: did the change
+  do something the body never mentions.
+
+## The prompt
+
+Paste the body under this with line numbers, then the diff.
+
+> You are judging the voice of a pull-request body. A deterministic linter has
+> already checked it for countable defects and found none, so do not look for
+> file paths, em dashes, emoji, or stock verdict phrasings. Judge only how it
+> reads, plus one question about coverage (rule 8).
+>
+> You are given the body with line numbers, and the diff of the change. The diff
+> is not for review. Use it only for rule 8.
+>
+> Return JSON: a `verdict` of `pass` or `rewrite`, and a `rewrites` list, each
+> entry carrying `line`, `was`, and `now`. `now` is the replacement text,
+> written out in full. An entry with an empty `was` is a line to add after
+> `line` (0 for the top). Never return a rewrite you cannot write the
+> replacement for, and never return a score or a general comment in place of a
+> rewrite.
+>
+> Be biased toward passing. A false deny costs a rewrite cycle on a body that
+> was fine, which is worse than letting one mediocre body through. One
+> parenthesis is not a finding. One long paragraph is not a finding. Pass unless
+> a specific line is wrong, or a specific fact is missing.
+>
+> Raise a rewrite for any of these, and nothing else:
+>
+> 1. Motivation the author could not know. "Ahead of the next release cycle"
+>    when nobody said that.
+> 2. A clause that rates the change instead of describing it. The reader can
+>    check a mechanism, not a rating.
+> 3. Parenthetical asides stacked up, several in a sentence or throughout.
+> 4. Inline code spans and symbol names where the behavior would say it better.
+> 5. A paragraph carrying a list of facts that should be bullets.
+> 6. Word count out of proportion to the number of distinct facts.
+> 7. Phrasing that reads as pretentious, or as juvenile.
+> 8. A fact the diff makes load-bearing that the body does not mention: the
+>    change does something a reader of the body would not expect, or a second
+>    distinct thing changed and only the first is named. The rewrite is the
+>    missing fact written out as a line to add, never a request for more detail.
+>    If you cannot state it in one line, there is no finding. A fact that is
+>    merely present in the diff (a renamed local, a reformatted block) is not
+>    load-bearing.
+>
+> Say nothing about length, markdown headers, template sections, checkboxes, the
+> AI disclosure line, or whether the change is correct, well-scoped, or a good
+> idea. Never ask for more words. Ask for one named missing fact, or for nothing.

--- a/skills/pr-body/references/rubric.md
+++ b/skills/pr-body/references/rubric.md
@@ -1,0 +1,282 @@
+# pr-body rubric
+
+One entry per rule `../scripts/pr_body_lint.py` implements. That file is the
+only rule engine; this one records what each rule fires on, what its fix says,
+and what grounds it. Corpus rates are AI-era (n=100) against human-era (n=109)
+merged PRs from the operator's own history. Labels are the hand-labeled set of
+25 bodies the operator judged blind.
+
+The corpus is one author's, and the labels are one author's. A rule grounded
+only in "elicited" is a preference this pack encodes on purpose, not an
+industry standard. Where a standard says otherwise, see *Known disagreements*.
+
+## Rules
+
+### `empty-body` (block)
+
+**Fires on** a body with no non-whitespace content at all.
+
+**Fix** State what changed and why; an empty body tells the reviewer nothing.
+
+**Grounds** Corpus: 33 empty bodies, all human-era. Labels: every empty or stub
+body in the sample was rejected. Shopify's review guide treats an inadequate
+description as grounds to send the PR back before judging the code at all
+(https://shopify.engineering/great-code-reviews).
+
+### `ai-disclosure-missing` (block)
+
+**Fires on** a body with no line naming an AI tool alongside a preparation or
+assistance verb. The match is deliberately loose so any phrasing of the
+disclosure counts, not one fixed sentence.
+
+**Fix** Add a disclosure line: 'This PR was written in part with the assistance
+of generative AI.'
+
+**Grounds** The Kubernetes contributor guide is the only verified institutional
+policy requiring disclosure in the description, and supplies that exact sentence
+(https://www.kubernetes.dev/docs/guide/pull-requests/). Scoping is free here:
+the hook fires on an agent's Bash tool, so every body it scores is
+agent-mediated by construction. The rule needs no heuristic for whether a body
+was AI-written, because the trigger already answers that. Kubernetes' companion
+ban on AI co-author commit trailers is left alone; this pack's commit convention
+already keeps attribution out of trailers.
+
+### `empty-template-section` (block)
+
+**Fires on** a heading with nothing under it, excluding a blank final section
+when the body has more than one heading (a trailing blank section is almost
+always optional metadata, not an abandoned one).
+
+**Fix** Fill in the named section, or delete it if it does not apply.
+
+**Grounds** Corpus: the human-era failure mode is underfill, typically a 52-char
+body that is the repo template with every section left empty. Labels confirm
+it. GitHub's own docs frame templates as a delivery mechanism and make no claim
+that they improve description quality
+(https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates),
+so an unfilled template earns nothing.
+
+### `vacuous-opener` (block)
+
+**Fires on** a first prose line matching a named-bad pattern: "Fix bug", "Fix
+build", "Add patch", "Add convenience functions", "Moving code from A to B",
+"Phase 1", "WIP", "Minor fixes", "Update", "Cleanup", "kill weird URLs". Only
+lines under 200 characters are tested, so a real opening sentence is never
+matched.
+
+**Fix** Open with the behavior that changed, not a generic label like this line.
+
+**Grounds** Google names these first lines outright as failing to provide useful
+information (https://google.github.io/eng-practices/review/developer/cl-descriptions.html).
+Zulip names the same failure from the other side: a summary that does not say
+what part of the codebase changed
+(https://zulip.readthedocs.io/en/stable/contributing/commit-discipline.html).
+
+### `oversized-input` (block)
+
+**Fires on** input past the scorer's robustness cap of 20,000 characters. The
+body is refused outright rather than run through every regex.
+
+**Fix** Pass the body as a file with `--body-file` instead of inline; this input
+is too large to lint directly.
+
+**Grounds** Not a judgment about length. This is the cap that keeps a pathological
+input from spending the hook's timeout budget. See *Known disagreements* for why
+there is no length rule underneath it.
+
+### `em-dash` (block)
+
+**Fires on** an em dash in prose (code fences, inline code, link targets, and
+bare URLs are masked out first).
+
+**Fix** Rewrite without an em dash; use a period or parentheses instead.
+
+**Grounds** Corpus 26% / 0%, the cleanest discriminator measured. Already banned
+by the operator's own style rules, which makes the corpus rate a confirmation
+rather than the reason. Freeburg's suppression study across 12 models and 5
+providers found em-dash frequency survives explicit instruction to drop markdown
+and reads as a fingerprint of fine-tuning methodology
+(https://arxiv.org/abs/2603.27006). That study is a single preprint about
+general prose, not PR bodies, and the counter-position is on record: a single em
+dash cannot convict an individual document, and em dashes are also a marker of
+skilled human writers
+(https://www.howtogeek.com/no-an-em-dash-cant-help-you-detect-ai-text/). The
+rule survives that objection because it is a house style ban, not a detector.
+
+### `emoji` (block)
+
+**Fires on** an emoji codepoint in prose.
+
+**Fix** Remove the emoji; state the fact in words.
+
+**Grounds** Corpus 29% / 0%. No institutional source addresses emoji directly.
+The plain declarative register of every source that does address tone (Google,
+Zulip, the kernel) leaves no room for one, and the operator's style rules ban
+emoji in technical content outright.
+
+### `path-in-prose` (block)
+
+**Fires on** a path-shaped token (a slash, and a short alphanumeric extension on
+the last segment) in prose, outside code formatting and URLs.
+
+**Fix** Name the behavior, not the file; the diff already lists files.
+
+**Grounds** Corpus 24% / 2%. This is the countable proxy for the most
+corroborated rule in the research pass, which no regex can test directly: the
+body explains what and why, because the diff already shows how. Five independent
+sources converge on it (https://google.github.io/eng-practices/review/developer/cl-descriptions.html,
+https://cbea.ms/git-commit/,
+https://zulip.readthedocs.io/en/stable/contributing/commit-discipline.html,
+https://github.com/sourcegraph/handbook/blob/main/content/departments/engineering/dev/process/pull-requests.md,
+https://docs.kernel.org/process/submitting-patches.html). A path is a "how".
+
+### `method-narration` (block)
+
+**Fires on** "verified with", "tested by running", "I ran", "ran the".
+
+**Fix** State the result of verification, not how you performed it.
+
+**Grounds** Corpus 7% / 0%. Elicited: the operator chose `Resources: 1 to
+update` over a sentence describing running preview against dev and prd. Zulip
+states the same rule for commit bodies, that unnecessary personal narrative
+about the process does not belong
+(https://zulip.readthedocs.io/en/stable/contributing/commit-discipline.html).
+
+### `verdict-clause` (block)
+
+**Fires on** clauses that rate the change rather than describe it: "this is a
+low-risk / simple / straightforward / minor / trivial change", "no downtime is
+expected", "should have no impact", "improves maintainability", "makes the code
+cleaner", "straightforward", "should be safe".
+
+**Fix** Replace the rating with the concrete fact that supports it.
+
+**Grounds** Corpus 2% / 0%, the lowest rate of any shipped rule, so the corpus
+is not what carries it. Elicited, and broadened from the elicited example to the
+whole class: the operator accepted "EBS expands online, no downtime" (mechanism)
+and rejected "no downtime is expected" (verdict). The distinction is that a
+verdict is a claim about the change that the reader cannot check, where a
+mechanism is a fact about the system that they can.
+
+### `reviewer-instruction` (block)
+
+**Fires on** "please review", "worth checking", "reviewers should", "take a look
+at", "let me know if".
+
+**Fix** Delete the instruction to the reviewer; let the diff and description
+stand on their own.
+
+**Grounds** Corpus 13% / 0%. Elicited: offered a targeted pointer, a generic ask,
+and nothing, the operator chose nothing. This one contradicts a published
+standard. See *Known disagreements*.
+
+### `bullet-per-file` (block)
+
+**Fires on** a list of 3 or more bullets where at least 60% lead with a filename
+or path.
+
+**Fix** Describe the behavior the files implement together, not a bullet per
+file.
+
+**Grounds** Elicited: never a bullet per file. No corpus rate was measured for
+this shape specifically. The thresholds exist so a legitimately multi-part
+change that names two files among six bullets does not trip it. Practitioner
+sources name the anti-pattern directly (line-by-line diff restatement), but at
+blog tier only; the institutional backing is the same what-and-why-not-how
+convergence cited under `path-in-prose`.
+
+### `symbol-in-prose` (warn)
+
+**Fires on** an identifier-shaped token in prose: snake_case, camelCase, or a
+bare `name()` call, outside code formatting.
+
+**Fix** Wrap the identifier in backticks, or name the behavior instead of the
+symbol.
+
+**Grounds** Elicited, from the operator's own annotations on the labeled set:
+"too many code references" is one of the recurring notes on bodies that were
+passed but marked down. Warn rather than block, because the pattern also matches
+legitimate prose words and product names, and a false block costs more than a
+false warning. The judge picks up the density judgment this rule cannot make.
+
+## Documented non-signals
+
+Three candidate rules were considered against the same evidence and refused.
+They are recorded here with their evidence so a future agent reading the corpus
+does not re-add them.
+
+### Markdown headers and section structure
+
+Corpus 79% AI-era against 83% human-era. Headers are not an AI tell here because
+the repos ship `.github/pull_request_template.md` supplying `## What does this
+PR do?` and friends, so a rule against headers would fire hardest on the era it
+is not meant to catch.
+
+Independently corroborated. Freeburg's suppression experiment found that overt
+markdown features (headers, bullets, bold) are eliminated or nearly eliminated
+the moment a model is told to drop markdown, which makes them near-pure
+instruction-following and close to worthless as a fingerprint
+(https://arxiv.org/abs/2603.27006).
+
+The rule is about what sits under a heading, not the heading. That is
+`empty-template-section`, and it is the only structure rule that ships.
+
+### AI-vocabulary wordlists
+
+Corpus 1% in both eras. "comprehensive", "leverage", "robust", "seamlessly": a
+rule built on that list fires on nothing and catches nothing.
+
+The detection literature is against the approach as a class, not just against
+this list. A comparison of 14 commercial AI-text detectors found none reaching
+80% accuracy and only five above 70%. That figure reached the research pass at
+search-summary level and was not traced to a single fetched paper, so treat it
+as corroborating direction rather than a hard number. No institutional or
+academic source was found endorsing wordlist detection at all. The one credible
+adjacent finding (Freeburg, above) is deliberately narrow: one punctuation mark,
+mechanistically explained and empirically tested, which is the opposite of a
+broad vocabulary list.
+
+### Checkboxes
+
+Corpus 18% AI-era against 0% human-era, a clean discriminator, and still not a
+defect. Operator ruling: checkboxes are legitimate whenever a template ships
+them, whenever they record what testing was done, and whenever they list
+post-merge steps someone has to verify.
+
+This is the entry that shows corpus rates alone cannot decide a rule. A clean
+discriminator can be a good practice the author only recently adopted. Every
+shipped rule above was re-checked against that standard.
+
+## Known disagreements
+
+### `reviewer-instruction` runs against GitHub's own advice
+
+GitHub's engineering blog recommends the opposite of this rule: be explicit
+about the kind of feedback you want, a quick look against a design critique
+(https://github.blog/developer-skills/github/how-to-write-the-perfect-pull-request/).
+The corpus rate (13% / 0%) measures a real era split, but the era split is not
+the argument; the elicited preference is. This rule is encoded as the operator
+wants it, and the counter-citation is recorded here so the preference is not
+laundered into a standard.
+
+### A length ceiling was built, measured, and removed
+
+The Linux kernel supplies the best argument for one: a description getting long
+is a signal the patch needs splitting, which frames a ceiling as a scope
+diagnostic rather than a prose-economy rule
+(https://docs.kernel.org/process/submitting-patches.html). No institutional
+source states a target length for a description; the kernel's is the closest
+thing, and it is diagnostic, not prescriptive.
+
+The operator's labels refuted it anyway. Passing bodies span 80 to 2242
+characters and failing bodies span 0 to 1703; the ranges nest, the longest body
+in the sample passed, and a 1703-character body failed. The best single length
+threshold reaches 72% against a 50% baseline and earns all of it at the bottom
+end, separating empty stubs from everything else. That is `empty-body`, not a
+ceiling. `oversized-input` is a robustness cap on the scorer, not a judgment
+about the body.
+
+One calibration note belongs with this. Era is barred as a tuning target: the
+labels put AI-era bodies at 69% pass and human-era at 33%, so a linter tuned to
+flag the AI era would have been tuned toward the labels the operator rejects
+more often, while reporting green.

--- a/skills/pr-body/scripts/pr_body_lint.py
+++ b/skills/pr-body/scripts/pr_body_lint.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Lint a PR body against the pr-body skill's rubric."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+THRESHOLDS = {
+    # Robustness cap only, not a judgment about the body: hand-labeled data
+    # showed body length does not separate pass from fail (a 2242-char body
+    # passed, a 1703-char body failed), so length is not a scored rule here.
+    # Past this, the input is refused outright rather than run through every
+    # regex below.
+    "max_input_chars": 20_000,
+    # Below this many prose chars, a body is too short for the density rules
+    # (em-dash, emoji, paths, narration, verdicts, reviewer asks,
+    # bullet-per-file, symbol-in-prose) to have signal.
+    "density_floor_chars": 40,
+    "bullet_per_file_min_bullets": 3,
+    "bullet_per_file_ratio": 0.6,
+    "excerpt_max_chars": 120,
+    "vacuous_opener_max_chars": 200,
+}
+
+
+CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
+LINK_TARGET_RE = re.compile(r"(?<=\])\([^)]*\)")
+BARE_URL_RE = re.compile(r"https?://\S+")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(.*)$")
+
+EMOJI_RE = re.compile(
+    "["
+    "\U0001F1E6-\U0001F1FF"
+    "\U0001F300-\U0001FAFF"
+    "\U00002600-\U000027BF"
+    "\U00002B00-\U00002BFF"
+    "]"
+)
+
+VACUOUS_OPENER_PATTERNS = [
+    re.compile(r"^fix(es|ed)?\.?$", re.I),
+    re.compile(r"^fix(es|ed)?\s+(the\s+)?(bug|build|issue|error)s?\.?$", re.I),
+    re.compile(r"^add(s|ed)?\s+(a\s+)?patch(es)?\.?$", re.I),
+    re.compile(r"^add(s|ed)?\s+convenience\s+functions?\.?$", re.I),
+    re.compile(r"^mov(e|ing)\s+code\s+from\s+.+\s+to\s+.+\.?$", re.I),
+    re.compile(r"^phase\s*\d+\.?$", re.I),
+    re.compile(r"^(wip|work[\s-]in[\s-]progress)\.?$", re.I),
+    re.compile(
+        r"^(minor|small|misc(ellaneous)?)\s+(fix(es)?|change(s)?|update(s)?)\.?$",
+        re.I,
+    ),
+    re.compile(r"^update(s|d)?\.?$", re.I),
+    re.compile(r"^clean\s*up\.?$", re.I),
+    re.compile(r"^kill\s+weird\s+urls\.?$", re.I),
+]
+
+METHOD_NARRATION_PATTERNS = [
+    re.compile(r"\bverified\s+with\b", re.I),
+    re.compile(r"\btested\s+by\s+running\b", re.I),
+    re.compile(r"\bi\s+ran\b", re.I),
+    re.compile(r"\bran\s+the\b", re.I),
+]
+
+VERDICT_CLAUSE_PATTERNS = [
+    re.compile(r"\bthis\s+is\s+a\s+(low[\s-]risk|simple|straightforward|minor|trivial)\s+change\b", re.I),
+    re.compile(r"\bno\s+downtime\s+is\s+expected\b", re.I),
+    re.compile(r"\bshould\s+have\s+(no|little|minimal)\s+impact\b", re.I),
+    re.compile(r"\bimproves?\s+maintainability\b", re.I),
+    re.compile(r"\bmakes?\s+the\s+code\s+(cleaner|more\s+readable)\b", re.I),
+    re.compile(r"\bstraightforward\b", re.I),
+    re.compile(r"\bshould\s+be\s+safe\b", re.I),
+]
+
+REVIEWER_INSTRUCTION_PATTERNS = [
+    re.compile(r"\bplease\s+review\b", re.I),
+    re.compile(r"\bworth\s+checking\b", re.I),
+    re.compile(r"\breviewers?\s+should\b", re.I),
+    re.compile(r"\btake\s+a\s+look\s+at\b", re.I),
+    re.compile(r"\blet\s+me\s+know\s+if\b", re.I),
+]
+
+# Identifier-shaped tokens: snake_case, camelCase, or a bare function call.
+SYMBOL_PATTERNS = [
+    re.compile(r"\b[a-z][a-z0-9]*_[a-z0-9_]+\b"),
+    re.compile(r"\b[a-z]+[A-Z][a-zA-Z0-9]*\b"),
+    re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\(\)"),
+]
+
+FILENAME_RE = re.compile(r"^[\w.-]+\.[A-Za-z0-9]{1,8}$")
+
+# Flexible AI-disclosure match: an AI-related term and a preparation/assist
+# verb on the same line, so any wording of the Kubernetes-style disclosure
+# sentence is accepted rather than one fixed string.
+AI_TERM_RE = re.compile(
+    r"\b(ai|artificial intelligence|generative ai|genai|an? assistant|"
+    r"copilot|claude(?:\s+code)?|chatgpt|gpt-?\d*|llm)\b",
+    re.I,
+)
+ASSIST_VERB_RE = re.compile(
+    r"\b(assist(ed|ance)?|help(ed)?|prepar(ed|ing)?|wrote|written|writing|"
+    r"generat(ed|ing)?|draft(ed|ing)?)\b",
+    re.I,
+)
+
+FIXES = {
+    "empty-body": "State what changed and why; an empty body tells the reviewer nothing.",
+    "ai-disclosure-missing": (
+        "Add a disclosure line: 'This PR was written in part with the "
+        "assistance of generative AI.'"
+    ),
+    "empty-template-section": "Fill in the {heading!r} section, or delete it if it does not apply.",
+    "vacuous-opener": "Open with the behavior that changed, not a generic label like this line.",
+    "oversized-input": "Pass the body as a file with --body-file instead of inline; this input is too large to lint directly.",
+    "em-dash": "Rewrite without an em dash; use a period or parentheses instead.",
+    "emoji": "Remove the emoji; state the fact in words.",
+    "path-in-prose": "Name the behavior, not the file; the diff already lists files.",
+    "method-narration": "State the result of verification, not how you performed it.",
+    "verdict-clause": "Replace the rating with the concrete fact that supports it.",
+    "reviewer-instruction": "Delete the instruction to the reviewer; let the diff and description stand on their own.",
+    "bullet-per-file": "Describe the behavior the files implement together, not a bullet per file.",
+    "symbol-in-prose": "Wrap the identifier in backticks, or name the behavior instead of the symbol.",
+}
+
+SEVERITY = {
+    "empty-body": "block",
+    "ai-disclosure-missing": "block",
+    "empty-template-section": "block",
+    "vacuous-opener": "block",
+    "oversized-input": "block",
+    "em-dash": "block",
+    "emoji": "block",
+    "path-in-prose": "block",
+    "method-narration": "block",
+    "verdict-clause": "block",
+    "reviewer-instruction": "block",
+    "bullet-per-file": "block",
+    "symbol-in-prose": "warn",
+}
+
+
+class LintError(RuntimeError):
+    """An internal failure that should surface as a JSON error object."""
+
+
+def _excerpt(text: str) -> str:
+    limit = THRESHOLDS["excerpt_max_chars"]
+    text = text.strip()
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _blank_spans(pattern: re.Pattern, text: str) -> str:
+    """Replace every match with just its own newlines, preserving line numbers."""
+    return pattern.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+
+
+def _prose_only(text: str) -> str:
+    text = _blank_spans(CODE_FENCE_RE, text)
+    text = _blank_spans(INLINE_CODE_RE, text)
+    text = _blank_spans(LINK_TARGET_RE, text)
+    text = _blank_spans(BARE_URL_RE, text)
+    return text
+
+
+def _normalize_line(line: str) -> str:
+    return re.sub(r"\s+", " ", line.strip())
+
+
+def _load_template_lines(repo: Optional[Path]) -> set[str]:
+    if repo is None:
+        return set()
+    template = repo / ".github" / "pull_request_template.md"
+    if not template.is_file():
+        return set()
+    try:
+        raw = template.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return set()
+    return {
+        _normalize_line(line)
+        for line in raw.splitlines()
+        if _normalize_line(line)
+    }
+
+
+def _scaffolding_mask(lines: list[str], template_lines: set[str]) -> list[bool]:
+    # A disclosure line (the Claude Code footer, e.g.) is tool-appended
+    # boilerplate, not authored prose, so it is exempt the same way a
+    # template heading is.
+    return [
+        (bool(template_lines) and _normalize_line(line) in template_lines)
+        or (AI_TERM_RE.search(line) is not None and ASSIST_VERB_RE.search(line) is not None)
+        for line in lines
+    ]
+
+
+def _first_prose_line(
+    lines: list[str], scaffolding: list[bool]
+) -> Optional[tuple[int, str]]:
+    for index, raw in enumerate(lines):
+        if scaffolding[index]:
+            continue
+        text = raw.strip()
+        if not text or HEADING_RE.match(text):
+            continue
+        bullet_match = BULLET_RE.match(raw)
+        content = bullet_match.group(1).strip() if bullet_match else text
+        if content:
+            return index, content
+    return None
+
+
+def _check_vacuous_opener(
+    lines: list[str], scaffolding: list[bool]
+) -> list[dict]:
+    found = _first_prose_line(lines, scaffolding)
+    if found is None:
+        return []
+    line_index, content = found
+    if len(content) > THRESHOLDS["vacuous_opener_max_chars"]:
+        return []
+    stripped = content.strip().rstrip(".")
+    for pattern in VACUOUS_OPENER_PATTERNS:
+        if pattern.match(stripped) or pattern.match(content):
+            return [
+                {
+                    "rule": "vacuous-opener",
+                    "line": line_index + 1,
+                    "excerpt": _excerpt(content),
+                }
+            ]
+    return []
+
+
+def _check_empty_template_sections(lines: list[str]) -> list[dict]:
+    # A heading with nothing under it is the underfill failure mode whether
+    # or not the heading happens to also live in a repo's PR template.
+    headings: list[tuple[int, str]] = []
+    for index, line in enumerate(lines):
+        match = HEADING_RE.match(line.strip())
+        if match:
+            headings.append((index, match.group(2).strip()))
+    findings = []
+    for position, (index, heading_text) in enumerate(headings):
+        # A blank final section is almost always optional trailing metadata
+        # (a ticket link, a screenshot placeholder); only a blank section
+        # with more document after it is the abandoned-template failure.
+        # A single lone heading has nowhere else to carry content, so it
+        # stays in scope even though it is technically "last".
+        if position == len(headings) - 1 and len(headings) > 1:
+            continue
+        is_last = position + 1 >= len(headings)
+        end = len(lines) if is_last else headings[position + 1][0]
+        section = lines[index + 1 : end]
+        if not any(line.strip() for line in section):
+            findings.append(
+                {
+                    "rule": "empty-template-section",
+                    "line": index + 1,
+                    "excerpt": _excerpt(heading_text or lines[index].strip()),
+                    "heading": heading_text or lines[index].strip(),
+                }
+            )
+    return findings
+
+
+def _check_pattern_rule(
+    rule: str,
+    patterns: list[re.Pattern],
+    lines: list[str],
+    scaffolding: list[bool],
+) -> list[dict]:
+    for index, line in enumerate(lines):
+        if scaffolding[index]:
+            continue
+        for pattern in patterns:
+            match = pattern.search(line)
+            if match:
+                return [
+                    {
+                        "rule": rule,
+                        "line": index + 1,
+                        "excerpt": _excerpt(line),
+                    }
+                ]
+    return []
+
+
+def _check_em_dash(lines: list[str], scaffolding: list[bool]) -> list[dict]:
+    for index, line in enumerate(lines):
+        if scaffolding[index]:
+            continue
+        if "—" in line:
+            return [
+                {
+                    "rule": "em-dash",
+                    "line": index + 1,
+                    "excerpt": _excerpt(line),
+                }
+            ]
+    return []
+
+
+def _check_emoji(lines: list[str], scaffolding: list[bool]) -> list[dict]:
+    for index, line in enumerate(lines):
+        if scaffolding[index]:
+            continue
+        if EMOJI_RE.search(line):
+            return [
+                {
+                    "rule": "emoji",
+                    "line": index + 1,
+                    "excerpt": _excerpt(line),
+                }
+            ]
+    return []
+
+
+def _looks_like_path(token: str) -> bool:
+    candidate = token.strip(".,;:()[]{}\"'")
+    if not candidate or "/" not in candidate:
+        return False
+    if candidate.startswith(("http://", "https://")):
+        return False
+    tail = candidate.rsplit("/", 1)[-1]
+    if "." not in tail:
+        return False
+    ext = tail.rsplit(".", 1)[-1]
+    return 1 <= len(ext) <= 8 and ext.isalnum()
+
+
+def _check_path_in_prose(
+    prose_lines: list[str], scaffolding: list[bool]
+) -> list[dict]:
+    for index, line in enumerate(prose_lines):
+        if scaffolding[index]:
+            continue
+        for token in line.split():
+            if _looks_like_path(token):
+                return [
+                    {
+                        "rule": "path-in-prose",
+                        "line": index + 1,
+                        "excerpt": _excerpt(token),
+                    }
+                ]
+    return []
+
+
+def _check_symbol_in_prose(
+    prose_lines: list[str], scaffolding: list[bool]
+) -> list[dict]:
+    for index, line in enumerate(prose_lines):
+        if scaffolding[index]:
+            continue
+        for pattern in SYMBOL_PATTERNS:
+            match = pattern.search(line)
+            if match:
+                return [
+                    {
+                        "rule": "symbol-in-prose",
+                        "line": index + 1,
+                        "excerpt": _excerpt(line),
+                    }
+                ]
+    return []
+
+
+def _leads_with_file(bullet_text: str) -> bool:
+    stripped = bullet_text.strip().lstrip("`*_\"'")
+    if not stripped:
+        return False
+    first_token = stripped.split()[0].rstrip(":,.")
+    if "/" in first_token:
+        return _looks_like_path(first_token)
+    return bool(FILENAME_RE.match(first_token))
+
+
+def _check_bullet_per_file(
+    lines: list[str], scaffolding: list[bool]
+) -> list[dict]:
+    bullets = []
+    for index, line in enumerate(lines):
+        if scaffolding[index]:
+            continue
+        match = BULLET_RE.match(line)
+        if match:
+            bullets.append((index, match.group(1)))
+    if len(bullets) < THRESHOLDS["bullet_per_file_min_bullets"]:
+        return []
+    file_led = [item for item in bullets if _leads_with_file(item[1])]
+    ratio = len(file_led) / len(bullets)
+    if ratio >= THRESHOLDS["bullet_per_file_ratio"]:
+        first_index, first_text = file_led[0]
+        return [
+            {
+                "rule": "bullet-per-file",
+                "line": first_index + 1,
+                "excerpt": _excerpt(first_text),
+            }
+        ]
+    return []
+
+
+def _check_ai_disclosure(body: str) -> list[dict]:
+    for line in body.splitlines():
+        if AI_TERM_RE.search(line) and ASSIST_VERB_RE.search(line):
+            return []
+    return [{"rule": "ai-disclosure-missing", "line": 1, "excerpt": ""}]
+
+
+def _finding(raw: dict) -> dict:
+    rule = raw["rule"]
+    fix = FIXES[rule]
+    if "{heading!r}" in fix:
+        fix = fix.format(heading=raw.get("heading", raw["excerpt"]))
+    return {
+        "rule": rule,
+        "severity": SEVERITY[rule],
+        "line": raw["line"],
+        "excerpt": raw["excerpt"],
+        "fix": fix,
+    }
+
+
+def lint(body: str, *, repo: Optional[Path] = None) -> dict:
+    chars = len(body)
+
+    if chars > THRESHOLDS["max_input_chars"]:
+        finding = _finding(
+            {
+                "rule": "oversized-input",
+                "line": 1,
+                "excerpt": _excerpt(body[: THRESHOLDS["excerpt_max_chars"]]),
+            }
+        )
+        return {"verdict": "fail", "chars": chars, "findings": [finding]}
+
+    if not body.strip():
+        findings = [
+            _finding({"rule": "empty-body", "line": 1, "excerpt": ""}),
+            _finding({"rule": "ai-disclosure-missing", "line": 1, "excerpt": ""}),
+        ]
+        return {"verdict": "fail", "chars": chars, "findings": findings}
+
+    template_lines = _load_template_lines(repo)
+    lines = body.splitlines()
+    scaffolding = _scaffolding_mask(lines, template_lines)
+
+    raw_findings: list[dict] = []
+    raw_findings.extend(_check_empty_template_sections(lines))
+    raw_findings.extend(_check_vacuous_opener(lines, scaffolding))
+    raw_findings.extend(_check_ai_disclosure(body))
+
+    prose_text = _prose_only(body)
+    prose_lines = prose_text.splitlines()
+    prose_chars = len(prose_text)
+
+    if prose_chars >= THRESHOLDS["density_floor_chars"]:
+        raw_findings.extend(_check_em_dash(prose_lines, scaffolding))
+        raw_findings.extend(_check_emoji(prose_lines, scaffolding))
+        raw_findings.extend(_check_path_in_prose(prose_lines, scaffolding))
+        raw_findings.extend(
+            _check_pattern_rule(
+                "method-narration", METHOD_NARRATION_PATTERNS, prose_lines, scaffolding
+            )
+        )
+        raw_findings.extend(
+            _check_pattern_rule(
+                "verdict-clause", VERDICT_CLAUSE_PATTERNS, prose_lines, scaffolding
+            )
+        )
+        raw_findings.extend(
+            _check_pattern_rule(
+                "reviewer-instruction",
+                REVIEWER_INSTRUCTION_PATTERNS,
+                prose_lines,
+                scaffolding,
+            )
+        )
+        raw_findings.extend(_check_bullet_per_file(lines, scaffolding))
+        raw_findings.extend(_check_symbol_in_prose(prose_lines, scaffolding))
+
+    findings = [_finding(item) for item in raw_findings]
+    verdict = "fail" if any(f["severity"] == "block" for f in findings) else "pass"
+    return {"verdict": verdict, "chars": chars, "findings": findings}
+
+
+def _extract_body(arguments: argparse.Namespace) -> str:
+    if arguments.body_file:
+        path = Path(arguments.body_file)
+        try:
+            return path.read_text(encoding="utf-8", errors="replace")
+        except OSError as error:
+            raise LintError(f"cannot read --body-file: {error}") from error
+    return sys.stdin.read()
+
+
+def _render_human(result: dict) -> str:
+    lines = [f"verdict: {result['verdict']} ({result['chars']} chars)"]
+    for finding in result["findings"]:
+        lines.append(
+            f"[{finding['severity']}] {finding['rule']} (line {finding['line']}): "
+            f"{finding['excerpt']!r}"
+        )
+        lines.append(f"  fix: {finding['fix']}")
+    return "\n".join(lines)
+
+
+def parse_arguments(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body-file", help="path to the PR body; defaults to stdin")
+    parser.add_argument("--repo", help="repo root, used to find the PR template")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    try:
+        arguments = parse_arguments(argv)
+        body = _extract_body(arguments)
+        repo = Path(arguments.repo).expanduser() if arguments.repo else None
+        result = lint(body, repo=repo)
+    except LintError as error:
+        print(json.dumps({"verdict": "error", "error": str(error)}))
+        return 2
+    except Exception as error:  # noqa: BLE001 - must never crash the caller
+        print(json.dumps({"verdict": "error", "error": f"internal error: {error}"}))
+        return 2
+
+    if arguments.json:
+        print(json.dumps(result))
+    else:
+        print(_render_human(result))
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/pr-body/scripts/pr_body_receipt.py
+++ b/skills/pr-body/scripts/pr_body_receipt.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Manage receipts proving a PR body was scored and passed.
+
+A receipt is keyed by the sha256 of the body file's exact bytes, so editing
+the file after scoring invalidates it; that is the property pr-body-gate
+relies on. `write` is called by the skill only after both the linter and the
+judge pass. `check` is the same lookup as a standalone exit code. `prune`
+clears receipts older than a week so the state directory does not grow
+without bound.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+STATE_ROOT = Path.home() / ".local" / "state" / "pr-body"
+RECEIPTS_DIR = STATE_ROOT / "receipts"
+BY_PATH_DIR = RECEIPTS_DIR / "by-path"
+PRUNE_AGE = timedelta(days=7)
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _receipt_path(digest: str) -> Path:
+    return RECEIPTS_DIR / f"{digest}.json"
+
+
+def _path_pointer_path(abs_path: str) -> Path:
+    # Keyed by a hash of the path, not the path itself, so the receipt tree
+    # never has to worry about characters a filesystem rejects in a name.
+    return BY_PATH_DIR / f"{_sha256_bytes(abs_path.encode('utf-8'))}.json"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, 0o700)
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _read_body_bytes(body_file: str) -> Optional[bytes]:
+    try:
+        return Path(body_file).read_bytes()
+    except OSError as error:
+        print(f"pr_body_receipt: cannot read {body_file}: {error}", file=sys.stderr)
+        return None
+
+
+def cmd_write(body_file: str) -> int:
+    data = _read_body_bytes(body_file)
+    if data is None:
+        return 1
+    digest = _sha256_bytes(data)
+    _ensure_dir(RECEIPTS_DIR)
+    _ensure_dir(BY_PATH_DIR)
+    timestamp = _now_iso()
+    receipt = {"sha256": digest, "timestamp": timestamp, "verdict": "pass"}
+    _receipt_path(digest).write_text(json.dumps(receipt), encoding="utf-8")
+
+    # The by-path pointer lets a later `check` on the same path tell "never
+    # scored" apart from "scored, then edited" instead of just failing both
+    # the same way.
+    abs_path = str(Path(body_file).resolve())
+    pointer = {"path": abs_path, "sha256": digest, "timestamp": timestamp}
+    _path_pointer_path(abs_path).write_text(json.dumps(pointer), encoding="utf-8")
+    return 0
+
+
+def cmd_check(body_file: str) -> int:
+    data = _read_body_bytes(body_file)
+    if data is None:
+        return 1
+    digest = _sha256_bytes(data)
+    receipt = _read_json(_receipt_path(digest))
+    if receipt and receipt.get("sha256") == digest and receipt.get("verdict") == "pass":
+        print("valid")
+        return 0
+
+    abs_path = str(Path(body_file).resolve())
+    pointer = _read_json(_path_pointer_path(abs_path))
+    if pointer and pointer.get("sha256") and pointer.get("sha256") != digest:
+        print("stale: body edited after it was scored", file=sys.stderr)
+    else:
+        print("no receipt for this body", file=sys.stderr)
+    return 1
+
+
+def cmd_prune() -> int:
+    cutoff = datetime.now(timezone.utc) - PRUNE_AGE
+    removed = 0
+    for directory in (RECEIPTS_DIR, BY_PATH_DIR):
+        if not directory.is_dir():
+            continue
+        for entry in directory.glob("*.json"):
+            record = _read_json(entry)
+            timestamp = record.get("timestamp") if record else None
+            when = None
+            if timestamp:
+                try:
+                    when = datetime.fromisoformat(timestamp)
+                except ValueError:
+                    when = None
+            if when is None or when < cutoff:
+                entry.unlink(missing_ok=True)
+                removed += 1
+    print(f"pruned {removed} receipt(s)")
+    return 0
+
+
+def parse_arguments(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    write_parser = subparsers.add_parser("write", help="record a passing receipt")
+    write_parser.add_argument("body_file")
+
+    check_parser = subparsers.add_parser("check", help="exit 0 if a valid receipt exists")
+    check_parser.add_argument("body_file")
+
+    subparsers.add_parser("prune", help="delete receipts older than 7 days")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    try:
+        arguments = parse_arguments(argv)
+        if arguments.action == "write":
+            return cmd_write(arguments.body_file)
+        if arguments.action == "check":
+            return cmd_check(arguments.body_file)
+        if arguments.action == "prune":
+            return cmd_prune()
+    except Exception as error:  # noqa: BLE001 - must never crash the caller
+        print(f"pr_body_receipt: internal error: {error}", file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_body.py
+++ b/tests/test_pr_body.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import Optional
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "skills" / "pr-body" / "scripts" / "pr_body_lint.py"
+SKILL_MD = ROOT / "skills" / "pr-body" / "SKILL.md"
+RUBRIC_MD = ROOT / "skills" / "pr-body" / "references" / "rubric.md"
+
+DISCLOSURE = "This PR was written in part with the assistance of generative AI."
+
+
+def lint(body: str, *, repo: Optional[Path] = None) -> dict:
+    command = [sys.executable, str(SCRIPT), "--json"]
+    if repo is not None:
+        command.extend(["--repo", str(repo)])
+    result = subprocess.run(
+        command,
+        input=body,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=5,
+    )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise AssertionError(
+            f"non-JSON output (exit {result.returncode}): "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        ) from error
+
+
+def rules_fired(result: dict) -> set[str]:
+    return {finding["rule"] for finding in result["findings"]}
+
+
+def finding_for(result: dict, rule: str) -> dict:
+    for finding in result["findings"]:
+        if finding["rule"] == rule:
+            return finding
+    raise AssertionError(f"rule {rule!r} did not fire: {result}")
+
+
+class EmptyBodyTests(unittest.TestCase):
+    def test_trips_on_empty_and_whitespace_only_bodies(self):
+        for body in ("", "   ", "\n\n  \n"):
+            with self.subTest(body=repr(body)):
+                result = lint(body)
+                self.assertEqual(result["verdict"], "fail")
+                self.assertIn("empty-body", rules_fired(result))
+
+    def test_does_not_trip_on_a_real_body(self):
+        body = f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("empty-body", rules_fired(result))
+
+    def test_fix_text_is_an_instruction(self):
+        result = lint("")
+        finding = finding_for(result, "empty-body")
+        self.assertIn("state", finding["fix"].lower())
+
+
+class AiDisclosureMissingTests(unittest.TestCase):
+    def test_trips_when_no_disclosure_is_present(self):
+        body = "Grows the appliance data volume from 2TB to 4TB.\n"
+        result = lint(body)
+        self.assertEqual(result["verdict"], "fail")
+        self.assertIn("ai-disclosure-missing", rules_fired(result))
+
+    def test_does_not_trip_on_the_suggested_wording(self):
+        body = f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("ai-disclosure-missing", rules_fired(result))
+
+    def test_does_not_trip_on_a_differently_worded_disclosure(self):
+        body = (
+            "Grows the appliance data volume from 2TB to 4TB.\n\n"
+            "Written with AI assistance.\n"
+        )
+        result = lint(body)
+        self.assertNotIn("ai-disclosure-missing", rules_fired(result))
+
+    def test_fix_text_supplies_a_usable_sentence(self):
+        result = lint("Grows the appliance data volume from 2TB to 4TB.\n")
+        finding = finding_for(result, "ai-disclosure-missing")
+        self.assertIn("generative ai", finding["fix"].lower())
+
+
+class EmptyTemplateSectionTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        (self.repo / ".github").mkdir()
+        (self.repo / ".github" / "pull_request_template.md").write_text(
+            "## What does this PR do?\n\n## Testing\n\n## Jira ticket number?\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_trips_when_a_template_section_is_left_unfilled(self):
+        # The empty section sits before another heading, not at the very
+        # end, so it is not the exempt trailing-metadata case.
+        body = (
+            "## What does this PR do?\n\n"
+            f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n\n"
+            "## Testing\n\n"
+            "## Jira ticket number?\n\nDEVOPS-1234\n"
+        )
+        result = lint(body, repo=self.repo)
+        self.assertEqual(result["verdict"], "fail")
+        self.assertIn("empty-template-section", rules_fired(result))
+
+    def test_does_not_trip_when_every_section_is_filled(self):
+        body = (
+            "## What does this PR do?\n\n"
+            f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n\n"
+            "## Testing\n\nResources: 1 to update.\n\n"
+            "## Jira ticket number?\n\nDEVOPS-1234\n"
+        )
+        result = lint(body, repo=self.repo)
+        self.assertNotIn("empty-template-section", rules_fired(result))
+
+    def test_does_not_trip_when_only_the_trailing_section_is_empty(self):
+        # An empty final section is almost always optional metadata (a
+        # ticket link with no ticket); it is not the abandoned-template
+        # failure this rule targets.
+        body = (
+            "## What does this PR do?\n\n"
+            f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n\n"
+            "## Jira ticket number?\n"
+        )
+        result = lint(body, repo=self.repo)
+        self.assertNotIn("empty-template-section", rules_fired(result))
+
+    def test_fix_text_names_the_empty_heading(self):
+        body = (
+            "## What does this PR do?\n\n"
+            f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n\n"
+            "## Testing\n\n"
+            "## Jira ticket number?\n\nDEVOPS-1234\n"
+        )
+        result = lint(body, repo=self.repo)
+        finding = finding_for(result, "empty-template-section")
+        self.assertIn("Testing", finding["fix"])
+
+
+class VacuousOpenerTests(unittest.TestCase):
+    def test_trips_on_googles_named_bad_openers(self):
+        for opener in ("Fix bug", "Fix build", "Add patch", "Phase 1"):
+            with self.subTest(opener=opener):
+                body = f"{opener}.\n\n{DISCLOSURE}\n"
+                result = lint(body)
+                self.assertIn("vacuous-opener", rules_fired(result), body)
+
+    def test_does_not_trip_on_a_real_opener(self):
+        body = f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("vacuous-opener", rules_fired(result))
+
+    def test_fix_text_asks_for_the_actual_behavior(self):
+        result = lint(f"Fix bug.\n\n{DISCLOSURE}\n")
+        finding = finding_for(result, "vacuous-opener")
+        self.assertIn("behavior", finding["fix"].lower())
+
+
+class EmDashTests(unittest.TestCase):
+    def test_trips_on_an_em_dash(self):
+        body = f"Grows the volume — it was near capacity.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertIn("em-dash", rules_fired(result))
+
+    def test_does_not_trip_without_one(self):
+        body = f"Grows the volume; it was near capacity.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("em-dash", rules_fired(result))
+
+    def test_fix_text_asks_for_a_rewrite(self):
+        result = lint(f"Grows the volume — it was near capacity.\n\n{DISCLOSURE}\n")
+        finding = finding_for(result, "em-dash")
+        self.assertIn("em dash", finding["fix"].lower())
+
+
+class EmojiTests(unittest.TestCase):
+    def test_trips_on_an_emoji(self):
+        body = f"Grows the volume \U0001F680 to 4TB.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertIn("emoji", rules_fired(result))
+
+    def test_does_not_trip_without_one(self):
+        body = f"Grows the volume from 2TB to 4TB.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("emoji", rules_fired(result))
+
+    def test_fix_text_asks_for_removal(self):
+        result = lint(f"Grows the volume \U0001F680 to 4TB.\n\n{DISCLOSURE}\n")
+        finding = finding_for(result, "emoji")
+        self.assertIn("remove", finding["fix"].lower())
+
+
+class PathInProseTests(unittest.TestCase):
+    def test_trips_on_a_path_in_prose(self):
+        body = (
+            "Fixes the rule loaded from roles/checkmk_manage_config/tasks/rules.yml.\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertIn("path-in-prose", rules_fired(result))
+
+    def test_does_not_trip_on_the_same_path_in_a_code_fence(self):
+        body = (
+            "Fixes the rule loading order.\n\n"
+            "```\nroles/checkmk_manage_config/tasks/rules.yml\n```\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertNotIn("path-in-prose", rules_fired(result))
+
+    def test_does_not_trip_on_the_same_path_in_backticks(self):
+        body = (
+            "Fixes the rule loading order in `roles/checkmk_manage_config/tasks/rules.yml`.\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertNotIn("path-in-prose", rules_fired(result))
+
+    def test_does_not_trip_on_a_markdown_link_target(self):
+        body = (
+            "See [the rule file](roles/checkmk_manage_config/tasks/rules.yml) for detail.\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertNotIn("path-in-prose", rules_fired(result))
+
+    def test_fix_text_asks_for_behavior_not_files(self):
+        body = (
+            "Fixes the rule loaded from roles/checkmk_manage_config/tasks/rules.yml.\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        finding = finding_for(result, "path-in-prose")
+        self.assertIn("diff already lists files", finding["fix"])
+
+
+class MethodNarrationTests(unittest.TestCase):
+    def test_trips_on_narrating_the_verification_method(self):
+        body = f"Verified with pulumi preview against dev.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertIn("method-narration", rules_fired(result))
+
+    def test_does_not_trip_on_stating_the_result(self):
+        body = f"Resources: 1 to update.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("method-narration", rules_fired(result))
+
+    def test_fix_text_asks_for_the_result(self):
+        result = lint(f"I ran the test suite locally.\n\n{DISCLOSURE}\n")
+        finding = finding_for(result, "method-narration")
+        self.assertIn("result", finding["fix"].lower())
+
+
+class VerdictClauseTests(unittest.TestCase):
+    def test_trips_on_a_rating_of_the_change(self):
+        body = f"This is a low-risk change.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertIn("verdict-clause", rules_fired(result))
+
+    def test_does_not_trip_on_the_mechanism_fact(self):
+        body = f"EBS expands online, no downtime.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("verdict-clause", rules_fired(result))
+
+    def test_fix_text_asks_for_the_concrete_fact(self):
+        result = lint(f"This is a low-risk change.\n\n{DISCLOSURE}\n")
+        finding = finding_for(result, "verdict-clause")
+        self.assertIn("fact", finding["fix"].lower())
+
+
+class ReviewerInstructionTests(unittest.TestCase):
+    def test_trips_on_an_instruction_to_the_reviewer(self):
+        body = f"Please review the linked runbook before merging.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertIn("reviewer-instruction", rules_fired(result))
+
+    def test_does_not_trip_when_nothing_is_asked(self):
+        body = f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("reviewer-instruction", rules_fired(result))
+
+    def test_fix_text_asks_to_delete_the_instruction(self):
+        result = lint(f"Please review the linked runbook before merging.\n\n{DISCLOSURE}\n")
+        finding = finding_for(result, "reviewer-instruction")
+        self.assertIn("delete", finding["fix"].lower())
+
+
+class BulletPerFileTests(unittest.TestCase):
+    def test_trips_when_most_bullets_lead_with_a_file(self):
+        body = (
+            "Refactors the config loader.\n\n"
+            "- config/loader.py: rewrote parsing\n"
+            "- config/schema.yml: added new fields\n"
+            "- tests/test_loader.py: added coverage\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertIn("bullet-per-file", rules_fired(result))
+
+    def test_does_not_trip_when_bullets_describe_behavior(self):
+        body = (
+            "Refactors the config loader to validate schema before parsing.\n\n"
+            "- Validates required fields before parsing\n"
+            "- Falls back to defaults for optional fields\n"
+            "- Adds coverage for the new validation path\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertNotIn("bullet-per-file", rules_fired(result))
+
+    def test_fix_text_asks_for_the_shared_behavior(self):
+        body = (
+            "Refactors the config loader.\n\n"
+            "- config/loader.py: rewrote parsing\n"
+            "- config/schema.yml: added new fields\n"
+            "- tests/test_loader.py: added coverage\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        finding = finding_for(result, "bullet-per-file")
+        self.assertIn("behavior", finding["fix"].lower())
+
+
+class SymbolInProseTests(unittest.TestCase):
+    def test_trips_on_an_identifier_outside_backticks(self):
+        body = f"Sets schedule_expression to run nightly.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertIn("symbol-in-prose", rules_fired(result))
+
+    def test_is_warn_severity_and_does_not_fail_the_verdict_alone(self):
+        body = f"Sets schedule_expression to run nightly.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        finding = finding_for(result, "symbol-in-prose")
+        self.assertEqual(finding["severity"], "warn")
+        self.assertEqual(result["verdict"], "pass")
+
+    def test_does_not_trip_when_the_identifier_is_backticked(self):
+        body = f"Sets `schedule_expression` to run nightly.\n\n{DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("symbol-in-prose", rules_fired(result))
+
+
+class TemplateAwarenessTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        (self.repo / ".github").mkdir()
+        (self.repo / ".github" / "pull_request_template.md").write_text(
+            "## What does this PR do?\n\n"
+            "## Testing\n\n"
+            "## Jira ticket number?\n\n"
+            "- [ ] Please review the linked runbook before merging\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_template_checkbox_line_is_not_flagged_as_a_reviewer_instruction(self):
+        body = (
+            "## What does this PR do?\n\n"
+            f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n\n"
+            "- [ ] Please review the linked runbook before merging\n\n"
+            "## Testing\n\nResources: 1 to update.\n\n"
+            "## Jira ticket number?\n\nDEVOPS-1234\n"
+        )
+        result = lint(body, repo=self.repo)
+        self.assertNotIn("reviewer-instruction", rules_fired(result))
+
+    def test_unfilled_template_section_still_trips_despite_scaffolding(self):
+        # "Testing" is left blank and is not the trailing section, so the
+        # scaffolding checkbox elsewhere in the body must not mask it.
+        body = (
+            "## What does this PR do?\n\n"
+            f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n\n"
+            "- [ ] Please review the linked runbook before merging\n\n"
+            "## Testing\n\n"
+            "## Jira ticket number?\n\nDEVOPS-1234\n"
+        )
+        result = lint(body, repo=self.repo)
+        self.assertIn("empty-template-section", rules_fired(result))
+
+    def test_without_repo_the_same_checkbox_line_is_scored_normally(self):
+        body = (
+            "## What does this PR do?\n\n"
+            f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n\n"
+            "- [ ] Please review the linked runbook before merging\n\n"
+            "## Jira ticket number?\n"
+        )
+        result = lint(body, repo=None)
+        self.assertIn("reviewer-instruction", rules_fired(result))
+
+
+class NonSignalRegressionTests(unittest.TestCase):
+    """Guards against re-adding rules the corpus and research refuted."""
+
+    def test_markdown_headers_alone_do_not_fail(self):
+        body = (
+            "## Summary\n\n"
+            "Grows the appliance data volume from 2TB to 4TB.\n\n"
+            "## Testing\n\n"
+            "Resources: 1 to update.\n\n"
+            "## Notes\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertEqual(result["verdict"], "pass")
+
+    def test_checkboxes_alone_do_not_fail(self):
+        body = (
+            "Grows the appliance data volume from 2TB to 4TB.\n\n"
+            "- [ ] Migration applied in staging\n"
+            "- [ ] On-call notified\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertEqual(result["verdict"], "pass")
+
+    def test_generic_ai_vocabulary_words_alone_do_not_fail(self):
+        body = (
+            "This is a comprehensive, robust rewrite that seamlessly leverages "
+            "the existing cache layer.\n\n"
+            f"{DISCLOSURE}\n"
+        )
+        result = lint(body)
+        self.assertEqual(result["verdict"], "pass")
+
+
+class BacktrackingGuardTests(unittest.TestCase):
+    def test_pathological_input_completes_quickly(self):
+        cases = [
+            "/" * 50_000,
+            "-" * 50_000,
+            ("to " * 5_000) + "x",
+            ("/" + "a" * 10 + ".py ") * 3_000,
+            "!" * 50_000,
+        ]
+        for case in cases:
+            with self.subTest(case=case[:20]):
+                start = time.monotonic()
+                result = lint(case)
+                elapsed = time.monotonic() - start
+                self.assertLess(elapsed, 2.0)
+                self.assertIn(result["verdict"], ("pass", "fail"))
+
+    def test_oversized_input_is_a_block_not_a_hang(self):
+        start = time.monotonic()
+        result = lint("x" * 30_000)
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 2.0)
+        self.assertEqual(result["verdict"], "fail")
+        self.assertIn("oversized-input", rules_fired(result))
+
+    def test_oversized_input_fix_asks_for_a_file_not_a_shorter_body(self):
+        result = lint("x" * 30_000)
+        finding = finding_for(result, "oversized-input")
+        self.assertIn("--body-file", finding["fix"])
+
+
+class RobustnessTests(unittest.TestCase):
+    def test_exit_code_matches_verdict(self):
+        passing = subprocess.run(
+            [sys.executable, str(SCRIPT), "--json"],
+            input=f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(passing.returncode, 0)
+
+        failing = subprocess.run(
+            [sys.executable, str(SCRIPT), "--json"],
+            input="",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(failing.returncode, 1)
+
+    def test_body_file_argument_is_read_instead_of_stdin(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            body_file = Path(scratch) / "body.txt"
+            body_file.write_text(
+                f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--json", "--body-file", str(body_file)],
+                input="",
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["verdict"], "pass")
+
+
+class RuleNameDriftTests(unittest.TestCase):
+    """Keeps the rule names in the scorer, SKILL.md, and rubric.md from diverging.
+
+    Extraction convention (keep this comment accurate if the docs' shape changes):
+      - pr_body_lint.py: the keys of its own SEVERITY dict, the scorer's rule
+        registry.
+      - SKILL.md: the first column of the "Rules the scorer implements" table,
+        a backticked lowercase-hyphen token at the start of a table row
+        (`^\\| \\`([a-z][a-z0-9-]*)\\` \\|`).
+      - rubric.md: the rule heading for each entry, a level-3 heading whose text
+        is a backticked lowercase-hyphen token followed by "(block)" or "(warn)"
+        (`^### \\`([a-z][a-z0-9-]*)\\` \\((?:block|warn)\\)`). This intentionally
+        excludes the "Known disagreements" headings further down that also
+        backtick a rule name (e.g. "`reviewer-instruction` runs against..."),
+        because those aren't followed by a severity in parens.
+    """
+
+    SKILL_TABLE_ROW_RE = re.compile(r"^\|\s*`([a-z][a-z0-9-]*)`\s*\|", re.MULTILINE)
+    RUBRIC_HEADING_RE = re.compile(
+        r"^### `([a-z][a-z0-9-]*)` \((?:block|warn)\)", re.MULTILINE
+    )
+
+    @staticmethod
+    def _rules_in_lint_registry() -> set[str]:
+        spec = importlib.util.spec_from_file_location("pr_body_lint_drift_check", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return set(module.SEVERITY.keys())
+
+    @classmethod
+    def _rules_in_skill_md(cls) -> set[str]:
+        return set(cls.SKILL_TABLE_ROW_RE.findall(SKILL_MD.read_text(encoding="utf-8")))
+
+    @classmethod
+    def _rules_in_rubric_md(cls) -> set[str]:
+        return set(cls.RUBRIC_HEADING_RE.findall(RUBRIC_MD.read_text(encoding="utf-8")))
+
+    def test_rule_names_agree_across_scorer_skill_and_rubric(self):
+        sources = {
+            "pr_body_lint.py (SEVERITY registry)": self._rules_in_lint_registry(),
+            "SKILL.md (rules table)": self._rules_in_skill_md(),
+            "references/rubric.md (rule headings)": self._rules_in_rubric_md(),
+        }
+        for name, rules in sources.items():
+            self.assertTrue(rules, f"extracted zero rule names from {name}; "
+                                    f"the extraction pattern likely no longer matches its shape")
+
+        all_rules = set().union(*sources.values())
+        problems = []
+        for rule in sorted(all_rules):
+            missing_from = [name for name, rules in sources.items() if rule not in rules]
+            if missing_from:
+                problems.append(f"  {rule!r} missing from: {', '.join(missing_from)}")
+
+        if problems:
+            self.fail(
+                "Rule name drift between the scorer, SKILL.md, and rubric.md "
+                "(a rule present in one and absent from another is decorative "
+                "documentation or an unscored claim):\n" + "\n".join(problems)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_body_bench.py
+++ b/tests/test_pr_body_bench.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCH_SCRIPT = ROOT / "bench" / "pr_body_bench.py"
+
+
+def _load_bench():
+    spec = importlib.util.spec_from_file_location("pr_body_bench", BENCH_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+BENCH = _load_bench()
+
+DISCLOSURE = "This PR was written in part with the assistance of generative AI."
+BODY_PASS = f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n"
+BODY_FAIL_VACUOUS = "Fix bug.\n"
+
+
+class SkillSliceExtractionTests(unittest.TestCase):
+    """Experiment A: does extraction find the four slices, and fail loudly if not."""
+
+    def test_extracts_all_four_slices_non_empty_or_deliberately_empty(self):
+        slices = BENCH.build_skill_slices()
+        self.assertEqual(slices["none"], "")
+        for arm in ("example", "rules", "full"):
+            self.assertTrue(slices[arm].strip(), f"{arm} slice was empty")
+
+    def test_example_slice_contains_the_fenced_block_and_following_paragraph(self):
+        slices = BENCH.build_skill_slices()
+        self.assertIn("```markdown", slices["example"])
+        self.assertIn(DISCLOSURE, slices["example"])
+        self.assertIn("No headings", slices["example"])
+
+    def test_rules_slice_contains_the_shape_and_textures_to_cut_only(self):
+        slices = BENCH.build_skill_slices()
+        self.assertIn("Open with the action", slices["rules"])
+        self.assertIn("Verdict clauses", slices["rules"])
+        # Content unique to other sections must not leak in.
+        self.assertNotIn("gh pr create --body-file", slices["rules"])
+        self.assertNotIn("PreToolUse hook", slices["rules"])
+
+    def test_full_slice_is_the_entire_skill_md(self):
+        slices = BENCH.build_skill_slices()
+        self.assertEqual(slices["full"], BENCH.SKILL_MD.read_text(encoding="utf-8"))
+
+    def test_slices_are_disjoint_in_size_and_full_is_largest(self):
+        slices = BENCH.build_skill_slices()
+        sizes = {arm: len(slices[arm]) for arm in BENCH.ARMS}
+        self.assertLess(sizes["none"], sizes["example"])
+        self.assertLess(sizes["example"], sizes["full"])
+        self.assertLess(sizes["rules"], sizes["full"])
+
+    def test_moved_shape_heading_raises_instead_of_shipping_empty_slice(self):
+        text = BENCH.SKILL_MD.read_text(encoding="utf-8").replace(
+            "## The shape", "## The Shapeee"
+        )
+        with self.assertRaises(BENCH.SkillExtractionError):
+            BENCH.build_skill_slices(text)
+
+    def test_moved_textures_heading_raises(self):
+        text = BENCH.SKILL_MD.read_text(encoding="utf-8").replace(
+            "## Textures to cut", "## Stuff to trim"
+        )
+        with self.assertRaises(BENCH.SkillExtractionError):
+            BENCH.build_skill_slices(text)
+
+    def test_missing_fenced_example_block_raises(self):
+        text = BENCH.SKILL_MD.read_text(encoding="utf-8").replace(
+            "```markdown", "~~~markdown"
+        )
+        with self.assertRaises(BENCH.SkillExtractionError):
+            BENCH.build_skill_slices(text)
+
+    def test_heading_present_but_body_empty_raises(self):
+        text = "# PR body\n\n## The shape\n\n## Textures to cut\n\nsomething\n"
+        with self.assertRaises(BENCH.SkillExtractionError):
+            BENCH.build_skill_slices(text)
+
+
+class BuildPromptTests(unittest.TestCase):
+    def test_none_arm_is_the_diff_only(self):
+        slices = {"none": "", "example": "EX", "rules": "R", "full": "F"}
+        prompt = BENCH.build_prompt("diff body", "none", slices)
+        self.assertNotIn("EX", prompt)
+        self.assertIn("diff body", prompt)
+
+    def test_other_arms_prepend_their_slice(self):
+        slices = {"none": "", "example": "EX-TEXT", "rules": "R", "full": "F"}
+        prompt = BENCH.build_prompt("diff body", "example", slices)
+        self.assertIn("EX-TEXT", prompt)
+        self.assertLess(prompt.index("EX-TEXT"), prompt.index("diff body"))
+
+
+class RetryPromptTests(unittest.TestCase):
+    """Experiment C: fix-text carries the fix instruction, rule-names does not."""
+
+    def setUp(self):
+        self.findings = [
+            {"rule": "em-dash", "severity": "block", "line": 3, "excerpt": "x",
+             "fix": "Rewrite without an em dash; use a period or parentheses instead."},
+            {"rule": "symbol-in-prose", "severity": "warn", "line": 5, "excerpt": "y",
+             "fix": "Wrap the identifier in backticks."},
+        ]
+
+    def test_fix_text_mode_includes_the_fix_instruction(self):
+        prompt = BENCH.build_retry_prompt("previous body", self.findings, "fix-text")
+        self.assertIn("Rewrite without an em dash", prompt)
+        self.assertIn("Wrap the identifier in backticks", prompt)
+        self.assertIn("em-dash", prompt)
+
+    def test_rule_names_mode_excludes_the_fix_instruction(self):
+        prompt = BENCH.build_retry_prompt("previous body", self.findings, "rule-names")
+        self.assertIn("em-dash", prompt)
+        self.assertNotIn("Rewrite without an em dash", prompt)
+        self.assertNotIn("Wrap the identifier in backticks", prompt)
+
+    def test_both_modes_echo_the_previous_body(self):
+        for mode in ("fix-text", "rule-names"):
+            prompt = BENCH.build_retry_prompt("previous body", self.findings, mode)
+            self.assertIn("previous body", prompt)
+
+
+class ScoreBodyTests(unittest.TestCase):
+    def test_passing_body_scores_pass_with_no_blocking_rules(self):
+        result = BENCH.score_body(BODY_PASS)
+        self.assertEqual(result["verdict"], "pass")
+        self.assertEqual(result["blocking_rules_fired"], [])
+
+    def test_failing_body_carries_findings_for_the_retry_prompt(self):
+        result = BENCH.score_body(BODY_FAIL_VACUOUS)
+        self.assertEqual(result["verdict"], "fail")
+        self.assertIn("vacuous-opener", result["rules_fired"])
+        findings_rules = {f["rule"] for f in result["findings"]}
+        self.assertIn("vacuous-opener", findings_rules)
+
+
+class OneRunLoopTests(unittest.TestCase):
+    """Experiment B: the deny-and-fix loop, exercised with a stubbed call_claude
+    so no model call happens. Each test replaces BENCH.call_claude with a canned
+    sequence of responses and checks the round bookkeeping one_run produces."""
+
+    def setUp(self):
+        self._original_call_claude = BENCH.call_claude
+        self.slices = {"none": "", "example": "EX", "rules": "R", "full": "F"}
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.diff_path = Path(self._tmpdir.name) / "fixture.diff"
+        self.diff_path.write_text("diff --git a/x b/x\n+line\n", encoding="utf-8")
+
+    def tearDown(self):
+        BENCH.call_claude = self._original_call_claude
+        self._tmpdir.cleanup()
+
+    def _run(self, responses, arm="none", retry_mode="fix-text"):
+        fake = MagicMock(side_effect=responses)
+        BENCH.call_claude = fake
+        row = BENCH.one_run(
+            project=Path("/unused"), model="m", arm=arm,
+            diff_path=self.diff_path,
+            retry_mode=retry_mode, skill_slices=self.slices,
+        )
+        return row, fake
+
+    def test_pass_on_first_draft_needs_no_retry(self):
+        row, fake = self._run([{"body": BODY_PASS, "output_tokens": 10}])
+        self.assertEqual(fake.call_count, 1)
+        self.assertEqual(len(row["rounds"]), 1)
+        self.assertEqual(row["rounds"][0]["verdict"], "pass")
+        self.assertEqual(row["rounds_to_pass"], 0)
+        self.assertEqual(row["output_tokens_total"], 10)
+        self.assertNotIn("error", row)
+
+    def test_fails_then_recovers_on_first_retry(self):
+        row, fake = self._run([
+            {"body": BODY_FAIL_VACUOUS, "output_tokens": 5},
+            {"body": BODY_PASS, "output_tokens": 8},
+        ])
+        self.assertEqual(fake.call_count, 2)
+        self.assertEqual(len(row["rounds"]), 2)
+        self.assertEqual(row["rounds"][0]["verdict"], "fail")
+        self.assertEqual(row["rounds"][1]["verdict"], "pass")
+        self.assertEqual(row["rounds_to_pass"], 1)
+        self.assertEqual(row["output_tokens_total"], 13)
+
+    def test_retry_prompt_carries_the_prior_findings(self):
+        _row, fake = self._run([
+            {"body": BODY_FAIL_VACUOUS, "output_tokens": 5},
+            {"body": BODY_PASS, "output_tokens": 8},
+        ], retry_mode="fix-text")
+        second_call_prompt = fake.call_args_list[1].args[2]
+        self.assertIn("vacuous-opener", second_call_prompt)
+        self.assertIn(BODY_FAIL_VACUOUS.strip(), second_call_prompt)
+
+    def test_never_passes_stops_after_max_rounds(self):
+        row, fake = self._run([{"body": BODY_FAIL_VACUOUS, "output_tokens": 1}] * 4)
+        self.assertEqual(fake.call_count, 4, "1 draft + 3 retries, no 5th call")
+        self.assertEqual(len(row["rounds"]), 4)
+        self.assertIsNone(row["rounds_to_pass"])
+        self.assertNotIn("error", row)
+
+    def test_error_mid_loop_stops_and_is_recorded_without_a_synthetic_round(self):
+        row, fake = self._run([
+            {"body": BODY_FAIL_VACUOUS, "output_tokens": 1},
+            {"error": "socket timeout"},
+        ])
+        self.assertEqual(fake.call_count, 2)
+        self.assertEqual(len(row["rounds"]), 1, "the errored attempt never got scored")
+        self.assertEqual(row.get("error"), "socket timeout")
+        self.assertIsNone(row["rounds_to_pass"])
+
+    def test_draft_error_leaves_rounds_empty(self):
+        row, fake = self._run([{"error": "no draft"}])
+        self.assertEqual(fake.call_count, 1)
+        self.assertEqual(row["rounds"], [])
+        self.assertEqual(row["error"], "no draft")
+
+
+class CompletedKeysTests(unittest.TestCase):
+    def test_dedupes_by_arm_diff_model_repeat_and_retry_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "r.jsonl"
+            rows = [
+                {"arm": "full", "diff": "a.diff", "model": "m", "repeat": 0, "retry_mode": "fix-text"},
+                {"arm": "full", "diff": "a.diff", "model": "m", "repeat": 0, "retry_mode": "rule-names"},
+                {"arm": "full", "diff": "a.diff", "model": "m"},  # legacy row, no repeat/retry_mode
+            ]
+            path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+            keys = BENCH._completed_keys(path)
+        self.assertIn(("full", "a.diff", "m", 0, "fix-text"), keys)
+        self.assertIn(("full", "a.diff", "m", 0, "rule-names"), keys)
+        self.assertEqual(len(keys), 2, "legacy row with no retry_mode collapses onto fix-text/repeat0")
+
+    def test_missing_file_yields_empty_set(self):
+        self.assertEqual(BENCH._completed_keys(Path("/no/such/file.jsonl")), set())
+
+
+def _row(arm, rounds, retry_mode="fix-text", error=None, diff="d.diff", repeat=0):
+    row = {
+        "arm": arm, "retry_mode": retry_mode, "diff": diff, "model": "m",
+        "repeat": repeat, "rounds": rounds,
+    }
+    if rounds:
+        row["rounds_to_pass"] = next(
+            (r["round"] for r in rounds if r["verdict"] == "pass"), None
+        )
+    else:
+        row["rounds_to_pass"] = None
+    if error:
+        row["error"] = error
+    return row
+
+
+def _round(index, verdict, rules_fired, chars=100):
+    blocking = list(rules_fired) if verdict == "fail" else []
+    return {
+        "round": index, "body": f"body {index}", "chars": chars, "verdict": verdict,
+        "rules_fired": list(rules_fired), "blocking_rules_fired": blocking,
+    }
+
+
+class AggregationTests(unittest.TestCase):
+    """Exercises cmd_score's aggregation and reporting against fabricated rows,
+    standing in for a real 'run' (no model call is made anywhere in this class)."""
+
+    def _canned_rows(self):
+        rows = []
+        # Two never-in-3 survivors sharing "path-in-prose" so the final-round
+        # per-rule table should flag it as surviving the loop.
+        rows.append(_row("none", [
+            _round(0, "fail", ["ai-disclosure-missing"]),
+            _round(1, "pass", []),
+        ]))
+        rows.append(_row("none", [
+            _round(0, "fail", ["ai-disclosure-missing", "path-in-prose"]),
+            _round(1, "fail", ["path-in-prose"]),
+            _round(2, "fail", ["path-in-prose"]),
+            _round(3, "fail", ["path-in-prose"]),
+        ]))
+        rows.append(_row("example", [_round(0, "pass", [])]))
+        rows.append(_row("example", [
+            _round(0, "fail", ["em-dash"]),
+            _round(1, "pass", []),
+        ]))
+        rows.append(_row("rules", [
+            _round(0, "fail", ["path-in-prose"]),
+            _round(1, "fail", ["path-in-prose"]),
+            _round(2, "fail", ["path-in-prose"]),
+            _round(3, "fail", ["path-in-prose"]),
+        ]))
+        rows.append(_row("full", [_round(0, "pass", [])]))
+        # Fully errored: no draft at all.
+        rows.append(_row("full", [], error="timeout"))
+        # Partial: a draft exists but a retry call errored before round 3.
+        rows.append(_row("rules", [_round(0, "fail", ["emoji"])], error="non-JSON output"))
+        # rule-names arm for Experiment C.
+        rows.append(_row("full", [
+            _round(0, "fail", ["em-dash"]),
+            _round(1, "pass", []),
+        ], retry_mode="rule-names"))
+        rows.append(_row("full", [
+            _round(0, "fail", ["em-dash"]),
+            _round(1, "fail", ["em-dash"]),
+            _round(2, "fail", ["em-dash"]),
+            _round(3, "fail", ["em-dash"]),
+        ], retry_mode="rule-names"))
+        return rows
+
+    def _score_output(self, tag="canned"):
+        with tempfile.TemporaryDirectory() as tmp:
+            results_dir = Path(tmp)
+            original_results = BENCH.RESULTS
+            BENCH.RESULTS = results_dir
+            try:
+                out_path = results_dir / f"{tag}.jsonl"
+                out_path.write_text(
+                    "\n".join(json.dumps(r) for r in self._canned_rows()) + "\n"
+                )
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    exit_code = BENCH.cmd_score(argparse.Namespace(tag=tag))
+            finally:
+                BENCH.RESULTS = original_results
+        return exit_code, buffer.getvalue()
+
+    def test_reports_the_caveat_verbatim_and_not_buried(self):
+        _code, output = self._score_output()
+        self.assertIn(BENCH.CAVEAT, output)
+
+    def test_counts_fully_errored_and_partial_rows_separately(self):
+        _code, output = self._score_output()
+        self.assertIn("1 errored before any draft", output)
+        self.assertIn("1 errored mid-loop after a draft", output)
+
+    def test_reports_first_draft_pass_rate_per_arm_with_n(self):
+        _code, output = self._score_output()
+        for arm in BENCH.ARMS:
+            self.assertIn(f"{arm}:", output)
+        self.assertIn("n=", output)
+
+    def test_untaught_ai_disclosure_is_adjusted_for_the_none_arm(self):
+        # Row 1 for "none" fails raw lint on ai-disclosure-missing alone at
+        # round 0; the adjusted first-draft pass rate must still count it as
+        # a pass, since "none" was never told the requirement exists.
+        rows = [r for r in self._canned_rows() if r["arm"] == "none"]
+        bucket = BENCH._bucket_first_draft(rows, "none")
+        self.assertEqual(bucket["n"], 2)
+        self.assertEqual(bucket["raw_pass"], 0, "both round-0s fail raw lint")
+        self.assertEqual(bucket["adj_pass"], 1, "only the disclosure-only failure is forgiven")
+
+    def test_flags_a_rule_that_survives_the_loop(self):
+        _code, output = self._score_output()
+        self.assertIn("SURVIVES THE LOOP", output)
+        self.assertIn("path-in-prose", output)
+
+    def test_prints_not_measurable_language_when_a_delta_is_inside_the_band(self):
+        _code, output = self._score_output()
+        self.assertIn("the effect is not measurable at this sample size", output)
+
+    def test_experiment_c_section_compares_fix_text_and_rule_names(self):
+        _code, output = self._score_output()
+        self.assertIn("Experiment C", output)
+        self.assertIn("fix-text vs rule-names", output)
+        self.assertIn("rule-names:", output)
+
+    def test_experiment_c_section_handles_no_rule_names_data_gracefully(self):
+        rows = [r for r in self._canned_rows() if r.get("retry_mode") != "rule-names"]
+        with tempfile.TemporaryDirectory() as tmp:
+            results_dir = Path(tmp)
+            original_results = BENCH.RESULTS
+            BENCH.RESULTS = results_dir
+            try:
+                out_path = results_dir / "no-rn.jsonl"
+                out_path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    exit_code = BENCH.cmd_score(argparse.Namespace(tag="no-rn"))
+            finally:
+                BENCH.RESULTS = original_results
+        self.assertEqual(exit_code, 0)
+        self.assertIn("no rule-names runs recorded", buffer.getvalue())
+
+    def test_missing_results_file_reports_error_and_nonzero_exit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original_results = BENCH.RESULTS
+            BENCH.RESULTS = Path(tmp)
+            try:
+                exit_code = BENCH.cmd_score(argparse.Namespace(tag="does-not-exist"))
+            finally:
+                BENCH.RESULTS = original_results
+        self.assertEqual(exit_code, 1)
+
+
+class TwoSampleReportTests(unittest.TestCase):
+    def _capture(self, *args):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            BENCH._report_two_sample("label", *args)
+        return buffer.getvalue()
+
+    def test_small_delta_relative_to_band_is_not_measurable(self):
+        output = self._capture(0.55, 20, 0.50, 20)
+        self.assertIn("the effect is not measurable at this sample size", output)
+
+    def test_large_delta_relative_to_band_clears_the_band(self):
+        output = self._capture(0.95, 40, 0.10, 40)
+        self.assertIn("clears the noise band", output)
+
+    def test_both_unanimous_and_equal_reports_zero_effect_not_measurable(self):
+        output = self._capture(1.0, 10, 1.0, 10)
+        self.assertIn("the effect is not measurable at this sample size", output)
+
+    def test_both_unanimous_but_different_reports_full_separation(self):
+        output = self._capture(1.0, 10, 0.0, 10)
+        self.assertIn("full separation", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_body_gate.py
+++ b/tests/test_pr_body_gate.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT_SCRIPT = ROOT / "skills" / "pr-body" / "scripts" / "pr_body_receipt.py"
+# The gate is a hook, so it lives with the machine's other hooks rather than in
+# this pack. Point PR_BODY_GATE_HOOK at a working copy to test it before install;
+# otherwise these tests run against the installed hook, or skip.
+HOOK = Path(
+    os.environ.get("PR_BODY_GATE_HOOK", Path.home() / ".claude" / "hooks" / "pr-body-gate")
+)
+
+BODY = "Grows the appliance data volume from 2TB to 4TB.\n"
+
+
+def run_hook(command: str, cwd: Path, home: Path) -> subprocess.CompletedProcess:
+    payload = json.dumps({"tool_input": {"command": command}, "cwd": str(cwd)})
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=payload,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+        timeout=5,
+    )
+
+
+def run_hook_raw(stdin_text: str, cwd: Path, home: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=stdin_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+        timeout=5,
+        cwd=str(cwd),
+    )
+
+
+def deny_reason(result: subprocess.CompletedProcess) -> Optional[str]:
+    stdout = result.stdout.strip()
+    if not stdout:
+        return None
+    payload = json.loads(stdout)
+    return payload["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def write_receipt(body_file: Path, home: Path) -> None:
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    result = subprocess.run(
+        [sys.executable, str(RECEIPT_SCRIPT), "write", str(body_file)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@unittest.skipUnless(
+    HOOK.exists(),
+    f"gate hook not found at {HOOK}; set PR_BODY_GATE_HOOK to a working copy",
+)
+class GateTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.cwd = Path(self.temporary.name)
+        self.home = self.cwd / "home"
+        self.home.mkdir()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def write_body(self, name: str, text: str = BODY) -> Path:
+        path = self.cwd / name
+        path.write_text(text, encoding="utf-8")
+        return path
+
+
+class ValidReceiptTests(GateTestCase):
+    def test_body_file_with_a_valid_receipt_is_allowed(self):
+        body = self.write_body("body.md")
+        write_receipt(body, self.home)
+        result = run_hook(f"gh pr create --body-file {body.name}", self.cwd, self.home)
+        self.assertIsNone(deny_reason(result))
+
+    def test_pr_edit_with_a_valid_receipt_is_allowed(self):
+        body = self.write_body("body.md")
+        write_receipt(body, self.home)
+        result = run_hook(
+            f"gh pr edit 5 --body-file {body.name}", self.cwd, self.home
+        )
+        self.assertIsNone(deny_reason(result))
+
+    def test_short_flag_and_equals_form_are_both_recognized(self):
+        body = self.write_body("body.md")
+        write_receipt(body, self.home)
+        for command in (f"gh pr create -F{body.name}", f"gh pr create --body-file={body.name}"):
+            with self.subTest(command=command):
+                result = run_hook(command, self.cwd, self.home)
+                self.assertIsNone(deny_reason(result))
+
+
+class NoReceiptTests(GateTestCase):
+    def test_body_file_with_no_receipt_denies(self):
+        body = self.write_body("body.md")
+        result = run_hook(f"gh pr create --body-file {body.name}", self.cwd, self.home)
+        reason = deny_reason(result)
+        self.assertIsNotNone(reason)
+        self.assertIn("no scoring receipt", reason)
+        self.assertIn("pr-body skill", reason)
+
+
+class StaleReceiptTests(GateTestCase):
+    def test_editing_the_body_after_scoring_denies_and_names_the_edit(self):
+        body = self.write_body("body.md")
+        write_receipt(body, self.home)
+        body.write_text(BODY + "One more sentence.\n", encoding="utf-8")
+        result = run_hook(f"gh pr create --body-file {body.name}", self.cwd, self.home)
+        reason = deny_reason(result)
+        self.assertIsNotNone(reason)
+        self.assertIn("changed since it was scored", reason)
+
+
+class UnreadableBodyFormTests(GateTestCase):
+    def test_a_missing_body_file_denies_as_unreadable(self):
+        result = run_hook("gh pr create --body-file does-not-exist.md", self.cwd, self.home)
+        reason = deny_reason(result)
+        self.assertIsNotNone(reason)
+        self.assertIn("cannot read", reason)
+
+
+class BypassShapeTests(GateTestCase):
+    """One assertion per way the body flag can dodge the receipt check."""
+
+    def test_inline_body_text_denies(self):
+        result = run_hook('gh pr create --body "some inline text"', self.cwd, self.home)
+        self.assertIsNotNone(deny_reason(result))
+
+    def test_body_from_a_shell_variable_denies(self):
+        result = run_hook('gh pr create --body "$BODY"', self.cwd, self.home)
+        self.assertIsNotNone(deny_reason(result))
+
+    def test_body_from_a_command_substitution_denies(self):
+        result = run_hook('gh pr create --body "$(cat f.md)"', self.cwd, self.home)
+        self.assertIsNotNone(deny_reason(result))
+
+    def test_body_from_a_heredoc_denies(self):
+        command = (
+            'gh pr create --body "$(cat <<'"'"'EOF'"'"'\n'
+            "some heredoc body\n"
+            'EOF\n'
+            ')"'
+        )
+        result = run_hook(command, self.cwd, self.home)
+        self.assertIsNotNone(deny_reason(result))
+
+    def test_fill_denies(self):
+        result = run_hook("gh pr create --fill", self.cwd, self.home)
+        self.assertIsNotNone(deny_reason(result))
+
+    def test_bypass_deny_reason_names_body_file(self):
+        result = run_hook('gh pr create --body "inline"', self.cwd, self.home)
+        reason = deny_reason(result)
+        self.assertIn("--body-file", reason)
+
+
+class ApiPullRequestTests(GateTestCase):
+    def test_api_post_to_a_pulls_collection_denies(self):
+        result = run_hook(
+            "gh api repos/o/r/pulls -X POST -f title=x -f body=y", self.cwd, self.home
+        )
+        reason = deny_reason(result)
+        self.assertIsNotNone(reason)
+        self.assertIn("gh api", reason)
+
+    def test_api_patch_to_a_specific_pull_denies(self):
+        result = run_hook(
+            "gh api repos/o/r/pulls/12 -X PATCH -f body=y", self.cwd, self.home
+        )
+        self.assertIsNotNone(deny_reason(result))
+
+    def test_api_post_without_explicit_dash_x_still_denies(self):
+        # gh switches its default method from GET to POST once a data flag
+        # is present, with no explicit -X required.
+        result = run_hook("gh api repos/o/r/pulls -f title=x -f body=y", self.cwd, self.home)
+        self.assertIsNotNone(deny_reason(result))
+
+    def test_api_get_against_pulls_is_allowed(self):
+        result = run_hook("gh api repos/o/r/pulls", self.cwd, self.home)
+        self.assertIsNone(deny_reason(result))
+
+
+class ScopeTests(GateTestCase):
+    def test_a_non_gh_command_is_allowed(self):
+        result = run_hook('git commit -m "unrelated change"', self.cwd, self.home)
+        self.assertIsNone(deny_reason(result))
+
+    def test_pr_edit_that_does_not_touch_the_body_is_allowed(self):
+        result = run_hook("gh pr edit 5 --add-label needs-review", self.cwd, self.home)
+        self.assertIsNone(deny_reason(result))
+
+    def test_pr_list_is_out_of_scope_and_allowed(self):
+        result = run_hook("gh pr list --state open", self.cwd, self.home)
+        self.assertIsNone(deny_reason(result))
+
+
+class MalformedPayloadTests(GateTestCase):
+    def test_malformed_json_payload_denies(self):
+        result = run_hook_raw("not valid json", self.cwd, self.home)
+        reason = deny_reason(result)
+        self.assertIsNotNone(reason)
+        self.assertIn("hook payload", reason)
+
+
+class RobustnessTests(GateTestCase):
+    def test_hook_never_exits_nonzero(self):
+        result = run_hook_raw("not valid json", self.cwd, self.home)
+        self.assertEqual(result.returncode, 0)
+
+    def test_hook_never_prints_to_stderr_on_normal_input(self):
+        result = run_hook('git status', self.cwd, self.home)
+        self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a skill that writes and scores a PR body, and a hook that denies `gh pr create` until the body has been scored. The hook is what makes it stick: measured against 128 model runs, a body written with the skill in context still omits the one disclosure line the skill states outright 38% of the time.

* Scorer with 13 rules, stdlib only, the single source of truth for what a rule is.
* Voice judge for the phrasing failures no regex sees. It reads the diff too, so it can name a fact the body omits.
* Receipt keyed to the body file's sha256. Editing after scoring voids it.
* Drift test binds the rules named in the docs to the rules the scorer implements.

Three candidate rules were measured and refused: markdown headers (79% of AI-written bodies, 83% of human-written ones, because repos ship templates), AI-vocabulary wordlists (1% in both), and checkboxes (a clean split, but a legitimate device). A length ceiling was built, refuted by hand labels, and removed: passing bodies span 80 to 2242 characters and failing ones 0 to 1703.

Every number is in `docs/pr-body-measurement.md`. The corpus and eval fixtures stay out of the repo.

The gate hook lives with the machine's other hooks, so its tests skip unless `PR_BODY_GATE_HOOK` points at it.

This PR was written in part with the assistance of generative AI.
