### PR TITLE
orchestrate: skip the headroom probe when the codex cli is absent

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -17,6 +17,12 @@ operator says otherwise. Detect the parent before dispatching:
 
 Before any routing, check whether the Codex side has budget left:
 
+0. **Claude parent, presence check first:** run `command -v codex` before
+   spending anything on a probe. If the Codex CLI is absent from PATH, skip
+   step 1 entirely and go straight to the same **Claude-only** branch as
+   headroom ≤ 5% / unknown below; tell the operator once. A Codex UI parent
+   cannot land on this branch — the CLI exists there by construction — so the
+   check only applies to a Claude parent.
 1. Probe fresh with a trivial one-word worker run (cheapest available Codex
    model, `read-only`). The Codex adapter binds headroom to that worker's
    captured session ID: it finds the rollout whose `session_meta.payload.session_id`


### PR DESCRIPTION
Skips the Codex headroom probe when the Codex CLI is not installed. A machine without the CLI currently needs a hand-maintained Claude-only fork of the orchestrate skill just to avoid a probe that can only fail.

* On a Claude parent, a presence check runs before the probe. When the CLI is absent from PATH the session goes straight to Claude-only routing, with one operator notice.
* When the CLI is present, the probe and its unknown-headroom semantics are unchanged.
* A Codex UI parent never reaches the new branch. The CLI exists there by construction.

This PR was written in part with the assistance of generative AI.
