### PR TITLE
pr-body: adopt the agent-attribution blockquote as the disclosure line

### DIFF
--- a/skills/pr-body/SKILL.md
+++ b/skills/pr-body/SKILL.md
@@ -19,7 +19,7 @@ running near capacity.
 
 EBS expands online. The filesystem grows on the next boot.
 
-This PR was written in part with the assistance of generative AI.
+> Written by an AI agent operating for <operator>. Verify before relying on it.
 ```
 
 No headings. No reason the author does not actually know. No advice for the
@@ -214,7 +214,8 @@ there is decorative. Grounds and fix text for each:
 
 Two behaviors of the scorer are worth knowing before arguing with a finding.
 Lines matching the repo's `.github/pull_request_template.md`, and the AI
-disclosure line, are treated as scaffolding and exempt from the prose rules.
+disclosure blockquote, are treated as scaffolding and exempt from the prose
+rules.
 Below 40 characters of prose the density rules (em dash, emoji, paths,
 narration, verdicts, reviewer asks, bullet-per-file, symbols) do not run at all;
 the structural rules run at every length.

--- a/skills/pr-body/references/rubric.md
+++ b/skills/pr-body/references/rubric.md
@@ -29,17 +29,22 @@ description as grounds to send the PR back before judging the code at all
 assistance verb. The match is deliberately loose so any phrasing of the
 disclosure counts, not one fixed sentence.
 
-**Fix** Add a disclosure line: 'This PR was written in part with the assistance
-of generative AI.'
+**Fix** Add a disclosure line: '> Written by an AI agent operating for
+<operator>. Verify before relying on it.'
 
 **Grounds** The Kubernetes contributor guide is the only verified institutional
-policy requiring disclosure in the description, and supplies that exact sentence
-(https://www.kubernetes.dev/docs/guide/pull-requests/). Scoping is free here:
-the hook fires on an agent's Bash tool, so every body it scores is
-agent-mediated by construction. The rule needs no heuristic for whether a body
-was AI-written, because the trigger already answers that. Kubernetes' companion
-ban on AI co-author commit trailers is left alone; this pack's commit convention
-already keeps attribution out of trailers.
+policy requiring disclosure in the description
+(https://www.kubernetes.dev/docs/guide/pull-requests/). This pack's canonical
+wording is the blockquote form already used elsewhere for agent-authored
+content, so the disclosure reads the same way across surfaces. The older plain
+sentence still satisfies the check: it matches the same loose pattern, and
+retro-failing bodies written before this change would be pure audit noise with
+no behavior fixed. Scoping is free here: the hook fires on an agent's Bash
+tool, so every body it scores is agent-mediated by construction. The rule
+needs no heuristic for whether a body was AI-written, because the trigger
+already answers that. Kubernetes' companion ban on AI co-author commit
+trailers is left alone; this pack's commit convention already keeps
+attribution out of trailers.
 
 ### `empty-template-section` (block)
 

--- a/skills/pr-body/scripts/pr_body_lint.py
+++ b/skills/pr-body/scripts/pr_body_lint.py
@@ -113,8 +113,8 @@ ASSIST_VERB_RE = re.compile(
 FIXES = {
     "empty-body": "State what changed and why; an empty body tells the reviewer nothing.",
     "ai-disclosure-missing": (
-        "Add a disclosure line: 'This PR was written in part with the "
-        "assistance of generative AI.'"
+        "Add a disclosure line: '> Written by an AI agent operating for "
+        "<operator>. Verify before relying on it.'"
     ),
     "empty-template-section": "Fill in the {heading!r} section, or delete it if it does not apply.",
     "vacuous-opener": "Open with the behavior that changed, not a generic label like this line.",

--- a/tests/test_pr_body.py
+++ b/tests/test_pr_body.py
@@ -17,7 +17,8 @@ SCRIPT = ROOT / "skills" / "pr-body" / "scripts" / "pr_body_lint.py"
 SKILL_MD = ROOT / "skills" / "pr-body" / "SKILL.md"
 RUBRIC_MD = ROOT / "skills" / "pr-body" / "references" / "rubric.md"
 
-DISCLOSURE = "This PR was written in part with the assistance of generative AI."
+DISCLOSURE = "> Written by an AI agent operating for <operator>. Verify before relying on it."
+LEGACY_DISCLOSURE = "This PR was written in part with the assistance of generative AI."
 
 
 def lint(body: str, *, repo: Optional[Path] = None) -> dict:
@@ -84,6 +85,14 @@ class AiDisclosureMissingTests(unittest.TestCase):
         result = lint(body)
         self.assertNotIn("ai-disclosure-missing", rules_fired(result))
 
+    def test_does_not_trip_on_the_legacy_sentence_form(self):
+        # The old plain-sentence disclosure still satisfies the rule: it
+        # matches the same loose pattern, and retro-failing bodies written
+        # before the blockquote convention would be pure audit noise.
+        body = f"Grows the appliance data volume from 2TB to 4TB.\n\n{LEGACY_DISCLOSURE}\n"
+        result = lint(body)
+        self.assertNotIn("ai-disclosure-missing", rules_fired(result))
+
     def test_does_not_trip_on_a_differently_worded_disclosure(self):
         body = (
             "Grows the appliance data volume from 2TB to 4TB.\n\n"
@@ -92,10 +101,25 @@ class AiDisclosureMissingTests(unittest.TestCase):
         result = lint(body)
         self.assertNotIn("ai-disclosure-missing", rules_fired(result))
 
-    def test_fix_text_supplies_a_usable_sentence(self):
+    def test_fix_text_supplies_the_blockquote_form(self):
         result = lint("Grows the appliance data volume from 2TB to 4TB.\n")
         finding = finding_for(result, "ai-disclosure-missing")
-        self.assertIn("generative ai", finding["fix"].lower())
+        self.assertIn("written by an ai agent operating for", finding["fix"].lower())
+
+    def test_disclosure_blockquote_is_exempt_from_prose_density_rules(self):
+        # The scaffolding mask keys on an AI term plus an assist verb
+        # anywhere in the line, not on the leading "> ", so a blockquote
+        # disclosure carrying density-rule bait (an em dash, a rated
+        # verdict) must still be masked out rather than flagged.
+        body = (
+            "Grows the appliance data volume from 2TB to 4TB.\n\n"
+            "> Written by an AI agent operating for <operator> — this is a "
+            "low-risk change. Verify before relying on it.\n"
+        )
+        result = lint(body)
+        self.assertNotIn("em-dash", rules_fired(result))
+        self.assertNotIn("verdict-clause", rules_fired(result))
+        self.assertNotIn("ai-disclosure-missing", rules_fired(result))
 
 
 class EmptyTemplateSectionTests(unittest.TestCase):

--- a/tests/test_pr_body_bench.py
+++ b/tests/test_pr_body_bench.py
@@ -23,7 +23,7 @@ def _load_bench():
 
 BENCH = _load_bench()
 
-DISCLOSURE = "This PR was written in part with the assistance of generative AI."
+DISCLOSURE = "> Written by an AI agent operating for <operator>. Verify before relying on it."
 BODY_PASS = f"Grows the appliance data volume from 2TB to 4TB.\n\n{DISCLOSURE}\n"
 BODY_FAIL_VACUOUS = "Fix bug.\n"
 


### PR DESCRIPTION
Changes the recommended AI-disclosure line from a plain sentence to the blockquote form other agent-authored postings already use, naming the operator the agent acts for.

* The worked example, rubric, and fix text now recommend a quote line: Written by an AI agent operating for the named operator, verify before relying on it.
* The legacy sentence form still passes the linter, so already-merged bodies do not retro-fail audits.
* The disclosure line stays exempt from the prose density rules in either form, with a test pinning that.

> Written by an AI agent operating for connor.griffin. Verify before relying on it.
