### PR TITLE
Enroll the pack into the agentflow fleet

### DIFF
--- a/.cbmignore
+++ b/.cbmignore
@@ -1,0 +1,29 @@
+# >>> cbm-onboard managed baseline — do not edit inside this block >>>
+# codebase-memory-mcp ignore (gitignore syntax).
+# Keeps non-source noise out of the knowledge graph and query results.
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+node_modules/
+dist/
+build/
+*.egg-info/
+# generated agent workspaces
+.agentflow/
+.claude/worktrees/
+.impeccable/
+# data & secrets
+*.db
+*.sqlite
+*.sqlite3
+*.csv
+*.parquet
+.env
+*.log
+# <<< cbm-onboard managed baseline <<<

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,12 @@ jobs:
       - name: Validate skill pack and reachable history
         run: python3 scripts/validate.py
       - name: Run public-interface behavior tests
-        run: python3 -m unittest -v tests.test_behavior
+        run: >-
+          python3 -m unittest -v
+          tests.test_behavior
+          tests.test_pr_body
+          tests.test_pr_body_gate
+          tests.test_pr_body_bench
       - name: Check DCO
         if: github.event_name == 'pull_request'
         run: >-

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules/
 __pycache__/
 bench/fixtures/pr-body/
 bench/results/pr-body/
+.agentflow/
+.agents/
+.claude/
+skills-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# skills
+
+Connor Griffin's public, portable skill pack for coding agents. Skills live under
+`skills/`, one directory each, and are consumed by the standard `skills` CLI and
+pinned by content hash into agentflow's runtime.
+
+profile: reviewed
+ui-surfaces: none
+
+## Repo facts
+
+- Install: none for the pack itself; Python 3 standard library only. The browser
+  driver installs its own deps under `skills/drive-local-webapp` (`npm ci` plus
+  `npx playwright install chromium`).
+- Test: `python3 scripts/validate.py && python3 -m unittest tests.test_behavior
+  tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench`
+- Dev: no app to run. To exercise a skill, install the pack into a scratch
+  directory with `npx skills add . --skill '<name>' --copy --yes`.
+- Source: `skills/<name>/` (SKILL.md plus its own `references/`, `reference/`, and
+  `scripts/`), with `profile/`, `output-styles/`, `hooks/`, and `docs/` alongside.
+- Tests: `tests/`. `scripts/validate.py` is the structural validator and is part
+  of the gate, not a lint.
+
+## Hazards
+
+- Never commit without `Signed-off-by:` — `scripts/check_dco.py` runs on every
+  pull request and a missing trailer fails CI, so the commit cannot be fixed
+  after the fact without a rewrite.
+- Never move, retag, or delete a release tag. agentflow pins this repo by tag,
+  commit, and per-file SHA-256 (`agentflow/capabilities.toml`, `skills-lock.json`);
+  a moved tag silently changes what the fleet executes.
+- Never edit `.agents/skills/` or `.claude/skills/` — those are vendored, pinned
+  copies of skills this repo itself authors under `skills/`. Edit the source and
+  let the pin be bumped deliberately; editing the copy forks the pack against
+  itself.
+- Never publish real colleague identities. `persona-review` mines real people's
+  GitHub activity into persona profiles; the profiles belong in a private data
+  repo, and nothing identifying a real colleague may land in this public repo.
+- Never add a third-party dependency to the pack. The pack must install and run
+  from a stock Python 3 and Node 20 with no package manager step, which is what
+  makes it portable across agents.
+- Never run the pack's own scripts against a real project checkout while testing
+  them. `skills/cbm-onboard/scripts/cbm-onboard.sh` writes `.cbmignore` and
+  installs git hooks, and `skills/spin-worktree/scripts/spin-worktree.py` creates
+  worktrees and branches; both mutate whatever repo they are aimed at.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Lets the autonomous fleet pick up issues in this repo. Nothing about how the skills themselves behave changes.

## What this adds

**Repository instructions.** `AGENTS.md` (with `CLAUDE.md` symlinked to it, so both tools read the same bytes) tells a session what it needs to work here safely: the autonomy profile, how to install and test, where the source lives, and the hazards. The hazards are the part worth reading. A missing sign-off trailer fails the build irrecoverably, and moving a release tag silently changes what the fleet executes, because the fleet pins this pack by tag, commit, and per-file hash.

**Profile: `reviewed`.** A person clicks merge. This pack is public and its contents are pinned into the fleet's own runtime, so a wrong merge here propagates outward. The conservative setting is the right starting point, and it can be loosened later.

## Two things the enrollment surfaced

**The pack authors the skills the fleet pins into it.** Enrolling drops frozen copies of `tdd`, `codebase-design`, and `domain-modeling` into `.agents/skills` and `.claude/skills`, copies of skills this repo is the source of. They are byte-identical to the originals today, and they are generated (the build already writes `.agents/skills` itself during the fresh-install check), so they are ignored rather than committed. Two tracked copies of the same skill would eventually disagree, and consumers would have no way to tell which one is real. `AGENTS.md` names editing a vendored copy as a hazard for the same reason.

**The build was only running a quarter of the tests.** It ran one test module and skipped the rest, so the 111 pr-body tests gated nothing. That was survivable when a person read every diff. It is not, now that a green build is what the fleet merges on. The step now runs the whole test package, 176 tests, all passing.

## What to check

- The hazard list in `AGENTS.md` matches how you actually want agents to treat this repo, especially the rule against publishing real colleague identities from persona mining.
- `reviewed` is the profile you want, rather than `guarded`.

Enrollment also touched things outside this PR: the repo was added to the fleet list in your private dotfiles, the queue labels were created, and provider discovery receipts were recorded. `agentflow doctor` reports ready.

> Written by an AI agent operating for Connor Griffin.
