### PR TITLE
ui-craft: retire a surface's mock CI leg atomically with its port

### DIFF
--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -142,6 +142,19 @@ Spec:
 - Wire the script into CI **explicitly**. Test globs discover `*.test.js`, not a
   `.replay.mjs`; a browser job that hand-lists its files gets a hand-added step in
   the same change.
+- **The mock's CI leg is temporary: it runs from lock until the surface ships, and
+  then it is deleted.** While the port is being built the mock is the contract
+  artifact and the `TARGET=mock` leg is what guards it; once the app-opener leg is
+  green the app is the contract artifact and the mock leg guards nothing the app
+  leg does not. **Retirement is atomic with the port**: the same PR that turns the
+  app leg green deletes that surface's mock leg, flips its row in `mockups/INDEX.md`
+  to `shipped`, and archives the mockup (`lock.md`'s archive-after-ship rule). A
+  follow-up issue for any of the three is forbidden — that is exactly how surfaces
+  end up merged-but-still-`locked`. The anti-drift guarantee is not lost with the
+  leg, because it never lived there: it lives in the ledger's stories replayed
+  against the built app, which run forever. A permanent mock leg instead means the
+  surface's logic exists twice and is hand-synced, and that drifts — one port branch
+  carried three divergent wordings of a single copy-pasted note builder.
 
 ## 4. The behavior ledger
 

--- a/skills/ui-craft/reference/lock.md
+++ b/skills/ui-craft/reference/lock.md
@@ -144,8 +144,15 @@ Locking is complete only when ALL of these exist:
    links and other surfaces share; `mockups/INDEX.md` set to `locked`,
    pointing at mock + manifest; the implementation issue references both.
 
-After implementation ships, set the ledger row to `shipped` and archive the
-mockup; the app becomes the source of truth.
+After implementation ships, set the surface-ledger row to `shipped`, archive the
+mockup, and delete that surface's `TARGET=mock` CI leg; the app becomes the
+source of truth. **All three land in the port PR itself** — the PR that turns the
+app-opener replay leg green — never in a follow-up issue, which is how a surface
+stays `locked` long after it merged. The mock, its screenshots, the manifest and
+the behavior ledger stay as the design record, and the ledger's stories keep
+running against the built app forever; post-ship hotfixes owe no mock pass and no
+mock sync, and a later `resettle` starts from the shipping app rather than a
+runnable mock.
 
 ## Lock manifest format
 


### PR DESCRIPTION
A locked mockup's behavior-ledger replay now has a stated lifetime in CI: the TARGET=mock leg runs from lock until the surface ships, then it is deleted — in the same PR that turns the app-opener leg green, together with flipping the surface-ledger row to shipped and archiving the mockup. After ship only the app leg runs, forever; hotfixes owe no mock pass, and a later resettle starts from the shipping app.

Why: behavior-sweep made mocks runnable in CI but no rule ever retired the run, so every swept surface kept two hand-synced implementations. The anti-drift guarantee lives in the ledger's stories replayed against the built app, not in the mock leg; the permanent mock leg only produced churn (real drift observed: one port branch carried three divergent wordings of one copy-pasted note builder — ciq-autotune #719 fell out of it).

What to check: reference/behavior-sweep.md (CI-wiring bullet gains the retirement rule) and reference/lock.md (archive-after-ship extended to include the leg deletion and the all-three-in-the-port-PR obligation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
