### PR TITLE
Let scoped work declare acceptable risk

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -159,13 +159,29 @@ joins the enumeration: who calls whom, and at which point. A change reviewed onl
 in isolation passes clean and then spends the next round on nothing but seam
 defects.
 
-If no spec exists, skip the Spec sub-agent and say so in the report. Do not
-substitute the PR description written by the same author as the code.
+Before declaring the Spec axis unavailable, extract the admitted
+[risk contract](../scope/SKILL.md#risk-contract) from the spec, then look in the
+matching scope ledger if necessary. Do not substitute the PR description written by
+the same author as the code.
+
+If neither a spec nor a risk contract exists, skip the Spec sub-agent and say so. A
+ledger-only contract still bounds the review: run the Spec sub-agent against it and
+include an unmet item stating that admission never promoted it into an authoritative
+artifact. If a bounded spec exists but failure handling, recovery, or evidence scope
+is material and its contract is missing, add that omission as an unmet Spec item;
+otherwise do not manufacture one.
+
+Append `Must prevent`, `Must recover`, and `Evidence owed` entries to the Spec
+enumeration. Carry `Accepted failure` and `Unsupported` entries as explicit bounds for
+both sub-agents. A reviewer may challenge a bound only with evidence that changes its
+assumed likelihood, consequence, or recoverability; label that result `reopen scope`,
+not a code finding.
 
 ### 4. Run both axes in parallel
 
 Two sub-agents, one message, `general-purpose` for both. Each gets: the diff
-command, the commit list, its enumeration, and its brief.
+command, the commit list, its enumeration, the risk contract when one exists, and its
+brief.
 
 **Shared brief** — give this to both:
 
@@ -176,7 +192,10 @@ command, the commit list, its enumeration, and its brief.
 > enforces. Do not report style preferences the repo has not written down. Any
 > executable literal in the diff or its documents — a regex, a shell fragment, a
 > workflow expression, a query — is verified by executing it against a real
-> input, never by reading it. Under 400 words.
+> input, never by reading it. Behavior matching an `Accepted failure` or `Unsupported`
+> entry is accepted risk, not a finding. A missing test is a finding only
+> when the enumeration or risk contract says evidence is owed; test count and an
+> uncovered branch alone prove nothing. Under 400 words.
 
 **Standards brief:**
 
@@ -194,8 +213,11 @@ command, the commit list, its enumeration, and its brief.
 > criterion and naming the code or test that settles it. Then report behaviour
 > in the diff that no criterion asked for (scope creep). Do not re-litigate
 > decisions the plan already settled, and do not report unticked checkboxes as
-> findings — an unchecked box for work the plan defers is not a defect. State
-> how many criteria you checked.
+> findings — an unchecked box for work the plan defers is not a defect. Return
+> met / partial / unmet / not verifiable for every must-prevent, must-recover, and
+> evidence-owed entry. Report accepted-risk bounds only when the implementation
+> contradicts them or added unasked-for machinery to handle them. State how many
+> criteria and risk entries you checked.
 
 ### 5. Aggregate and report
 
@@ -209,6 +231,11 @@ the number that makes a clean round mean something.
 List `unverified` items separately and briefly, if any. They are not findings.
 They are the honest residue, and naming them stops a later round from
 re-deriving the same suspicion as if it were new.
+
+List any `reopen scope` items separately from findings. They return a risk decision to
+the user because new evidence invalidated its premise; they are not instructions to
+harden the implementation. Do not list accepted risks merely to make the report look
+complete.
 
 End with one line: findings per axis, and the worst issue *within each axis*.
 Never pick a single winner across axes.

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -59,10 +59,20 @@ definitions below are the fallback.
    seam before the second caller exists. A plan that never says what the
    interface looks like is itself an objection — that decision made implicitly
    at build time is how shallow modules happen.
-4. **Scope and complexity budget.** Out-of-scope must be explicit. An edge
-   case earns handling only if it is reachable from inputs the acceptance
-   criteria describe — speculative hardening is a defect in a plan, not a
-   virtue. The right change is the smallest one that meets acceptance.
+4. **Scope, risk contract, and complexity budget.** Out-of-scope must be explicit.
+   For bounded work, load the admitted
+   [risk contract](../scope/SKILL.md#risk-contract). Missing risk decisions block
+   countersign only when the build would otherwise have to invent failure handling,
+   recovery, or evidence obligations. An edge case earns handling only if it is
+   reachable from inputs the acceptance criteria describe **and** its contracted
+   outcome requires handling. A scenario covered by `Accepted failure` or
+   `Unsupported` is not an objection unless the plan claims stronger behavior. If
+   evidence changes the assumed likelihood, consequence, or recoverability, object
+   that the risk decision must reopen; do not silently prescribe hardening. Require
+   evidence only for acceptance criteria, must-prevent outcomes, enforced invariants,
+   and observed regressions — never for a target test count or an exhaustive failure
+   matrix. The right change is the smallest one that meets acceptance and the risk
+   contract.
 5. **Cost.** Is the effort implied by the plan sane for the ask? Flag a plan
    whose blast radius (files touched, migrations, new machinery) is out of
    proportion to its outcome.

--- a/skills/scope/SKILL.md
+++ b/skills/scope/SKILL.md
@@ -49,6 +49,40 @@ At the moment routing happens, open a ledger before invoking the specialist:
 - The ledger is the durable session state. A fresh agent resumes by reading it, not by
   re-deriving context from chat history.
 
+## Risk contract
+
+For interview-mode work, and for any other bounded plan being declared ready to
+build, settle a risk contract before admission. A Wayfinder map whose work is not yet
+bounded does not need one.
+
+Keep one `### Risk contract` block under the ledger's `Decisions` section:
+
+- **Must prevent:** harmful outcomes the work may never produce.
+- **Must recover:** concrete failures that require automatic recovery.
+- **Accepted failure:** a concrete failure and the exact consequence the user accepts,
+  such as a clear stop with manual recovery, skipped best-effort work, or degraded
+  non-authoritative output.
+- **Unsupported:** inputs or operating conditions the work does not promise to handle.
+- **Evidence owed:** public-interface behaviors and named invariants that require tests
+  or another explicit check.
+
+Give the block one-line `Why:` and `Disposition:` fields rather than tagging every
+line separately. Default `Must prevent` to secret exposure, irreversible loss of
+authoritative data, and silent incorrect success; changing one of those defaults
+requires an explicit user decision. Default rare, recoverable failures to an
+`Accepted failure` with a clear stop and manual recovery, not automatic recovery.
+
+Price the contract from concrete consequences, exposure, and recoverability. Audience
+size is evidence, not an assurance tier: one person's financial tool can be
+high-stakes, while a public toy can be disposable. Do not use a target test count.
+Evidence is owed only by supported behavior, a must-prevent outcome, an enforced
+invariant, or an observed regression.
+
+At admission, copy the risk contract unchanged into the authoritative issue, plan, or
+brief that the implementation and reviews will use. The ledger remains the session
+record; the admitted artifact becomes the downstream authority. Do not declare bounded
+work ready while the contract is missing or still only in the ledger.
+
 ## Evidence v2
 
 Consult [the shared envelope reference](../../docs/evidence/envelope-v2.md) when a

--- a/skills/scope/references/interview.md
+++ b/skills/scope/references/interview.md
@@ -104,6 +104,19 @@ standards document (a charter, architecture guide, or design doc the repo or
 your global instructions provide), it is part of the frontier, not an
 implementation detail:
 
+- **Set the risk contract once the work is bounded.** Follow
+  [scope's risk-contract schema](../SKILL.md#risk-contract). Ask one concrete
+  behavior question after the audience, consequence, and recoverability are known;
+  reopen it only for a failure with materially different stakes. Never ask an abstract
+  "how robust should this be?" question. For example:
+
+  **Q1. If this one-person tool hits a rare malformed-state case, what must happen?**
+  > A. Fail clearly; I repair it manually
+  > B. Preserve work and recover automatically
+  > C. Support every reachable case without intervention
+  >
+  > ↳ *rec A: the state is rare, recoverable, and has one operator*
+
 - **Interface shape is a decision, not a byproduct.** If the plan adds or
   reshapes a module, put its front door on the frontier explicitly — what the
   caller sees, judged by the deep-module test (an interface far simpler than
@@ -112,10 +125,11 @@ implementation detail:
   shallow modules happen. `design-it-twice` (`skills/codebase-design/`) may be
   offered right there as a grounding step for this frontier question, the same
   way `ground it` grounds any other one.
-- **Edge cases are priced, not assumed.** An edge case earns handling only if
-  it is reachable from real inputs (`ground it` measures this). Default the
-  answer to "don't handle it"; make me overrule the default rather than making
-  me strip speculative hardening out later.
+- **Edge cases are priced against the risk contract, not assumed.** An edge case
+  earns handling only if it is reachable from real inputs (`ground it` measures
+  this). Reachability does not automatically earn recovery: default a rare,
+  recoverable case to visible failure and manual recovery. Make me overrule that
+  default rather than making me strip speculative hardening out later.
 
 ## Docs as you go
 
@@ -133,4 +147,6 @@ The session is done when the frontier is empty: every branch has been visited an
 nothing remains silently assumed. End with a compact summary of every decision made
 (the shared understanding), flag anything deferred or defaulted, and confirm every
 ledger disposition — `→ ADR`, `→ issue` — has been discharged per scope's exit
-protocol. Do not enact the plan until I confirm we have reached a shared understanding.
+protocol. For bounded work, confirm the risk contract has been copied into the
+admitted issue, plan, or brief. Do not enact the plan until I confirm we have reached
+a shared understanding.


### PR DESCRIPTION
## What changed

Bounded scoping now produces a risk contract that distinguishes outcomes the work must prevent, failures it must recover from, failures the user explicitly accepts, unsupported operating conditions, and the evidence the change owes.

Interview mode settles that contract with concrete behavior questions and promotes it into the issue or plan admitted for implementation. Plan review and code review then treat the contract as authority: accepted failures do not become fix requests, test counts do not create obligations, and evidence that invalidates an assumption reopens scope instead of silently expanding the build.

## Why

The existing workflow could reject unreachable edge cases, but it had no durable way to record that a reachable failure was consciously acceptable for a small or recoverable piece of work. Later review phases could therefore keep inventing hardening and tests after scope was already settled.

## Impact

Small and internal work can choose clear failure with manual recovery, best-effort degradation, or an unsupported path without lowering the non-negotiable defaults around secrets, authoritative data, and truthful success reporting. Review remains strict about the promises the work actually makes.

## Validation

- `python3 scripts/validate.py` (23 skills and 218 tracked files)
- `git diff --check`
- Push hook: `DCO_OK commits=1`