### PR TITLE
Scope interrupted worker cleanup to its process group

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -58,6 +58,11 @@ is the reason the review is not optional); prototyping routes straight to
 - The coordinator keeps for itself: small mechanical glue (git/gh plumbing,
   toggles, log checks, daemon restarts), verification probes, and all
   communication/decisions with the operator.
+- The coordinator that launched an interrupted worker owns its exact recovery:
+  run the adapter's scoped `stop --state ... --cwd ...`, then scoped `verify`
+  before a successor receives the worktree. Successors never discover or clean
+  unknown processes; names, descendants, sessions, and global test/provider
+  searches are not ownership.
 - Worktree creation is not raw git plumbing: when preparing a worktree for a
   sub-agent (or any task work), invoke the `spin-worktree` skill so worktrees
   land under its `~/worktrees/<repository>/<task>` convention, not ad-hoc

--- a/skills/orchestrate/references/dispatch-codex.md
+++ b/skills/orchestrate/references/dispatch-codex.md
@@ -17,6 +17,17 @@ On success the helper emits one public JSON object. Read its `final_message`
 field as the current worker's answer; do not infer an answer from its session or
 headroom metadata.
 
+## Interrupted workers
+
+The coordinator that launched a worker owns its recovery. Before handing a
+preserved worktree to a successor, run `codex-worker.py stop --state STATE --cwd
+WORKTREE`, then run `codex-worker.py verify --state STATE --cwd WORKTREE` and
+require success. State is retained for interrupted, failed, and completed runs.
+Only the helper's recorded dedicated process group is in scope; a successor must
+never search for or clean unknown processes, tests, providers, sessions, or
+descendants. `stop` and `verify` reject legacy state. Ordinary `resume` can read
+a completed legacy state, but only from a terminal state with a session ID.
+
 The adapter reports session-bound headroom only when the matching persisted
 rollout contains rate limits. `unknown`, headroom at or below 5%, and rate-limit
 failures block a Codex UI parent: stop dispatching and report the blocker. It

--- a/skills/orchestrate/scripts/codex-worker.py
+++ b/skills/orchestrate/scripts/codex-worker.py
@@ -1,20 +1,43 @@
 #!/usr/bin/env python3
-"""Start and resume isolated Codex CLI workers for /orchestrate."""
+"""Launch, resume, stop, and verify one durable Codex worker process family."""
 
 from __future__ import annotations
 
 import argparse
+import ctypes
+import fcntl
 import json
 import os
+import signal
+import struct
 import subprocess
 import sys
+import tempfile
+import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+STATE_VERSION = 2
+UNSUPPORTED = "UNSUPPORTED_PROCESS_FAMILY_SEMANTICS"
+TERMINAL = {"stopped", "exited"}
+TRANSITIONS = {
+    "launching": {"running", "stopping", "exited"},
+    "running": {"stopping", "exited"},
+    "stopping": {"stopped", "exited"},
+    "stopped": set(),
+    "exited": set(),
+}
+PROC_PIDTBSDINFO = 3
+PROC_PIDVNODEPATHINFO = 9
+BSD_SIZE = 136
+VNODE_SIZE = 2352
+VNODE_CWD_OFFSET = 152
 
-def fail(message: str) -> int:
+
+def fail(message: str, code: int = 1) -> int:
     print(f"codex-worker: {message}", file=sys.stderr)
-    return 1
+    return code
 
 
 def resolved_directory(value: str) -> Path:
@@ -25,8 +48,117 @@ def resolved_directory(value: str) -> Path:
 
 
 def is_within(path: Path, directory: Path) -> bool:
-    """Return whether a resolved path is the directory or one of its descendants."""
     return path == directory or directory in path.parents
+
+
+@contextmanager
+def state_lock(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = path.with_name(path.name + ".lock")
+    with lock.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
+
+
+def atomic_write(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            json.dump(state, file, indent=2, sort_keys=True)
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+        parent = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(parent)
+        finally:
+            os.close(parent)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def read_state(path: Path, *, family_required: bool = False) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, dict):
+        return None
+    if family_required and value.get("version") != STATE_VERSION:
+        return None
+    return value
+
+
+def transition(path: Path, state: dict[str, Any], lifecycle: str) -> dict[str, Any]:
+    previous = state.get("lifecycle")
+    if previous not in TRANSITIONS or lifecycle not in TRANSITIONS[previous]:
+        raise ValueError(f"illegal lifecycle transition {previous!r} to {lifecycle!r}")
+    updated = dict(state)
+    updated["lifecycle"] = lifecycle
+    atomic_write(path, updated)
+    return updated
+
+
+def _libproc() -> ctypes.CDLL | None:
+    if sys.platform != "darwin":
+        return None
+    try:
+        library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        library.proc_pidinfo.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int]
+        library.proc_pidinfo.restype = ctypes.c_int
+        library.proc_listpgrppids.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_int]
+        library.proc_listpgrppids.restype = ctypes.c_int
+        return library
+    except OSError:
+        return None
+
+
+def live_identity(pid: int) -> dict[str, Any] | None:
+    library = _libproc()
+    if library is None:
+        return None
+    bsd = ctypes.create_string_buffer(BSD_SIZE)
+    ctypes.set_errno(0)
+    if library.proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, bsd, BSD_SIZE) != BSD_SIZE:
+        return None
+    cwd = ctypes.create_string_buffer(VNODE_SIZE)
+    ctypes.set_errno(0)
+    if library.proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, cwd, VNODE_SIZE) != VNODE_SIZE:
+        return None
+    try:
+        returned_pid = struct.unpack_from("<I", bsd.raw, 12)[0]
+        pgid = struct.unpack_from("<I", bsd.raw, 100)[0]
+        seconds, microseconds = struct.unpack_from("<QQ", bsd.raw, 120)
+        sid = os.getsid(pid)
+        directory = cwd.raw[VNODE_CWD_OFFSET:].split(b"\0", 1)[0].decode("utf-8")
+        canonical_cwd = str(Path(directory).resolve(strict=True))
+    except (OSError, UnicodeDecodeError, struct.error):
+        return None
+    if returned_pid != pid or not directory:
+        return None
+    return {"pid": pid, "pgid": pgid, "sid": sid, "cwd": canonical_cwd,
+            "birth": {"seconds": seconds, "microseconds": microseconds}}
+
+
+def group_members(pgid: int) -> list[int] | None:
+    library = _libproc()
+    if library is None:
+        return None
+    capacity = 64
+    while capacity <= 65536:
+        values = (ctypes.c_int * capacity)()
+        ctypes.set_errno(0)
+        count = library.proc_listpgrppids(pgid, values, ctypes.sizeof(values))
+        if count < 0 or (count == 0 and ctypes.get_errno()):
+            return None
+        members = list(values[:count])
+        if count < capacity:
+            return members
+        capacity *= 2
+    return None
 
 
 def parse_jsonl(output: str) -> tuple[list[dict[str, Any]], str | None]:
@@ -45,261 +177,245 @@ def parse_jsonl(output: str) -> tuple[list[dict[str, Any]], str | None]:
 
 
 def captured_thread_id(items: list[dict[str, Any]]) -> tuple[str | None, str | None]:
-    if any(
-        item.get("type") == "item.completed"
-        and isinstance(item.get("item"), dict)
-        and item["item"].get("type") == "error"
-        for item in items
-    ):
+    if any(item.get("type") == "item.completed" and isinstance(item.get("item"), dict) and item["item"].get("type") == "error" for item in items):
         return None, "Codex reported an error item"
-    ids = {
-        item["thread_id"]
-        for item in items
-        if item.get("type") == "thread.started"
-        and isinstance(item.get("thread_id"), str)
-        and item["thread_id"]
-    }
-    if len(ids) != 1:
-        return None, "missing or ambiguous thread ID in Codex JSONL"
-    return ids.pop(), None
+    ids = {item["thread_id"] for item in items if item.get("type") == "thread.started" and isinstance(item.get("thread_id"), str) and item["thread_id"]}
+    return (ids.pop(), None) if len(ids) == 1 else (None, "missing or ambiguous thread ID in Codex JSONL")
 
 
 def final_agent_message(items: list[dict[str, Any]]) -> tuple[str | None, str | None]:
-    message = None
-    for entry in items:
-        item = entry.get("item")
-        if (
-            entry.get("type") == "item.completed"
-            and isinstance(item, dict)
-            and item.get("type") == "agent_message"
-            and isinstance(item.get("text"), str)
-        ):
-            message = item["text"]
-    if message is None:
-        return None, "missing completed agent message in Codex JSONL"
-    return message, None
+    messages = [item["item"]["text"] for item in items if item.get("type") == "item.completed" and isinstance(item.get("item"), dict) and item["item"].get("type") == "agent_message" and isinstance(item["item"].get("text"), str)]
+    return (messages[-1], None) if messages else (None, "missing completed agent message in Codex JSONL")
 
 
 def latest_rate_limits(session_id: str) -> dict[str, Any] | None:
     root = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "sessions"
-    matches: list[Path] = []
+    matches = []
     for rollout in root.rglob("*.jsonl") if root.exists() else ():
-        try:
-            entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
-        except OSError:
-            continue
-        if error is None and any(
-            entry.get("type") == "session_meta"
-            and isinstance(entry.get("payload"), dict)
-            and entry["payload"].get("session_id") == session_id
-            for entry in entries
-        ):
-            matches.append(rollout)
-    if not matches:
-        return None
-    rollout = max(matches, key=lambda path: path.stat().st_mtime_ns)
-    entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
-    if error:
-        return None
-    rate_limits = None
+        try: entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
+        except OSError: continue
+        if error is None and any(entry.get("type") == "session_meta" and isinstance(entry.get("payload"), dict) and entry["payload"].get("session_id") == session_id for entry in entries): matches.append(rollout)
+    if not matches: return None
+    entries, error = parse_jsonl(max(matches, key=lambda item: item.stat().st_mtime_ns).read_text(encoding="utf-8"))
+    if error: return None
+    limits = None
     for entry in entries:
         payload = entry.get("payload")
-        if (
-            entry.get("type") == "event_msg"
-            and isinstance(payload, dict)
-            and payload.get("type") == "token_count"
-        ):
-            candidate = payload.get("rate_limits")
-            rate_limits = candidate if isinstance(candidate, dict) else None
-    return rate_limits
+        if entry.get("type") == "event_msg" and isinstance(payload, dict) and payload.get("type") == "token_count": limits = payload.get("rate_limits") if isinstance(payload.get("rate_limits"), dict) else None
+    return limits
 
 
-def headroom(rate_limits: dict[str, Any] | None) -> int | float | None:
-    if not rate_limits:
-        return None
-    primary = rate_limits.get("primary")
-    if not isinstance(primary, dict):
-        return None
-    used_percent = primary.get("used_percent")
-    if not isinstance(used_percent, (int, float)):
-        return None
-    return 100 - used_percent
+def emit(state: dict[str, Any], final_message: str) -> None:
+    limits = latest_rate_limits(state["session_id"])
+    primary = limits.get("primary") if isinstance(limits, dict) else None
+    remaining = 100 - primary["used_percent"] if isinstance(primary, dict) and isinstance(primary.get("used_percent"), (int, float)) else None
+    print(json.dumps({"session_id": state["session_id"], "model": state["model"], "sandbox": state["sandbox"], "cwd": state["cwd"], "final_message": final_message, "headroom": remaining, "headroom_status": "known" if remaining is not None else "unknown"}))
 
 
-def write_state(
-    path: Path,
-    session_id: str,
-    model: str,
-    sandbox: str,
-    cwd: Path,
-    control_checkout: Path | None,
-) -> None:
-    state: dict[str, str] = {
-        "session_id": session_id,
-        "model": model,
-        "sandbox": sandbox,
-        "cwd": str(cwd),
-    }
-    if control_checkout is not None:
-        state["control_checkout"] = str(control_checkout)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(state, indent=2) + "\n",
-        encoding="utf-8",
+def gate_wait(fd: int) -> None:
+    if os.read(fd, 1) != b"R":
+        os._exit(125)
+
+
+def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str], int]:
+    """Exec a session-leading gate wrapper; Popen can return before the real exec."""
+    gate_read, gate_write = os.pipe()
+    wrapper = (
+        "import json,os,sys; "
+        "os.setsid(); os.chdir(sys.argv[2]); "
+        "os.read(int(sys.argv[1]), 1) == b'R' or os._exit(125); "
+        "os.execvp(json.loads(sys.argv[3])[0], json.loads(sys.argv[3]))"
     )
-
-
-def run_worker(
-    command: list[str],
-    cwd: Path,
-) -> tuple[subprocess.CompletedProcess[str], list[dict[str, Any]] | None, str | None]:
-    result = subprocess.run(
-        command,
-        cwd=cwd,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
+    process = subprocess.Popen(
+        [sys.executable, "-c", wrapper, str(gate_read), str(cwd), json.dumps(command)],
+        text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=(gate_read,),
     )
-    if result.returncode:
-        sys.stdout.write(result.stdout)
-        sys.stderr.write(result.stderr)
-        return result, None, None
-    items, error = parse_jsonl(result.stdout)
-    return result, items, error
+    os.close(gate_read)
+    return process, gate_write
 
 
-def emit(
-    session_id: str,
-    model: str,
-    sandbox: str,
-    cwd: Path,
-    final_message: str,
-) -> None:
-    limits = latest_rate_limits(session_id)
-    remaining = headroom(limits)
-    print(
-        json.dumps(
-            {
-                "session_id": session_id,
-                "model": model,
-                "sandbox": sandbox,
-                "cwd": str(cwd),
-                "final_message": final_message,
-                "headroom": remaining,
-                "headroom_status": "known" if remaining is not None else "unknown",
-            }
-        )
-    )
+def run_lifecycle(args: argparse.Namespace, command: list[str], state: dict[str, Any]) -> int:
+    if _libproc() is None:
+        return fail(UNSUPPORTED)
+    process, write_fd = gated_process(command, Path(state["cwd"]))
+    pid = process.pid
+    try:
+        identity = None
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            identity = live_identity(pid)
+            if identity and identity["pgid"] == pid and identity["sid"] == pid and identity["cwd"] == state["cwd"]:
+                break
+            time.sleep(0.01)
+        if identity is None or identity["pgid"] != pid or identity["sid"] != pid or identity["cwd"] != state["cwd"]:
+            os.kill(pid, signal.SIGKILL); process.communicate()
+            return fail(f"could not establish dedicated worker process family: observed={identity!r} expected_cwd={state['cwd']!r}")
+        state.update(identity)
+        with state_lock(args.state):
+            atomic_write(args.state, state)
+        os.write(write_fd, b"R")
+        with state_lock(args.state):
+            current = read_state(args.state, family_required=True)
+            if current and current.get("lifecycle") == "launching":
+                state = transition(args.state, current, "running")
+    finally:
+        os.close(write_fd)
+    stdout, stderr = process.communicate()
+    returncode = process.returncode
+    with state_lock(args.state):
+        current = read_state(args.state, family_required=True)
+        if current and current.get("lifecycle") in {"launching", "running"}:
+            state = transition(args.state, current, "running") if current["lifecycle"] == "launching" else current
+            state = transition(args.state, state, "exited")
+    if returncode:
+        sys.stdout.write(stdout); sys.stderr.write(stderr); return returncode
+    items, error = parse_jsonl(stdout)
+    if error: return fail(error)
+    session_id, error = captured_thread_id(items)
+    if error: return fail(error)
+    message, error = final_agent_message(items)
+    if error: return fail(error)
+    with state_lock(args.state):
+        current = read_state(args.state, family_required=True)
+        if current is None: return fail("state file was lost during worker execution")
+        current["session_id"] = session_id
+        atomic_write(args.state, current)
+    emit(current, message)
+    return 0
 
 
 def start(args: argparse.Namespace) -> int:
-    cwd = args.cwd
     if args.sandbox == "workspace-write":
-        if args.control_checkout is None:
-            return fail("workspace-write requires --control-checkout")
-        if is_within(cwd, args.control_checkout):
-            return fail("workspace-write refuses the control checkout")
-    command = [
-        args.codex,
-        "exec",
-        "-m",
-        args.model,
-        "-c",
-        "model_reasoning_effort=medium",
-        "--sandbox",
-        args.sandbox,
-        "--skip-git-repo-check",
-        "-C",
-        str(cwd),
-        "--json",
-        args.prompt,
-    ]
-    result, items, error = run_worker(command, cwd)
-    if result.returncode:
-        return result.returncode
-    if error:
-        return fail(error)
-    session_id, error = captured_thread_id(items or [])
-    if error:
-        return fail(error)
-    message, error = final_agent_message(items or [])
-    if error:
-        return fail(error)
-    write_state(
-        args.state,
-        session_id or "",
-        args.model,
-        args.sandbox,
-        cwd,
-        args.control_checkout,
-    )
-    emit(session_id or "", args.model, args.sandbox, cwd, message or "")
-    return 0
+        if args.control_checkout is None: return fail("workspace-write requires --control-checkout")
+        if is_within(args.cwd, args.control_checkout): return fail("workspace-write refuses the control checkout")
+    state: dict[str, Any] = {"version": STATE_VERSION, "lifecycle": "launching", "model": args.model, "sandbox": args.sandbox, "cwd": str(args.cwd), "session_id": ""}
+    if args.control_checkout: state["control_checkout"] = str(args.control_checkout)
+    command = [args.codex, "exec", "-m", args.model, "-c", "model_reasoning_effort=medium", "--sandbox", args.sandbox, "--skip-git-repo-check", "-C", str(args.cwd), "--json", args.prompt]
+    return run_lifecycle(args, command, state)
 
 
 def resume(args: argparse.Namespace) -> int:
-    try:
-        state = json.loads(args.state.read_text(encoding="utf-8"))
-        session_id, model, sandbox, cwd = (
-            state[key] for key in ("session_id", "model", "sandbox", "cwd")
-        )
-    except (OSError, json.JSONDecodeError, KeyError, ValueError):
-        return fail("state file is malformed or incomplete")
-    if not all(isinstance(value, str) and value for value in (session_id, model, sandbox, cwd)):
-        return fail("state file is malformed or incomplete")
-    if sandbox not in {"read-only", "workspace-write"}:
-        return fail("state file has an invalid sandbox")
-    try:
-        canonical_cwd = resolved_directory(cwd)
-    except (OSError, argparse.ArgumentTypeError):
-        return fail("state file has an invalid cwd")
-    control_checkout = None
-    if sandbox == "workspace-write":
-        control = state.get("control_checkout")
-        if not isinstance(control, str) or not control:
-            return fail("state file is missing the control checkout")
-        try:
-            control_checkout = resolved_directory(control)
-        except (OSError, argparse.ArgumentTypeError):
-            return fail("state file has an invalid control checkout")
-        if is_within(canonical_cwd, control_checkout):
-            return fail("workspace-write refuses the control checkout")
-    command = [
-        args.codex,
-        "exec",
-        "resume",
-        session_id,
-        "-m",
-        model,
-        "-c",
-        f'sandbox_mode="{sandbox}"',
-        "--json",
-        args.prompt,
-    ]
-    result, items, error = run_worker(command, canonical_cwd)
-    if result.returncode:
-        return result.returncode
-    if error:
-        return fail(error)
-    returned_id, error = captured_thread_id(items or [])
-    if error:
-        return fail(error)
-    if returned_id != session_id:
-        return fail("resume returned a different thread ID")
-    message, error = final_agent_message(items or [])
-    if error:
-        return fail(error)
-    write_state(
-        args.state,
-        session_id,
-        model,
-        sandbox,
-        canonical_cwd,
-        control_checkout,
-    )
-    emit(session_id, model, sandbox, canonical_cwd, message or "")
+    with state_lock(args.state):
+        state = read_state(args.state)
+        if state is None: return fail("state file is malformed or incomplete")
+        if state.get("version") != STATE_VERSION:
+            # Legacy completed states are compatible only for ordinary resume.
+            if not all(isinstance(state.get(key), str) and state[key] for key in ("session_id", "model", "sandbox", "cwd")): return fail("state file is malformed or incomplete")
+        elif state.get("lifecycle") not in TERMINAL or not state.get("session_id"):
+            return fail("resume requires a terminal worker state with a session ID")
+        try: cwd = resolved_directory(state["cwd"])
+        except (OSError, argparse.ArgumentTypeError): return fail("state file has an invalid cwd")
+        sandbox = state.get("sandbox")
+        if sandbox not in {"read-only", "workspace-write"}: return fail("state file has an invalid sandbox")
+        if sandbox == "workspace-write":
+            try: control = resolved_directory(state["control_checkout"])
+            except (KeyError, OSError, argparse.ArgumentTypeError): return fail("state file is missing the control checkout")
+            if is_within(cwd, control): return fail("workspace-write refuses the control checkout")
+        fresh = {"version": STATE_VERSION, "lifecycle": "launching", "session_id": state["session_id"], "model": state["model"], "sandbox": sandbox, "cwd": str(cwd)}
+        if sandbox == "workspace-write": fresh["control_checkout"] = str(control)
+        # This is a durable claim while the release-gated leader is being made.
+        # A concurrent resume sees nonterminal state and cannot launch another group.
+        atomic_write(args.state, fresh)
+    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "--json", args.prompt]
+    return run_lifecycle(args, command, fresh)
+
+
+def family_state(path: Path, expected: Path) -> tuple[dict[str, Any] | None, str | None]:
+    state = read_state(path, family_required=True)
+    if state is None: return None, "state is missing, corrupt, or legacy"
+    required = ("pid", "pgid", "sid", "cwd", "birth", "lifecycle")
+    if any(key not in state for key in required): return None, "state is malformed"
+    if state["cwd"] != str(expected): return None, f"cwd mismatch: recorded={state['cwd']!r} expected={str(expected)!r}"
+    return state, None
+
+
+def matching_leader(state: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    observed = live_identity(state["pid"])
+    if observed is None: return None, "leader identity probe failed"
+    recorded = {key: state[key] for key in ("pid", "pgid", "sid", "cwd", "birth")}
+    if observed != recorded: return None, f"identity mismatch: recorded={recorded!r} observed={observed!r}"
+    return observed, None
+
+
+def verify(args: argparse.Namespace) -> int:
+    if _libproc() is None: return fail(UNSUPPORTED)
+    with state_lock(args.state):
+        state, error = family_state(args.state, args.cwd)
+        if error: return fail(error)
+        members = group_members(state["pgid"])
+        if members is None: return fail("process-group probe failed")
+        if members: return fail(f"worker process group still has members: {members}")
+        if state["lifecycle"] not in TERMINAL:
+            if state["lifecycle"] != "stopping":
+                state = transition(args.state, state, "stopping")
+            state = transition(args.state, state, "stopped")
     return 0
+
+
+def stop(args: argparse.Namespace) -> int:
+    if _libproc() is None: return fail(UNSUPPORTED)
+    with state_lock(args.state):
+        state, error = family_state(args.state, args.cwd)
+        if error: return fail(error)
+        leader, error = matching_leader(state)
+        if error and state["lifecycle"] not in TERMINAL:
+            if "identity mismatch:" in error:
+                return fail(error)
+            # A gone leader is safe only after the recorded PGID is observed empty
+            # or is itself the exact group proved eligible for KILL below.
+            members = group_members(state["pgid"])
+            if members is None: return fail("process-group probe failed")
+            if not members:
+                if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
+                transition(args.state, state, "stopped")
+                return 0
+            state = transition(args.state, state, "stopping") if state["lifecycle"] != "stopping" else state
+            try: os.killpg(state["pgid"], signal.SIGKILL)
+            except OSError as exc: return fail(f"KILL refused: {exc}")
+            return 0
+        members = group_members(state["pgid"])
+        if members is None: return fail("process-group probe failed")
+        if not members:
+            if state["lifecycle"] not in TERMINAL:
+                if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
+                transition(args.state, state, "stopped")
+            return 0
+        if state["lifecycle"] in TERMINAL:
+            try: os.killpg(state["pgid"], signal.SIGKILL)
+            except OSError as exc: return fail(f"KILL refused: {exc}")
+            deadline = time.monotonic() + args.grace_seconds
+            while time.monotonic() < deadline:
+                members = group_members(state["pgid"])
+                if members is None: return fail("process-group probe failed")
+                if not members: return verify(args)
+                time.sleep(0.05)
+            return fail(f"worker process group still has members: {members}")
+        if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
+        try: os.killpg(state["pgid"], signal.SIGTERM)
+        except OSError as exc: return fail(f"TERM refused: {exc}")
+    deadline = time.monotonic() + args.grace_seconds
+    while time.monotonic() < deadline:
+        members = group_members(state["pgid"])
+        if members is None: return fail("process-group probe failed")
+        if not members:
+            with state_lock(args.state):
+                current = read_state(args.state, family_required=True)
+                if current and current["lifecycle"] == "stopping": transition(args.state, current, "stopped")
+            return 0
+        time.sleep(0.05)
+    members = group_members(state["pgid"])
+    if members is None: return fail("process-group probe failed")
+    if not members: return 0
+    # The leader may have exited; KILL is authorized solely by a successful exact-group enumeration.
+    try: os.killpg(state["pgid"], signal.SIGKILL)
+    except OSError as exc: return fail(f"KILL refused: {exc}")
+    deadline = time.monotonic() + args.grace_seconds
+    while time.monotonic() < deadline:
+        members = group_members(state["pgid"])
+        if members is None: return fail("process-group probe failed")
+        if not members: break
+        time.sleep(0.05)
+    return verify(args)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -308,20 +424,16 @@ def parser() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--codex", default="codex")
     common.add_argument("--state", type=Path, required=True)
-    common.add_argument("prompt")
-    start_parser = commands.add_parser("start", parents=[common])
-    start_parser.add_argument("--model", required=True)
-    start_parser.add_argument(
-        "--sandbox", choices=("read-only", "workspace-write"), required=True
-    )
-    start_parser.add_argument("--cwd", type=resolved_directory, required=True)
-    start_parser.add_argument("--control-checkout", type=resolved_directory)
-    start_parser.set_defaults(handler=start)
-    resume_parser = commands.add_parser("resume", parents=[common])
-    resume_parser.set_defaults(handler=resume)
+    common.add_argument("prompt", nargs="?")
+    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--cwd", type=resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=resolved_directory); start_parser.set_defaults(handler=start)
+    resume_parser = commands.add_parser("resume", parents=[common]); resume_parser.set_defaults(handler=resume)
+    for name, handler in (("stop", stop), ("verify", verify)):
+        command = commands.add_parser(name, parents=[common]); command.add_argument("--cwd", type=resolved_directory, required=True); command.add_argument("--grace-seconds", type=float, default=1.0); command.set_defaults(handler=handler)
     return result
 
 
 if __name__ == "__main__":
     arguments = parser().parse_args()
+    if arguments.command in {"start", "resume"} and not arguments.prompt:
+        raise SystemExit(fail("prompt is required"))
     raise SystemExit(arguments.handler(arguments))

--- a/skills/orchestrate/scripts/codex-worker.py
+++ b/skills/orchestrate/scripts/codex-worker.py
@@ -20,6 +20,7 @@ from typing import Any
 
 STATE_VERSION = 2
 UNSUPPORTED = "UNSUPPORTED_PROCESS_FAMILY_SEMANTICS"
+FAMILY_SEMANTICS_UNSUPPORTED = "unsupported"
 TERMINAL = {"stopped", "exited"}
 TRANSITIONS = {
     "launching": {"running", "stopping", "exited"},
@@ -117,13 +118,11 @@ def _canonical_path(value: Any) -> bool:
         return False
 
 
-def valid_family_schema(state: dict[str, Any]) -> bool:
-    required = {
-        "version", "lifecycle", "session_id", "model", "sandbox", "cwd",
-        "pid", "pgid", "sid", "birth",
-    }
-    allowed = required | {"control_checkout"}
-    if not required.issubset(state):
+BASE_STATE_FIELDS = {"version", "lifecycle", "session_id", "model", "sandbox", "cwd"}
+
+
+def _valid_common_schema(state: dict[str, Any], allowed: set[str]) -> bool:
+    if not BASE_STATE_FIELDS.issubset(state):
         return False
     if not set(state).issubset(allowed):
         return False
@@ -139,6 +138,21 @@ def valid_family_schema(state: dict[str, Any]) -> bool:
         return False
     if not _canonical_path(state["cwd"]):
         return False
+    control = state.get("control_checkout")
+    if control is not None and not _canonical_path(control):
+        return False
+    if state["sandbox"] == "workspace-write":
+        if control is None or is_within(Path(state["cwd"]), Path(control)):
+            return False
+    return True
+
+
+def valid_family_schema(state: dict[str, Any]) -> bool:
+    identity = {"pid", "pgid", "sid", "birth"}
+    if not identity.issubset(state):
+        return False
+    if not _valid_common_schema(state, BASE_STATE_FIELDS | identity | {"control_checkout"}):
+        return False
     for field in ("pid", "pgid", "sid"):
         if not _bounded_integer(state[field], 1, PID_MAX):
             return False
@@ -149,12 +163,19 @@ def valid_family_schema(state: dict[str, Any]) -> bool:
         return False
     if not _bounded_integer(birth["microseconds"], 0, 999_999):
         return False
-    control = state.get("control_checkout")
-    if control is not None and not _canonical_path(control):
+    return True
+
+
+def valid_portable_schema(state: dict[str, Any]) -> bool:
+    allowed = BASE_STATE_FIELDS | {"control_checkout", "family_semantics", "generation"}
+    if not _valid_common_schema(state, allowed):
         return False
-    if state["sandbox"] == "workspace-write":
-        if control is None or is_within(Path(state["cwd"]), Path(control)):
-            return False
+    if state["lifecycle"] != "exited":
+        return False
+    if state.get("family_semantics") != FAMILY_SEMANTICS_UNSUPPORTED:
+        return False
+    if not _bounded_integer(state.get("generation"), 1, UINT64_MAX):
+        return False
     return True
 
 
@@ -296,8 +317,6 @@ def establish_family(
     state: dict[str, Any],
 ) -> tuple[subprocess.Popen[str] | None, int | None]:
     """Persist and release one gated family while the caller holds the state lock."""
-    if _libproc() is None:
-        return None, fail(UNSUPPORTED)
     process, write_fd = gated_process(command, Path(state["cwd"]))
     pid = process.pid
     try:
@@ -345,6 +364,48 @@ def finish_lifecycle(args: argparse.Namespace, process: subprocess.Popen[str]) -
     return 0
 
 
+def run_portable(
+    args: argparse.Namespace,
+    command: list[str],
+    state: dict[str, Any],
+    generation: int,
+) -> int:
+    """Run under the state lock and persist no recoverable process-family claim."""
+    result = subprocess.run(
+        command,
+        cwd=Path(state["cwd"]),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    terminal = {
+        **state,
+        "lifecycle": "exited",
+        "family_semantics": FAMILY_SEMANTICS_UNSUPPORTED,
+        "generation": generation,
+    }
+    if result.returncode:
+        atomic_write(args.state, terminal)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        return result.returncode
+    items, error = parse_jsonl(result.stdout)
+    session_id = None
+    message = None
+    if error is None:
+        session_id, error = captured_thread_id(items)
+    if error is None:
+        message, error = final_agent_message(items)
+    if session_id is not None:
+        terminal["session_id"] = session_id
+    atomic_write(args.state, terminal)
+    if error is not None:
+        return fail(error)
+    emit(terminal, message or "")
+    return 0
+
+
 def run_lifecycle(
     args: argparse.Namespace,
     command: list[str],
@@ -355,6 +416,11 @@ def run_lifecycle(
     with state_lock(args.state):
         if expected is not None and read_state(args.state) != expected:
             return fail("resume requires an unchanged terminal worker state")
+        if _libproc() is None:
+            previous_generation = expected["generation"] if expected is not None and valid_portable_schema(expected) else 0
+            if previous_generation == UINT64_MAX:
+                return fail("portable state generation exhausted")
+            return run_portable(args, command, state, previous_generation + 1)
         process, error = establish_family(args, command, state)
         if error is not None:
             return error
@@ -373,15 +439,18 @@ def start(args: argparse.Namespace) -> int:
 
 
 def resume(args: argparse.Namespace) -> int:
+    snapshot = read_state(args.state)
     with state_lock(args.state):
         state = read_state(args.state)
+        if state != snapshot:
+            return fail("resume requires an unchanged terminal worker state")
         if state is None: return fail("state file is malformed or incomplete")
         if "version" not in state:
             # Legacy completed states are compatible only for ordinary resume.
             legacy = {"session_id", "model", "sandbox", "cwd"}
             if not legacy.issubset(state) or not set(state).issubset(legacy | {"control_checkout"}): return fail("state file is malformed or incomplete")
             if not all(isinstance(state[key], str) and state[key] for key in legacy): return fail("state file is malformed or incomplete")
-        elif not valid_family_schema(state):
+        elif not (valid_family_schema(state) or valid_portable_schema(state)):
             return fail("state file is malformed or incomplete")
         elif state["lifecycle"] not in TERMINAL or not state["session_id"]:
             return fail("resume requires a terminal worker state with a session ID")
@@ -405,7 +474,8 @@ def family_state(path: Path, expected: Path) -> tuple[dict[str, Any] | None, str
     version = state.get("version")
     if "version" not in state or (type(version) is int and version != STATE_VERSION):
         return None, "state is missing, corrupt, or legacy"
-    if not valid_family_schema(state): return None, "state is malformed"
+    if not (valid_family_schema(state) or valid_portable_schema(state)):
+        return None, "state is malformed"
     if state["cwd"] != str(expected): return None, f"cwd mismatch: recorded={state['cwd']!r} expected={str(expected)!r}"
     return state, None
 
@@ -423,6 +493,8 @@ def verify(args: argparse.Namespace) -> int:
         state, error = family_state(args.state, args.cwd)
         if error: return fail(error)
         if _libproc() is None: return fail(UNSUPPORTED)
+        if valid_portable_schema(state):
+            return fail("state has no recoverable process family")
         members = group_members(state["pgid"])
         if members is None: return fail("process-group probe failed")
         if members: return fail(f"worker process group still has members: {members}")
@@ -438,6 +510,8 @@ def stop(args: argparse.Namespace) -> int:
         state, error = family_state(args.state, args.cwd)
         if error: return fail(error)
         if _libproc() is None: return fail(UNSUPPORTED)
+        if valid_portable_schema(state):
+            return fail("state has no recoverable process family")
         leader, error = matching_leader(state)
         if error and state["lifecycle"] not in TERMINAL:
             if "identity mismatch:" in error:

--- a/skills/orchestrate/scripts/codex-worker.py
+++ b/skills/orchestrate/scripts/codex-worker.py
@@ -33,6 +33,8 @@ PROC_PIDVNODEPATHINFO = 9
 BSD_SIZE = 136
 VNODE_SIZE = 2352
 VNODE_CWD_OFFSET = 152
+PID_MAX = 2**31 - 1
+UINT64_MAX = 2**64 - 1
 
 
 def fail(message: str, code: int = 1) -> int:
@@ -100,6 +102,60 @@ def transition(path: Path, state: dict[str, Any], lifecycle: str) -> dict[str, A
     updated["lifecycle"] = lifecycle
     atomic_write(path, updated)
     return updated
+
+
+def _bounded_integer(value: Any, minimum: int, maximum: int) -> bool:
+    return type(value) is int and minimum <= value <= maximum
+
+
+def _canonical_path(value: Any) -> bool:
+    if not isinstance(value, str) or not value or not Path(value).is_absolute():
+        return False
+    try:
+        return str(Path(value).resolve()) == value
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def valid_family_schema(state: dict[str, Any]) -> bool:
+    required = {
+        "version", "lifecycle", "session_id", "model", "sandbox", "cwd",
+        "pid", "pgid", "sid", "birth",
+    }
+    allowed = required | {"control_checkout"}
+    if not required.issubset(state):
+        return False
+    if not set(state).issubset(allowed):
+        return False
+    if type(state["version"]) is not int or state["version"] != STATE_VERSION:
+        return False
+    if not isinstance(state["lifecycle"], str) or state["lifecycle"] not in TRANSITIONS:
+        return False
+    if not isinstance(state["session_id"], str):
+        return False
+    if not isinstance(state["model"], str) or not state["model"]:
+        return False
+    if not isinstance(state["sandbox"], str) or state["sandbox"] not in {"read-only", "workspace-write"}:
+        return False
+    if not _canonical_path(state["cwd"]):
+        return False
+    for field in ("pid", "pgid", "sid"):
+        if not _bounded_integer(state[field], 1, PID_MAX):
+            return False
+    birth = state["birth"]
+    if not isinstance(birth, dict) or set(birth) != {"seconds", "microseconds"}:
+        return False
+    if not _bounded_integer(birth["seconds"], 1, UINT64_MAX):
+        return False
+    if not _bounded_integer(birth["microseconds"], 0, 999_999):
+        return False
+    control = state.get("control_checkout")
+    if control is not None and not _canonical_path(control):
+        return False
+    if state["sandbox"] == "workspace-write":
+        if control is None or is_within(Path(state["cwd"]), Path(control)):
+            return False
+    return True
 
 
 def _libproc() -> ctypes.CDLL | None:
@@ -234,9 +290,14 @@ def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str],
     return process, gate_write
 
 
-def run_lifecycle(args: argparse.Namespace, command: list[str], state: dict[str, Any]) -> int:
+def establish_family(
+    args: argparse.Namespace,
+    command: list[str],
+    state: dict[str, Any],
+) -> tuple[subprocess.Popen[str] | None, int | None]:
+    """Persist and release one gated family while the caller holds the state lock."""
     if _libproc() is None:
-        return fail(UNSUPPORTED)
+        return None, fail(UNSUPPORTED)
     process, write_fd = gated_process(command, Path(state["cwd"]))
     pid = process.pid
     try:
@@ -249,17 +310,17 @@ def run_lifecycle(args: argparse.Namespace, command: list[str], state: dict[str,
             time.sleep(0.01)
         if identity is None or identity["pgid"] != pid or identity["sid"] != pid or identity["cwd"] != state["cwd"]:
             os.kill(pid, signal.SIGKILL); process.communicate()
-            return fail(f"could not establish dedicated worker process family: observed={identity!r} expected_cwd={state['cwd']!r}")
-        state.update(identity)
-        with state_lock(args.state):
-            atomic_write(args.state, state)
+            return None, fail(f"could not establish dedicated worker process family: observed={identity!r} expected_cwd={state['cwd']!r}")
+        state = {**state, **identity}
+        atomic_write(args.state, state)
         os.write(write_fd, b"R")
-        with state_lock(args.state):
-            current = read_state(args.state, family_required=True)
-            if current and current.get("lifecycle") == "launching":
-                state = transition(args.state, current, "running")
+        state = transition(args.state, state, "running")
     finally:
         os.close(write_fd)
+    return process, None
+
+
+def finish_lifecycle(args: argparse.Namespace, process: subprocess.Popen[str]) -> int:
     stdout, stderr = process.communicate()
     returncode = process.returncode
     with state_lock(args.state):
@@ -284,6 +345,23 @@ def run_lifecycle(args: argparse.Namespace, command: list[str], state: dict[str,
     return 0
 
 
+def run_lifecycle(
+    args: argparse.Namespace,
+    command: list[str],
+    state: dict[str, Any],
+    *,
+    expected: dict[str, Any] | None = None,
+) -> int:
+    with state_lock(args.state):
+        if expected is not None and read_state(args.state) != expected:
+            return fail("resume requires an unchanged terminal worker state")
+        process, error = establish_family(args, command, state)
+        if error is not None:
+            return error
+    assert process is not None
+    return finish_lifecycle(args, process)
+
+
 def start(args: argparse.Namespace) -> int:
     if args.sandbox == "workspace-write":
         if args.control_checkout is None: return fail("workspace-write requires --control-checkout")
@@ -298,10 +376,14 @@ def resume(args: argparse.Namespace) -> int:
     with state_lock(args.state):
         state = read_state(args.state)
         if state is None: return fail("state file is malformed or incomplete")
-        if state.get("version") != STATE_VERSION:
+        if "version" not in state:
             # Legacy completed states are compatible only for ordinary resume.
-            if not all(isinstance(state.get(key), str) and state[key] for key in ("session_id", "model", "sandbox", "cwd")): return fail("state file is malformed or incomplete")
-        elif state.get("lifecycle") not in TERMINAL or not state.get("session_id"):
+            legacy = {"session_id", "model", "sandbox", "cwd"}
+            if not legacy.issubset(state) or not set(state).issubset(legacy | {"control_checkout"}): return fail("state file is malformed or incomplete")
+            if not all(isinstance(state[key], str) and state[key] for key in legacy): return fail("state file is malformed or incomplete")
+        elif not valid_family_schema(state):
+            return fail("state file is malformed or incomplete")
+        elif state["lifecycle"] not in TERMINAL or not state["session_id"]:
             return fail("resume requires a terminal worker state with a session ID")
         try: cwd = resolved_directory(state["cwd"])
         except (OSError, argparse.ArgumentTypeError): return fail("state file has an invalid cwd")
@@ -313,18 +395,17 @@ def resume(args: argparse.Namespace) -> int:
             if is_within(cwd, control): return fail("workspace-write refuses the control checkout")
         fresh = {"version": STATE_VERSION, "lifecycle": "launching", "session_id": state["session_id"], "model": state["model"], "sandbox": sandbox, "cwd": str(cwd)}
         if sandbox == "workspace-write": fresh["control_checkout"] = str(control)
-        # This is a durable claim while the release-gated leader is being made.
-        # A concurrent resume sees nonterminal state and cannot launch another group.
-        atomic_write(args.state, fresh)
     command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "--json", args.prompt]
-    return run_lifecycle(args, command, fresh)
+    return run_lifecycle(args, command, fresh, expected=state)
 
 
 def family_state(path: Path, expected: Path) -> tuple[dict[str, Any] | None, str | None]:
-    state = read_state(path, family_required=True)
+    state = read_state(path)
     if state is None: return None, "state is missing, corrupt, or legacy"
-    required = ("pid", "pgid", "sid", "cwd", "birth", "lifecycle")
-    if any(key not in state for key in required): return None, "state is malformed"
+    version = state.get("version")
+    if "version" not in state or (type(version) is int and version != STATE_VERSION):
+        return None, "state is missing, corrupt, or legacy"
+    if not valid_family_schema(state): return None, "state is malformed"
     if state["cwd"] != str(expected): return None, f"cwd mismatch: recorded={state['cwd']!r} expected={str(expected)!r}"
     return state, None
 
@@ -338,10 +419,10 @@ def matching_leader(state: dict[str, Any]) -> tuple[dict[str, Any] | None, str |
 
 
 def verify(args: argparse.Namespace) -> int:
-    if _libproc() is None: return fail(UNSUPPORTED)
     with state_lock(args.state):
         state, error = family_state(args.state, args.cwd)
         if error: return fail(error)
+        if _libproc() is None: return fail(UNSUPPORTED)
         members = group_members(state["pgid"])
         if members is None: return fail("process-group probe failed")
         if members: return fail(f"worker process group still has members: {members}")
@@ -353,10 +434,10 @@ def verify(args: argparse.Namespace) -> int:
 
 
 def stop(args: argparse.Namespace) -> int:
-    if _libproc() is None: return fail(UNSUPPORTED)
     with state_lock(args.state):
         state, error = family_state(args.state, args.cwd)
         if error: return fail(error)
+        if _libproc() is None: return fail(UNSUPPORTED)
         leader, error = matching_leader(state)
         if error and state["lifecycle"] not in TERMINAL:
             if "identity mismatch:" in error:

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import time
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Optional
 from unittest import mock
@@ -241,6 +241,9 @@ class CodexWorkerTests(unittest.TestCase):
             "pathlib.Path(os.environ['FAKE_CODEX_ARGUMENTS']).write_text(json.dumps(sys.argv[1:]))\n"
             "if os.environ.get('FAKE_CODEX_CWD'):\n"
             "    pathlib.Path(os.environ['FAKE_CODEX_CWD']).write_text(os.getcwd())\n"
+            "if os.environ.get('FAKE_CODEX_WAIT_FOR'):\n"
+            "    pathlib.Path(os.environ['FAKE_CODEX_STARTED']).touch()\n"
+            "    while not pathlib.Path(os.environ['FAKE_CODEX_WAIT_FOR']).exists(): time.sleep(0.01)\n"
             "if os.environ.get('FAKE_CODEX_HOLD'):\n"
             "    child = subprocess.Popen([sys.executable, '-c', \"import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)\"])\n"
             "    pathlib.Path(os.environ['FAKE_CODEX_CHILD']).write_text(str(child.pid))\n"
@@ -359,10 +362,16 @@ class CodexWorkerTests(unittest.TestCase):
         self.assertEqual(state["lifecycle"], "exited")
         self.assertEqual(state["session_id"], "worker-1")
         self.assertEqual(state["cwd"], str(self.worktree.resolve()))
-        self.assertEqual(state["pid"], state["pgid"])
-        self.assertEqual(state["pid"], state["sid"])
-        self.assertIn("seconds", state["birth"])
-        self.assertIn("microseconds", state["birth"])
+        if sys.platform == "darwin":
+            self.assertEqual(state["pid"], state["pgid"])
+            self.assertEqual(state["pid"], state["sid"])
+            self.assertIn("seconds", state["birth"])
+            self.assertIn("microseconds", state["birth"])
+            self.assertNotIn("family_semantics", state)
+        else:
+            self.assertEqual(state["family_semantics"], "unsupported")
+            self.assertEqual(state["generation"], 1)
+            self.assertFalse({"pid", "pgid", "sid", "birth"} & set(state))
         arguments = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertIn("--sandbox", arguments)
         self.assertIn(str(self.worktree.resolve()), arguments)
@@ -546,6 +555,7 @@ class CodexWorkerTests(unittest.TestCase):
         self.assertIn("refuses the control checkout", result.stderr)
         self.assertFalse(self.arguments.exists())
 
+    @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_stop_kills_only_the_recorded_group_after_its_leader_exits(self):
         child = self.scratch / "child-pid"
         self.environment["FAKE_CODEX_HOLD"] = "1"
@@ -570,6 +580,7 @@ class CodexWorkerTests(unittest.TestCase):
                 self.worker("stop", "--state", str(self.state), "--cwd", str(self.worktree))
             launcher.wait(timeout=5)
 
+    @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_stopping_one_distinct_worktree_group_leaves_the_other_group_alive(self):
         other_worktree = self.scratch / "other-worktree"
         other_worktree.mkdir()
@@ -596,6 +607,7 @@ class CodexWorkerTests(unittest.TestCase):
             first.wait(timeout=5)
             second.wait(timeout=5)
 
+    @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_identity_and_cwd_mismatches_refuse_without_signaling_the_fixture(self):
         child = self.scratch / "child-pid"
         launcher = self.launch_holding_worker(self.state, self.worktree, child)
@@ -624,6 +636,7 @@ class CodexWorkerTests(unittest.TestCase):
             self.stop_fixture(self.state, self.worktree)
             launcher.wait(timeout=5)
 
+    @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_concurrent_resume_cannot_win_against_a_durable_launch_claim(self):
         started = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
         self.assertEqual(started.returncode, 0, started.stderr)
@@ -646,6 +659,51 @@ class CodexWorkerTests(unittest.TestCase):
         repeated = self.worker("resume", "--codex", str(self.binary), "--state", str(self.state), "again")
         self.assertEqual(repeated.returncode, 0, repeated.stderr)
 
+    @unittest.skipIf(sys.platform == "darwin", "requires unsupported process-family semantics")
+    def test_portable_concurrent_resume_refuses_the_stale_contender(self):
+        started = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
+        self.assertEqual(started.returncode, 0, started.stderr)
+        first_started = self.scratch / "first-resume-started"
+        release = self.scratch / "release-first-resume"
+        environment = self.environment.copy()
+        environment.update(
+            {
+                "FAKE_CODEX_WAIT_FOR": str(release),
+                "FAKE_CODEX_STARTED": str(first_started),
+                "FAKE_CODEX_OUTPUT": (
+                    '{"type":"thread.started","thread_id":"worker-1"}\n'
+                    '{"type":"item.completed","item":{"type":"agent_message","text":"resumed"}}\n'
+                ),
+            }
+        )
+        command = [
+            "python3", str(CODEX_WORKER), "resume", "--codex", str(self.binary),
+            "--state", str(self.state), "continue",
+        ]
+        first = subprocess.Popen(
+            command, cwd=ROOT, env=environment,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        deadline = time.monotonic() + 3
+        while not first_started.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertTrue(first_started.exists(), "portable resume did not start")
+        second = subprocess.Popen(
+            command, cwd=ROOT, env=environment,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        time.sleep(0.1)
+        release.touch()
+        first_output, first_error = first.communicate(timeout=5)
+        second_output, second_error = second.communicate(timeout=5)
+
+        self.assertEqual(first.returncode, 0, first_error)
+        self.assertEqual(json.loads(first_output)["final_message"], "resumed")
+        self.assertNotEqual(second.returncode, 0, second_output)
+        self.assertIn("unchanged terminal worker state", second_error)
+        self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["generation"], 2)
+
+    @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_lock_contended_stop_and_resume_cannot_both_win(self):
         child = self.scratch / "contended-child"
         launcher = self.launch_holding_worker(self.state, self.worktree, child)
@@ -781,6 +839,18 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             **self.identity,
         }
 
+    def portable_state(self, generation=1):
+        return {
+            "version": WORKER_MODULE.STATE_VERSION,
+            "lifecycle": "exited",
+            "session_id": "worker-1",
+            "model": "Terra",
+            "sandbox": "read-only",
+            "cwd": str(self.cwd),
+            "family_semantics": WORKER_MODULE.FAMILY_SEMANTICS_UNSUPPORTED,
+            "generation": generation,
+        }
+
     def arguments(self):
         return argparse.Namespace(state=self.state, cwd=self.cwd, grace_seconds=0.01)
 
@@ -908,6 +978,46 @@ class WorkerLifecycleContractTests(unittest.TestCase):
                     members.assert_not_called()
                     killpg.assert_not_called()
 
+    def test_malformed_portable_mutations_are_rejected_before_any_process_probe_or_signal(self):
+        base = self.portable_state()
+        mutations = (
+            ("missing family semantics", {key: value for key, value in base.items() if key != "family_semantics"}),
+            ("family semantics type", {**base, "family_semantics": []}),
+            ("family semantics value", {**base, "family_semantics": "recoverable"}),
+            ("missing generation", {key: value for key, value in base.items() if key != "generation"}),
+            ("generation type", {**base, "generation": "1"}),
+            ("generation bool", {**base, "generation": True}),
+            ("generation zero", {**base, "generation": 0}),
+            ("generation overflow", {**base, "generation": 2**64}),
+            ("nonterminal lifecycle", {**base, "lifecycle": "running"}),
+            ("fabricated identity", {**base, "pid": 41}),
+        )
+        for name, state in mutations:
+            operations = (
+                ("stop", WORKER_MODULE.stop, self.arguments()),
+                ("verify", WORKER_MODULE.verify, self.arguments()),
+                ("resume", WORKER_MODULE.resume, self.resume_arguments()),
+            )
+            for operation_name, operation, arguments in operations:
+                with self.subTest(name=name, operation=operation_name):
+                    WORKER_MODULE.atomic_write(self.state, state)
+                    error = io.StringIO()
+                    with (
+                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()) as libproc,
+                        mock.patch.object(WORKER_MODULE, "gated_process") as gated,
+                        mock.patch.object(WORKER_MODULE, "live_identity") as identity,
+                        mock.patch.object(WORKER_MODULE, "group_members") as members,
+                        mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
+                        redirect_stderr(error),
+                    ):
+                        self.assertEqual(operation(arguments), 1)
+                    self.assertTrue(error.getvalue().startswith("codex-worker: state"))
+                    libproc.assert_not_called()
+                    gated.assert_not_called()
+                    identity.assert_not_called()
+                    members.assert_not_called()
+                    killpg.assert_not_called()
+
     def test_unsupported_platform_returns_the_exact_code_without_signaling(self):
         WORKER_MODULE.atomic_write(self.state, self.family_state())
         for operation in (WORKER_MODULE.stop, WORKER_MODULE.verify):
@@ -925,6 +1035,79 @@ class WorkerLifecycleContractTests(unittest.TestCase):
                 )
                 killpg.assert_not_called()
 
+    def test_forced_unsupported_start_resume_and_cleanup_contract(self):
+        output = (
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+            '{"type":"item.completed","item":{"type":"agent_message","text":"answer"}}\n'
+        )
+        arguments = argparse.Namespace(
+            state=self.state,
+            codex="codex",
+            prompt="do the work",
+            model="Terra",
+            sandbox="read-only",
+            cwd=self.cwd,
+            control_checkout=None,
+        )
+        completed = subprocess.CompletedProcess([], 0, stdout=output, stderr="")
+        with (
+            mock.patch.object(WORKER_MODULE, "_libproc", return_value=None),
+            mock.patch.object(WORKER_MODULE.subprocess, "run", return_value=completed) as run_worker,
+            mock.patch.object(WORKER_MODULE, "gated_process") as gated,
+            mock.patch.object(WORKER_MODULE, "latest_rate_limits", return_value=None),
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(WORKER_MODULE.start(arguments), 0)
+
+        state = WORKER_MODULE.read_state(self.state)
+        self.assertEqual(state["version"], WORKER_MODULE.STATE_VERSION)
+        self.assertEqual(state["lifecycle"], "exited")
+        self.assertEqual(state["session_id"], "worker-1")
+        self.assertEqual(state["family_semantics"], "unsupported")
+        self.assertEqual(state["generation"], 1)
+        self.assertFalse({"pid", "pgid", "sid", "birth"} & set(state))
+        run_worker.assert_called_once()
+        gated.assert_not_called()
+
+        refusal = io.StringIO()
+        with (
+            mock.patch.object(WORKER_MODULE, "_libproc", return_value=None),
+            mock.patch.object(WORKER_MODULE.subprocess, "run", return_value=completed) as resume_worker,
+            mock.patch.object(WORKER_MODULE, "gated_process") as resume_gate,
+            mock.patch.object(WORKER_MODULE, "latest_rate_limits", return_value=None),
+            mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(refusal),
+        ):
+            self.assertEqual(WORKER_MODULE.resume(self.resume_arguments()), 0)
+            self.assertEqual(WORKER_MODULE.stop(self.arguments()), 1)
+            self.assertEqual(WORKER_MODULE.verify(self.arguments()), 1)
+
+        resumed = WORKER_MODULE.read_state(self.state)
+        self.assertTrue(WORKER_MODULE.valid_portable_schema(resumed))
+        self.assertEqual(resumed["generation"], 2)
+        self.assertIn("resume", resume_worker.call_args.args[0])
+        resume_gate.assert_not_called()
+        self.assertEqual(
+            refusal.getvalue(),
+            f"codex-worker: {WORKER_MODULE.UNSUPPORTED}\n" * 2,
+        )
+        killpg.assert_not_called()
+
+        with (
+            mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
+            mock.patch.object(WORKER_MODULE, "live_identity") as identity,
+            mock.patch.object(WORKER_MODULE, "group_members") as members,
+            mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(WORKER_MODULE.stop(self.arguments()), 1)
+            self.assertEqual(WORKER_MODULE.verify(self.arguments()), 1)
+        identity.assert_not_called()
+        members.assert_not_called()
+        killpg.assert_not_called()
+
     def test_already_exited_leader_with_empty_group_stops_without_a_signal(self):
         WORKER_MODULE.atomic_write(self.state, self.family_state())
         with mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()), mock.patch.object(WORKER_MODULE, "live_identity", return_value=None), mock.patch.object(WORKER_MODULE, "group_members", return_value=[]), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
@@ -932,6 +1115,7 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             self.assertEqual(WORKER_MODULE.read_state(self.state)["lifecycle"], "stopped")
             killpg.assert_not_called()
 
+    @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_launch_gate_eof_exits_before_exec_with_a_dedicated_session_identity(self):
         marker = self.root / "executed"
         process, release = WORKER_MODULE.gated_process(
@@ -1063,21 +1247,24 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             self.assertEqual(WORKER_MODULE.resume(argparse.Namespace(state=self.state, codex="codex", prompt="continue")), 0)
             self.assertEqual(launch.call_args.args[2]["lifecycle"], "launching")
 
-    def test_darwin_probe_contract_and_no_global_cleanup_authority(self):
+    def test_process_family_constants_and_no_global_cleanup_authority(self):
         self.assertEqual(WORKER_MODULE.BSD_SIZE, 136)
         self.assertEqual(WORKER_MODULE.VNODE_SIZE, 2352)
         self.assertEqual(WORKER_MODULE.PROC_PIDTBSDINFO, 3)
         self.assertEqual(WORKER_MODULE.PROC_PIDVNODEPATHINFO, 9)
-        identity = WORKER_MODULE.live_identity(os.getpid())
-        self.assertIsNotNone(identity)
-        self.assertEqual(identity["cwd"], str(ROOT.resolve()))
-        self.assertIn(os.getpid(), WORKER_MODULE.group_members(os.getpgrp()))
         source = CODEX_WORKER.read_text(encoding="utf-8")
         instructions = (ROOT / "skills" / "orchestrate" / "SKILL.md").read_text(encoding="utf-8")
         self.assertNotIn("pkill", source)
         self.assertNotIn("proc_listchildpids", source)
         self.assertNotIn("proc_name", source)
         self.assertIn("Successors never discover or clean", instructions)
+
+    @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
+    def test_darwin_probe_contract(self):
+        identity = WORKER_MODULE.live_identity(os.getpid())
+        self.assertIsNotNone(identity)
+        self.assertEqual(identity["cwd"], str(ROOT.resolve()))
+        self.assertIn(os.getpid(), WORKER_MODULE.group_members(os.getpgrp()))
 
 
 if __name__ == "__main__":

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import argparse
+import fcntl
 import json
 import os
+import importlib.util
 import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from typing import Optional
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,6 +21,11 @@ SPIN_SCRIPT = ROOT / "skills" / "spin-worktree" / "scripts" / "spin-worktree.py"
 CODEX_WORKER = ROOT / "skills" / "orchestrate" / "scripts" / "codex-worker.py"
 BEGIN_IGNORE = "# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
 BEGIN_HOOK = "# >>> cbm-onboard managed reindex >>>"
+
+WORKER_SPEC = importlib.util.spec_from_file_location("orchestrate_worker", CODEX_WORKER)
+assert WORKER_SPEC and WORKER_SPEC.loader
+WORKER_MODULE = importlib.util.module_from_spec(WORKER_SPEC)
+WORKER_SPEC.loader.exec_module(WORKER_MODULE)
 
 
 def run(
@@ -224,10 +235,15 @@ class CodexWorkerTests(unittest.TestCase):
         self.child_cwd = self.scratch / "child-cwd"
         self.binary.write_text(
             "#!/usr/bin/env python3\n"
-            "import json, os, pathlib, sys\n"
+            "import json, os, pathlib, signal, subprocess, sys, time\n"
             "pathlib.Path(os.environ['FAKE_CODEX_ARGUMENTS']).write_text(json.dumps(sys.argv[1:]))\n"
             "if os.environ.get('FAKE_CODEX_CWD'):\n"
             "    pathlib.Path(os.environ['FAKE_CODEX_CWD']).write_text(os.getcwd())\n"
+            "if os.environ.get('FAKE_CODEX_HOLD'):\n"
+            "    child = subprocess.Popen([sys.executable, '-c', \"import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)\"])\n"
+            "    pathlib.Path(os.environ['FAKE_CODEX_CHILD']).write_text(str(child.pid))\n"
+            "    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+            "    while True: time.sleep(1)\n"
             "sys.stdout.write(os.environ.get('FAKE_CODEX_OUTPUT', ''))\n"
             "sys.exit(int(os.environ.get('FAKE_CODEX_EXIT', '0')))\n",
             encoding="utf-8",
@@ -279,6 +295,48 @@ class CodexWorkerTests(unittest.TestCase):
             arguments.extend(["--control-checkout", str(self.control)])
         return self.worker(*arguments, "do the work")
 
+    def launch_holding_worker(self, state: Path, cwd: Path, child: Path):
+        environment = self.environment.copy()
+        environment["FAKE_CODEX_HOLD"] = "1"
+        environment["FAKE_CODEX_CHILD"] = str(child)
+        command = [
+            "python3", str(CODEX_WORKER), "start", "--codex", str(self.binary),
+            "--state", str(state), "--model", "Terra", "--sandbox", "read-only",
+            "--cwd", str(cwd), "hold",
+        ]
+        launcher = subprocess.Popen(command, cwd=ROOT, env=environment)
+        deadline = time.monotonic() + 3
+        while (not child.exists() or not state.exists()) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertTrue(child.exists(), "fixture child did not start")
+        self.assertEqual(json.loads(state.read_text(encoding="utf-8"))["lifecycle"], "running")
+        return launcher
+
+    def launch_holding_resume(self, child: Path):
+        environment = self.environment.copy()
+        environment["FAKE_CODEX_HOLD"] = "1"
+        environment["FAKE_CODEX_CHILD"] = str(child)
+        launcher = subprocess.Popen(
+            ["python3", str(CODEX_WORKER), "resume", "--codex", str(self.binary), "--state", str(self.state), "hold"],
+            cwd=ROOT,
+            env=environment,
+        )
+        deadline = time.monotonic() + 3
+        while (not child.exists() or not self.state.exists()) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertTrue(child.exists(), "resumed fixture child did not start")
+        self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["lifecycle"], "running")
+        return launcher
+
+    def stop_fixture(self, state: Path, cwd: Path):
+        result = self.worker("stop", "--state", str(state), "--cwd", str(cwd))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        verified = self.worker("verify", "--state", str(state), "--cwd", str(cwd))
+        self.assertEqual(verified.returncode, 0, verified.stderr)
+
+    def assert_alive(self, path: Path):
+        os.kill(int(path.read_text(encoding="utf-8")), 0)
+
     def rollout(self, name: str, session_id: str, *events: dict):
         path = self.codex_home / "sessions" / name
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -294,15 +352,15 @@ class CodexWorkerTests(unittest.TestCase):
         result = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(
-            json.loads(self.state.read_text(encoding="utf-8")),
-            {
-                "session_id": "worker-1",
-                "model": "Terra",
-                "sandbox": "read-only",
-                "cwd": str(self.worktree.resolve()),
-            },
-        )
+        state = json.loads(self.state.read_text(encoding="utf-8"))
+        self.assertEqual(state["version"], 2)
+        self.assertEqual(state["lifecycle"], "exited")
+        self.assertEqual(state["session_id"], "worker-1")
+        self.assertEqual(state["cwd"], str(self.worktree.resolve()))
+        self.assertEqual(state["pid"], state["pgid"])
+        self.assertEqual(state["pid"], state["sid"])
+        self.assertIn("seconds", state["birth"])
+        self.assertIn("microseconds", state["birth"])
         arguments = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertIn("--sandbox", arguments)
         self.assertIn(str(self.worktree.resolve()), arguments)
@@ -380,7 +438,7 @@ class CodexWorkerTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("reported an error item", result.stderr)
-        self.assertFalse(self.state.exists())
+        self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["lifecycle"], "exited")
 
     def test_start_fails_without_a_completed_agent_message(self):
         result = self.start(
@@ -391,7 +449,7 @@ class CodexWorkerTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("missing completed agent message", result.stderr)
-        self.assertFalse(self.state.exists())
+        self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["lifecycle"], "exited")
 
     def test_preserves_a_nonzero_codex_exit_status(self):
         self.environment["FAKE_CODEX_EXIT"] = "7"
@@ -400,7 +458,7 @@ class CodexWorkerTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 7)
         self.assertEqual(result.stdout, "worker failed\n")
-        self.assertFalse(self.state.exists())
+        self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["lifecycle"], "exited")
 
     def test_headroom_uses_the_matching_session_rollout(self):
         token_count = {
@@ -459,7 +517,7 @@ class CodexWorkerTests(unittest.TestCase):
                     self.state.unlink()
                 result = self.start(output)
                 self.assertNotEqual(result.returncode, 0)
-                self.assertFalse(self.state.exists())
+                self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["lifecycle"], "exited")
 
     def test_workspace_write_rejects_the_control_checkout(self):
         self.environment["FAKE_CODEX_OUTPUT"] = (
@@ -485,6 +543,133 @@ class CodexWorkerTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("refuses the control checkout", result.stderr)
         self.assertFalse(self.arguments.exists())
+
+    def test_stop_kills_only_the_recorded_group_after_its_leader_exits(self):
+        child = self.scratch / "child-pid"
+        self.environment["FAKE_CODEX_HOLD"] = "1"
+        self.environment["FAKE_CODEX_CHILD"] = str(child)
+        command = [
+            "python3", str(CODEX_WORKER), "start", "--codex", str(self.binary),
+            "--state", str(self.state), "--model", "Terra", "--sandbox", "read-only",
+            "--cwd", str(self.worktree), "hold",
+        ]
+        launcher = subprocess.Popen(command, cwd=ROOT, env=self.environment)
+        try:
+            deadline = time.monotonic() + 3
+            while not child.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertTrue(child.exists())
+            result = self.worker("stop", "--state", str(self.state), "--cwd", str(self.worktree))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            verified = self.worker("verify", "--state", str(self.state), "--cwd", str(self.worktree))
+            self.assertEqual(verified.returncode, 0, verified.stderr)
+        finally:
+            if launcher.poll() is None and self.state.exists():
+                self.worker("stop", "--state", str(self.state), "--cwd", str(self.worktree))
+            launcher.wait(timeout=5)
+
+    def test_stopping_one_distinct_worktree_group_leaves_the_other_group_alive(self):
+        other_worktree = self.scratch / "other-worktree"
+        other_worktree.mkdir()
+        first_state = self.scratch / "first-state.json"
+        second_state = self.scratch / "second-state.json"
+        first_child = self.scratch / "first-child"
+        second_child = self.scratch / "second-child"
+        first = self.launch_holding_worker(first_state, self.worktree, first_child)
+        second = self.launch_holding_worker(second_state, other_worktree, second_child)
+        try:
+            self.stop_fixture(first_state, self.worktree)
+            self.assert_alive(second_child)
+            self.assertEqual(
+                json.loads(second_state.read_text(encoding="utf-8"))["cwd"],
+                str(other_worktree.resolve()),
+            )
+            still_running = self.worker("verify", "--state", str(second_state), "--cwd", str(other_worktree))
+            self.assertNotEqual(still_running.returncode, 0)
+        finally:
+            if first.poll() is None and first_state.exists():
+                self.stop_fixture(first_state, self.worktree)
+            if second.poll() is None and second_state.exists():
+                self.stop_fixture(second_state, other_worktree)
+            first.wait(timeout=5)
+            second.wait(timeout=5)
+
+    def test_identity_and_cwd_mismatches_refuse_without_signaling_the_fixture(self):
+        child = self.scratch / "child-pid"
+        launcher = self.launch_holding_worker(self.state, self.worktree, child)
+        original = json.loads(self.state.read_text(encoding="utf-8"))
+        other_worktree = self.scratch / "other-worktree"
+        other_worktree.mkdir()
+        try:
+            mismatch = self.worker("stop", "--state", str(self.state), "--cwd", str(other_worktree))
+            self.assertNotEqual(mismatch.returncode, 0)
+            self.assertIn("cwd mismatch", mismatch.stderr)
+            self.assert_alive(child)
+            for field, changed in (
+                ("birth", {"seconds": original["birth"]["seconds"] + 1, "microseconds": original["birth"]["microseconds"]}),
+                ("pgid", original["pgid"] + 1),
+                ("sid", original["sid"] + 1),
+            ):
+                state = dict(original)
+                state[field] = changed
+                self.state.write_text(json.dumps(state), encoding="utf-8")
+                mismatch = self.worker("stop", "--state", str(self.state), "--cwd", str(self.worktree))
+                self.assertNotEqual(mismatch.returncode, 0)
+                self.assertIn("identity mismatch", mismatch.stderr)
+                self.assert_alive(child)
+            self.state.write_text(json.dumps(original), encoding="utf-8")
+        finally:
+            self.stop_fixture(self.state, self.worktree)
+            launcher.wait(timeout=5)
+
+    def test_concurrent_resume_cannot_win_against_a_durable_launch_claim(self):
+        started = self.start('{"type":"thread.started","thread_id":"worker-1"}\n')
+        self.assertEqual(started.returncode, 0, started.stderr)
+        child = self.scratch / "resumed-child"
+        launcher = self.launch_holding_resume(child)
+        try:
+            concurrent = self.worker("resume", "--codex", str(self.binary), "--state", str(self.state), "compete")
+            self.assertNotEqual(concurrent.returncode, 0)
+            self.assertIn("terminal worker state", concurrent.stderr)
+            self.assert_alive(child)
+            self.stop_fixture(self.state, self.worktree)
+        finally:
+            if launcher.poll() is None and self.state.exists():
+                self.stop_fixture(self.state, self.worktree)
+            launcher.wait(timeout=5)
+        self.environment["FAKE_CODEX_OUTPUT"] = (
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+            '{"type":"item.completed","item":{"type":"agent_message","text":"resumed"}}\n'
+        )
+        repeated = self.worker("resume", "--codex", str(self.binary), "--state", str(self.state), "again")
+        self.assertEqual(repeated.returncode, 0, repeated.stderr)
+
+    def test_lock_contended_stop_and_resume_cannot_both_win(self):
+        child = self.scratch / "contended-child"
+        launcher = self.launch_holding_worker(self.state, self.worktree, child)
+        lock_path = self.state.with_name(self.state.name + ".lock")
+        with lock_path.open("a+") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            stop = subprocess.Popen(
+                ["python3", str(CODEX_WORKER), "stop", "--state", str(self.state), "--cwd", str(self.worktree)],
+                cwd=ROOT, env=self.environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            resume = subprocess.Popen(
+                ["python3", str(CODEX_WORKER), "resume", "--codex", str(self.binary), "--state", str(self.state), "compete"],
+                cwd=ROOT, env=self.environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            time.sleep(0.05)
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        try:
+            _, stop_error = stop.communicate(timeout=5)
+            _, resume_error = resume.communicate(timeout=5)
+            self.assertEqual(stop.returncode, 0, stop_error)
+            self.assertNotEqual(resume.returncode, 0)
+            self.assertIn("terminal worker state", resume_error)
+        finally:
+            if launcher.poll() is None and self.state.exists():
+                self.stop_fixture(self.state, self.worktree)
+            launcher.wait(timeout=5)
 
     def test_workspace_write_rejects_a_path_inside_the_control_checkout(self):
         nested = self.control / "nested"
@@ -563,6 +748,144 @@ class OrchestrateCodexPolicyTests(unittest.TestCase):
         self.assertIn("cannot switch to Claude workers", dispatch)
         self.assertIn("headroom at or below 5%", dispatch)
         self.assertIn("Each admitted v0 route is one", dispatch)
+
+
+class WorkerLifecycleContractTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.cwd = self.root / "worktree"
+        self.cwd.mkdir()
+        self.cwd = self.cwd.resolve()
+        self.state = self.root / "state.json"
+        self.identity = {
+            "pid": 41,
+            "pgid": 41,
+            "sid": 41,
+            "cwd": str(self.cwd.resolve()),
+            "birth": {"seconds": 1, "microseconds": 2},
+        }
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def family_state(self, lifecycle="running", session_id="worker-1"):
+        return {
+            "version": WORKER_MODULE.STATE_VERSION,
+            "lifecycle": lifecycle,
+            "session_id": session_id,
+            "model": "Terra",
+            "sandbox": "read-only",
+            **self.identity,
+        }
+
+    def arguments(self):
+        return argparse.Namespace(state=self.state, cwd=self.cwd, grace_seconds=0.01)
+
+    def test_transition_table_and_atomic_replace_fsync_the_state_and_parent(self):
+        self.assertEqual(WORKER_MODULE.TRANSITIONS["launching"], {"running", "stopping", "exited"})
+        self.assertEqual(WORKER_MODULE.TRANSITIONS["running"], {"stopping", "exited"})
+        self.assertEqual(WORKER_MODULE.TRANSITIONS["stopping"], {"stopped", "exited"})
+        with mock.patch.object(WORKER_MODULE.os, "fsync", wraps=os.fsync) as fsync, mock.patch.object(WORKER_MODULE.os, "replace", wraps=os.replace) as replace:
+            WORKER_MODULE.atomic_write(self.state, self.family_state("launching"))
+        self.assertEqual(replace.call_count, 1)
+        self.assertGreaterEqual(fsync.call_count, 2)
+        state = WORKER_MODULE.read_state(self.state, family_required=True)
+        self.assertEqual(WORKER_MODULE.transition(self.state, state, "running")["lifecycle"], "running")
+        with self.assertRaises(ValueError):
+            WORKER_MODULE.transition(self.state, state, "stopped")
+
+    def test_every_legal_transition_is_persisted_and_every_other_edge_is_rejected(self):
+        for source, destinations in WORKER_MODULE.TRANSITIONS.items():
+            for destination in destinations:
+                with self.subTest(source=source, destination=destination):
+                    WORKER_MODULE.atomic_write(self.state, self.family_state(source))
+                    state = WORKER_MODULE.read_state(self.state, family_required=True)
+                    self.assertEqual(WORKER_MODULE.transition(self.state, state, destination)["lifecycle"], destination)
+            illegal = next(candidate for candidate in WORKER_MODULE.TRANSITIONS if candidate not in destinations)
+            with self.subTest(source=source, illegal=illegal):
+                WORKER_MODULE.atomic_write(self.state, self.family_state(source))
+                with self.assertRaises(ValueError):
+                    WORKER_MODULE.transition(self.state, WORKER_MODULE.read_state(self.state), illegal)
+
+    def test_missing_corrupt_stale_and_legacy_state_are_rejected_by_stop_and_verify(self):
+        for name, contents in (
+            ("missing", None),
+            ("corrupt", "not json"),
+            ("stale", json.dumps({"version": 1})),
+            ("legacy", json.dumps({"session_id": "old", "model": "Terra", "sandbox": "read-only", "cwd": str(self.cwd)})),
+        ):
+            with self.subTest(name=name), mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
+                if contents is None:
+                    self.state.unlink(missing_ok=True)
+                else:
+                    self.state.write_text(contents, encoding="utf-8")
+                self.assertNotEqual(WORKER_MODULE.stop(self.arguments()), 0)
+                self.assertNotEqual(WORKER_MODULE.verify(self.arguments()), 0)
+                killpg.assert_not_called()
+
+    def test_unsupported_platform_returns_the_exact_code_without_signaling(self):
+        with mock.patch.object(WORKER_MODULE, "_libproc", return_value=None), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
+            self.assertEqual(WORKER_MODULE.stop(self.arguments()), 1)
+            self.assertEqual(WORKER_MODULE.verify(self.arguments()), 1)
+            killpg.assert_not_called()
+
+    def test_already_exited_leader_with_empty_group_stops_without_a_signal(self):
+        WORKER_MODULE.atomic_write(self.state, self.family_state())
+        with mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()), mock.patch.object(WORKER_MODULE, "live_identity", return_value=None), mock.patch.object(WORKER_MODULE, "group_members", return_value=[]), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
+            self.assertEqual(WORKER_MODULE.stop(self.arguments()), 0)
+            self.assertEqual(WORKER_MODULE.read_state(self.state)["lifecycle"], "stopped")
+            killpg.assert_not_called()
+
+    def test_launch_gate_eof_exits_before_exec_with_a_dedicated_session_identity(self):
+        marker = self.root / "executed"
+        process, release = WORKER_MODULE.gated_process(
+            [sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).touch()"],
+            self.cwd,
+        )
+        try:
+            deadline = time.monotonic() + 1
+            identity = None
+            while time.monotonic() < deadline:
+                identity = WORKER_MODULE.live_identity(process.pid)
+                if identity and identity["pid"] == identity["pgid"] == identity["sid"]:
+                    break
+                time.sleep(0.01)
+            self.assertIsNotNone(identity)
+            self.assertEqual(identity["cwd"], str(self.cwd))
+            self.assertFalse(marker.exists())
+        finally:
+            os.close(release)
+        process.communicate(timeout=3)
+        self.assertEqual(process.returncode, 125)
+        self.assertFalse(marker.exists())
+
+    def test_nonterminal_resume_is_rejected_and_legacy_completed_resume_is_accepted_to_launch(self):
+        WORKER_MODULE.atomic_write(self.state, self.family_state("running"))
+        with mock.patch.object(WORKER_MODULE, "run_lifecycle") as launch:
+            self.assertNotEqual(WORKER_MODULE.resume(argparse.Namespace(state=self.state, codex="codex", prompt="continue")), 0)
+            launch.assert_not_called()
+        legacy = {"session_id": "old", "model": "Terra", "sandbox": "read-only", "cwd": str(self.cwd)}
+        self.state.write_text(json.dumps(legacy), encoding="utf-8")
+        with mock.patch.object(WORKER_MODULE, "run_lifecycle", return_value=0) as launch:
+            self.assertEqual(WORKER_MODULE.resume(argparse.Namespace(state=self.state, codex="codex", prompt="continue")), 0)
+            self.assertEqual(launch.call_args.args[2]["lifecycle"], "launching")
+
+    def test_darwin_probe_contract_and_no_global_cleanup_authority(self):
+        self.assertEqual(WORKER_MODULE.BSD_SIZE, 136)
+        self.assertEqual(WORKER_MODULE.VNODE_SIZE, 2352)
+        self.assertEqual(WORKER_MODULE.PROC_PIDTBSDINFO, 3)
+        self.assertEqual(WORKER_MODULE.PROC_PIDVNODEPATHINFO, 9)
+        identity = WORKER_MODULE.live_identity(os.getpid())
+        self.assertIsNotNone(identity)
+        self.assertEqual(identity["cwd"], str(ROOT.resolve()))
+        self.assertIn(os.getpid(), WORKER_MODULE.group_members(os.getpgrp()))
+        source = CODEX_WORKER.read_text(encoding="utf-8")
+        instructions = (ROOT / "skills" / "orchestrate" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertNotIn("pkill", source)
+        self.assertNotIn("proc_listchildpids", source)
+        self.assertNotIn("proc_name", source)
+        self.assertIn("Successors never discover or clean", instructions)
 
 
 if __name__ == "__main__":

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import io
 import json
 import os
 import importlib.util
@@ -10,6 +11,7 @@ import sys
 import tempfile
 import time
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from typing import Optional
 from unittest import mock
@@ -782,6 +784,9 @@ class WorkerLifecycleContractTests(unittest.TestCase):
     def arguments(self):
         return argparse.Namespace(state=self.state, cwd=self.cwd, grace_seconds=0.01)
 
+    def resume_arguments(self):
+        return argparse.Namespace(state=self.state, codex="codex", prompt="continue")
+
     def test_transition_table_and_atomic_replace_fsync_the_state_and_parent(self):
         self.assertEqual(WORKER_MODULE.TRANSITIONS["launching"], {"running", "stopping", "exited"})
         self.assertEqual(WORKER_MODULE.TRANSITIONS["running"], {"stopping", "exited"})
@@ -824,11 +829,101 @@ class WorkerLifecycleContractTests(unittest.TestCase):
                 self.assertNotEqual(WORKER_MODULE.verify(self.arguments()), 0)
                 killpg.assert_not_called()
 
+    def test_malformed_v2_mutations_are_rejected_before_any_process_probe_or_signal(self):
+        base = self.family_state()
+        mutations = (
+            *((f"missing {field}", {key: value for key, value in base.items() if key != field}) for field in base),
+            ("version type", {**base, "version": "2"}),
+            ("version null", {**base, "version": None}),
+            ("version bool", {**base, "version": True}),
+            ("version value", {**base, "version": 3}),
+            ("lifecycle type", {**base, "lifecycle": []}),
+            ("lifecycle value", {**base, "lifecycle": "unknown"}),
+            ("pid type", {**base, "pid": "41"}),
+            ("pid bool", {**base, "pid": True}),
+            ("pid negative", {**base, "pid": -1}),
+            ("pid zero", {**base, "pid": 0}),
+            ("pid overflow", {**base, "pid": 2**31}),
+            ("pgid type", {**base, "pgid": "41"}),
+            ("pgid bool", {**base, "pgid": True}),
+            ("pgid negative", {**base, "pgid": -1}),
+            ("pgid zero", {**base, "pgid": 0}),
+            ("pgid overflow", {**base, "pgid": 2**31}),
+            ("sid type", {**base, "sid": "41"}),
+            ("sid bool", {**base, "sid": True}),
+            ("sid negative", {**base, "sid": -1}),
+            ("sid zero", {**base, "sid": 0}),
+            ("sid overflow", {**base, "sid": 2**31}),
+            ("cwd type", {**base, "cwd": [str(self.cwd)]}),
+            ("cwd empty", {**base, "cwd": ""}),
+            ("cwd relative", {**base, "cwd": "worktree"}),
+            ("cwd noncanonical", {**base, "cwd": str(self.cwd) + "/."}),
+            ("birth type", {**base, "birth": [1, 2]}),
+            ("birth missing seconds", {**base, "birth": {"microseconds": 2}}),
+            ("birth missing microseconds", {**base, "birth": {"seconds": 1}}),
+            ("birth seconds type", {**base, "birth": {"seconds": "1", "microseconds": 2}}),
+            ("birth seconds bool", {**base, "birth": {"seconds": True, "microseconds": 2}}),
+            ("birth seconds negative", {**base, "birth": {"seconds": -1, "microseconds": 2}}),
+            ("birth seconds zero", {**base, "birth": {"seconds": 0, "microseconds": 2}}),
+            ("birth seconds overflow", {**base, "birth": {"seconds": 2**64, "microseconds": 2}}),
+            ("birth microseconds type", {**base, "birth": {"seconds": 1, "microseconds": "2"}}),
+            ("birth microseconds bool", {**base, "birth": {"seconds": 1, "microseconds": True}}),
+            ("birth microseconds negative", {**base, "birth": {"seconds": 1, "microseconds": -1}}),
+            ("birth microseconds overflow", {**base, "birth": {"seconds": 1, "microseconds": 1_000_000}}),
+            ("birth extra field", {**base, "birth": {"seconds": 1, "microseconds": 2, "ticks": 3}}),
+            ("model type", {**base, "model": []}),
+            ("model empty", {**base, "model": ""}),
+            ("sandbox type", {**base, "sandbox": []}),
+            ("sandbox value", {**base, "sandbox": "danger-full-access"}),
+            ("session type", {**base, "session_id": 1}),
+            ("workspace control missing", {**base, "sandbox": "workspace-write"}),
+            ("control checkout type", {**base, "control_checkout": 1}),
+            ("control checkout empty", {**base, "control_checkout": ""}),
+            ("control checkout relative", {**base, "control_checkout": "control"}),
+            ("unknown field", {**base, "leader_name": "codex"}),
+        )
+        for name, state in mutations:
+            operations = (
+                ("stop", WORKER_MODULE.stop, self.arguments()),
+                ("verify", WORKER_MODULE.verify, self.arguments()),
+                ("resume", WORKER_MODULE.resume, self.resume_arguments()),
+            )
+            for operation_name, operation, arguments in operations:
+                with self.subTest(name=name, operation=operation_name):
+                    WORKER_MODULE.atomic_write(self.state, state)
+                    error = io.StringIO()
+                    with (
+                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()) as libproc,
+                        mock.patch.object(WORKER_MODULE, "gated_process") as gated,
+                        mock.patch.object(WORKER_MODULE, "live_identity") as identity,
+                        mock.patch.object(WORKER_MODULE, "group_members") as members,
+                        mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
+                        redirect_stderr(error),
+                    ):
+                        self.assertEqual(operation(arguments), 1)
+                    self.assertTrue(error.getvalue().startswith("codex-worker: state"))
+                    libproc.assert_not_called()
+                    gated.assert_not_called()
+                    identity.assert_not_called()
+                    members.assert_not_called()
+                    killpg.assert_not_called()
+
     def test_unsupported_platform_returns_the_exact_code_without_signaling(self):
-        with mock.patch.object(WORKER_MODULE, "_libproc", return_value=None), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
-            self.assertEqual(WORKER_MODULE.stop(self.arguments()), 1)
-            self.assertEqual(WORKER_MODULE.verify(self.arguments()), 1)
-            killpg.assert_not_called()
+        WORKER_MODULE.atomic_write(self.state, self.family_state())
+        for operation in (WORKER_MODULE.stop, WORKER_MODULE.verify):
+            with self.subTest(operation=operation.__name__):
+                error = io.StringIO()
+                with (
+                    mock.patch.object(WORKER_MODULE, "_libproc", return_value=None),
+                    mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
+                    redirect_stderr(error),
+                ):
+                    self.assertEqual(operation(self.arguments()), 1)
+                self.assertEqual(
+                    error.getvalue(),
+                    f"codex-worker: {WORKER_MODULE.UNSUPPORTED}\n",
+                )
+                killpg.assert_not_called()
 
     def test_already_exited_leader_with_empty_group_stops_without_a_signal(self):
         WORKER_MODULE.atomic_write(self.state, self.family_state())
@@ -859,6 +954,103 @@ class WorkerLifecycleContractTests(unittest.TestCase):
         process.communicate(timeout=3)
         self.assertEqual(process.returncode, 125)
         self.assertFalse(marker.exists())
+
+    def test_resume_cutpoints_before_family_persistence_preserve_the_terminal_state(self):
+        terminal = self.family_state("exited")
+        for name, cutpoint in (
+            ("before gate", "before gate"),
+            ("before family persistence", "before family persistence"),
+        ):
+            with self.subTest(name=name):
+                WORKER_MODULE.atomic_write(self.state, terminal)
+                if cutpoint == "before gate":
+                    patches = (
+                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
+                        mock.patch.object(WORKER_MODULE, "gated_process", side_effect=RuntimeError("cutpoint")),
+                    )
+                    read_fd = None
+                else:
+                    read_fd, write_fd = os.pipe()
+                    process = mock.Mock(pid=41)
+                    patches = (
+                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
+                        mock.patch.object(WORKER_MODULE, "gated_process", return_value=(process, write_fd)),
+                        mock.patch.object(WORKER_MODULE, "live_identity", side_effect=RuntimeError("cutpoint")),
+                    )
+                try:
+                    with patches[0], patches[1]:
+                        if len(patches) == 3:
+                            with patches[2]:
+                                with self.assertRaisesRegex(RuntimeError, "cutpoint"):
+                                    WORKER_MODULE.resume(self.resume_arguments())
+                        else:
+                            with self.assertRaisesRegex(RuntimeError, "cutpoint"):
+                                WORKER_MODULE.resume(self.resume_arguments())
+                finally:
+                    if read_fd is not None:
+                        os.close(read_fd)
+                self.assertEqual(WORKER_MODULE.read_state(self.state), terminal)
+
+    def test_resume_cutpoint_after_family_persistence_is_settled_without_signaling(self):
+        WORKER_MODULE.atomic_write(self.state, self.family_state("exited"))
+        read_fd, write_fd = os.pipe()
+        process = mock.Mock(pid=41)
+        try:
+            with (
+                mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
+                mock.patch.object(WORKER_MODULE, "gated_process", return_value=(process, write_fd)),
+                mock.patch.object(WORKER_MODULE, "live_identity", return_value=self.identity),
+                mock.patch.object(WORKER_MODULE.os, "write", side_effect=RuntimeError("cutpoint")),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "cutpoint"):
+                    WORKER_MODULE.resume(self.resume_arguments())
+        finally:
+            os.close(read_fd)
+
+        persisted = WORKER_MODULE.read_state(self.state)
+        self.assertEqual(persisted["lifecycle"], "launching")
+        self.assertEqual(
+            {key: persisted[key] for key in self.identity},
+            self.identity,
+        )
+        with (
+            mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
+            mock.patch.object(WORKER_MODULE, "live_identity", return_value=None),
+            mock.patch.object(WORKER_MODULE, "group_members", return_value=[]),
+            mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
+        ):
+            self.assertEqual(WORKER_MODULE.stop(self.arguments()), 0)
+            self.assertEqual(WORKER_MODULE.verify(self.arguments()), 0)
+            killpg.assert_not_called()
+
+    def test_resume_cutpoint_after_release_before_running_is_settled_without_signaling(self):
+        WORKER_MODULE.atomic_write(self.state, self.family_state("exited"))
+        read_fd, write_fd = os.pipe()
+        process = mock.Mock(pid=41)
+        try:
+            with (
+                mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
+                mock.patch.object(WORKER_MODULE, "gated_process", return_value=(process, write_fd)),
+                mock.patch.object(WORKER_MODULE, "live_identity", return_value=self.identity),
+                mock.patch.object(WORKER_MODULE, "transition", side_effect=RuntimeError("cutpoint")),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "cutpoint"):
+                    WORKER_MODULE.resume(self.resume_arguments())
+            self.assertEqual(os.read(read_fd, 1), b"R")
+        finally:
+            os.close(read_fd)
+
+        persisted = WORKER_MODULE.read_state(self.state)
+        self.assertEqual(persisted["lifecycle"], "launching")
+        with (
+            mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
+            mock.patch.object(WORKER_MODULE, "live_identity", return_value=None),
+            mock.patch.object(WORKER_MODULE, "group_members", return_value=[]),
+            mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
+        ):
+            self.assertEqual(WORKER_MODULE.stop(self.arguments()), 0)
+            self.assertEqual(WORKER_MODULE.verify(self.arguments()), 0)
+            killpg.assert_not_called()
 
     def test_nonterminal_resume_is_rejected_and_legacy_completed_resume_is_accepted_to_launch(self):
         WORKER_MODULE.atomic_write(self.state, self.family_state("running"))


### PR DESCRIPTION
## What changed

Interrupted orchestrated workers now carry a durable, versioned process-family identity. The coordinator can stop and verify exactly the worker group it launched before handing the worktree to a successor.

Recovery refuses unknown, stale, corrupt, or mismatched state. It never searches globally by test name, provider name, descendant tree, or session. A leader may exit while its children remain; only a successful lookup of that recorded process group can authorize the final stop.

Resume is replay-safe across launch cutpoints. An interruption before the process family exists preserves the prior resumable state; later interruptions retain a complete family record that scoped stop and verify can settle.

## Why

The previous recovery guidance let a successor mistake an unrelated test process for an orphan and terminate work in another worktree. Process names are not ownership; the recorded dedicated group is.

## What to check

- Two live worker groups in different worktrees remain isolated when one is stopped.
- Corrupt or reused identities refuse before any signal.
- Resume and stop cannot both win, including interruption cutpoints.
- Existing start, resume, headroom, and sandbox behavior remains compatible.

## Validation

- 36 behavior tests passed.
- The repository validator passed for 23 skills and 213 files.
- Standards and Spec review converged with no findings.
- Both commits carry DCO sign-off.

Closes #37
