### PR TITLE
docs: record the decision to stop mocking shipped surfaces

### DIFF
--- a/docs/adr/adr-48-never-mock-a-shipped-surface.md
+++ b/docs/adr/adr-48-never-mock-a-shipped-surface.md
@@ -1,0 +1,75 @@
+# ADR 48 — Never mock a surface that already exists
+
+Date: 2026-08-19
+Status: accepted
+Issue: https://github.com/ConnorGriffin/skills/issues/48
+Ledger: `docs/scope/ui-craft-shipped-surface-iteration.md`
+
+## Context
+
+`ui-craft`'s `lock` mode treats a mockup tournament as the default entry point
+for every surface, shipped or not. A surface that already exists therefore gets
+rebuilt from scratch as HTML, reviewed, locked, and only then ported back into
+the app.
+
+That inverts the default that makes review work. In the shipped app a behavior
+survives unless someone deletes it, and the deletion is a diff line with an
+author. In a from-scratch mock a behavior exists only if someone rebuilds it,
+and **absence has no representation**: nothing is emitted, nothing is diffed,
+nothing is reviewed. Every checker in the lifecycle compares things that are
+present, so all of them are blind in the same direction.
+
+The failure is measured, not hypothetical. harmonic's
+`mockups/finding-evidence-routing.behavior.md` records 55 behaviors of a shipped
+Diagnose surface driven against a real browser engine: 12 kept, **43 missed**,
+0 sanctioned. Ten exploration rounds, a persona panel and a 52-run technical
+audit all passed, and a 60-term lock froze those 43 retirements as contract
+(harmonichq/harmonic#40, retracted by #44). A human caught it by looking at a
+screenshot. Seventeen of the misses were one drag-to-draw selection window.
+
+`ui-craft`'s predecessor inventory (branch `ui-craft/predecessor-inventory`)
+makes a mock survivable by running one pass that reads the other artifact. It
+patches the inversion; it does not remove it.
+
+## Decision
+
+A surface the app already ships is revised by **iterating the running app on a
+branch**. Building a from-scratch mock of a shipped surface is banned.
+
+- The work lands as a new `ui-craft` mode, **`revise`**, beside `lock`. `lock`
+  refuses on a surface with a shipped embodiment and names `revise`.
+- The frozen contract is the **behavior ledger plus its replay script, run
+  against the built app**. No lock manifest is pinned to an app template.
+- The shipped surface gets **one full behavior inventory, frozen**, on its first
+  revision; later changes diff against it. It runs **before** the design
+  conversation, so the design is drawn against what exists.
+- Throwaway wireframes stay legitimate for **divergent** exploration, including a
+  new view inside a shipping shell. They live in the change's own decision record
+  (an OpenSpec change folder where the repo uses one, otherwise
+  `docs/scope/<slug>/`), carry no fidelity claim, are never lockable, and are
+  deleted when the change lands. Only screenshots survive.
+- The wireframe phase is **interactive**: the human and the agent work it
+  together in the code. An unattended fleet run never takes it on a surface whose
+  shell already ships. When the decisions settle, an agent lifts the wireframe
+  into a branch or worktree of the app and iteration continues there under a
+  fresh behavior sweep.
+- App-branch iteration requires the repo to **declare a safe dev-server
+  entrypoint** in its `CLAUDE.md`/`AGENTS.md` that names its data source. An
+  agent refuses to start the app on any ambiguity. Absent that declaration, the
+  round falls back to mockup plus the predecessor sweep, which is retained for
+  exactly this case.
+
+## Consequences
+
+- A dropped behavior becomes a diff line with an author again, which is the
+  property the mock path cannot provide at any review depth.
+- Repos that cannot run their own app safely keep the weaker path, and the cost
+  of that is now visible rather than implicit.
+- The predecessor inventory stops being load-bearing wherever `revise` applies,
+  and stays load-bearing everywhere else.
+- harmonic cannot use `revise` until its own prohibition on starting the app is
+  narrowed to the synthetic path and a provenance-stamped synthetic database
+  exists. Both are harmonic-side and operator-owned.
+- The mode owes one real end-to-end run on a shipped surface before it ships;
+  prose that has never been executed is a plan, and the last contract this pack
+  wrote passed every gate while being wrong.

--- a/docs/scope/ui-craft-shipped-surface-iteration.md
+++ b/docs/scope/ui-craft-shipped-surface-iteration.md
@@ -1,0 +1,149 @@
+# Scope ledger — ui-craft: never mock a surface that already exists
+
+Routed: scope → interview mode (2026-08-19). Proposal, accepted in conversation
+and not yet recorded anywhere: a surface that has already shipped is changed by
+iterating the running app on a branch, not by rebuilding it as a from-scratch
+mockup. Mockups survive only for divergent throwaway exploration, carry no
+fidelity claims, and are never lockable.
+
+Tracking issue: https://github.com/ConnorGriffin/skills/issues/48
+
+Origin: handoff from the harmonic session that produced
+`mockups/finding-evidence-routing.behavior.md` (55 rows: 12 kept, 43 missed) and
+PR harmonichq/harmonic#44, which retracted a 60-term lock that had frozen those
+43 retirements as contract.
+
+## The reasoning that must survive
+
+A from-scratch mock inverts the default. In the shipped app a behavior survives
+unless someone deletes it, and the deletion is a diff line with an author. In a
+mock a behavior exists only if someone rebuilds it, and **absence has no
+representation**. Every checker in the lifecycle compares things that are
+present, so none of them could see 43 behaviors that were never built.
+
+## Grounding facts (verified this session)
+
+- `harmonic serve --no-fetch --db <path>` exists and does what the handoff
+  claims: `ciq_autotune/cli.py:119` defines the flag ("skip the startup
+  live-fetch (safe for scratch/synthetic DBs)"), `ciq_autotune/api.py:94-95`
+  gates the hourly fetch loop on it. Not run end to end — verified by reading.
+- harmonic `CLAUDE.md` forbids `harmonic serve` / `harmonic fetch` in automated
+  work with no carve-out for a synthetic DB. Operator-owned to amend; not
+  amended, and `serve` not run.
+- No synthetic `.db` exists in the harmonic tree. `mockups/*.synthetic/` holds
+  captures and JSON payloads only.
+- **Handoff claim refuted:** ui-craft's `lock` reference does not distinguish
+  `local` from `surface` scope. The only "scope" in the pack is CSS scoping
+  (`skills/ui-craft/reference/build.md:24-27`). That candidate for the
+  divergent/convergent boundary does not exist and cannot be reused.
+- Branch `ui-craft/predecessor-inventory` (`f68c8d4`, `2e6fb4b`) is local and
+  unpushed. It adds the predecessor inventory to `behavior-sweep` §2, gates the
+  lock on it (`lock.md` §9.3), makes RETIRED entries replay in `build`, and
+  routes a post-lock `missed` verdict to `resettle`. It patches the inversion;
+  it does not remove it.
+
+## Decisions
+
+- Route to interview mode: the proposal is concrete, accepted, and untested;
+  its shape (mode vs. lock branch, contract artifact, preconditions) is not
+  designed. `inline`
+- **The core rule.** A surface the app already ships is revised by iterating the
+  running app on a branch. A from-scratch mock of a shipped surface is banned,
+  because absence has no representation in a mock and every checker in the
+  lifecycle reads only what is present. (why: 43 unruled retirements survived
+  ten rounds, a persona panel and a 52-run audit) `→ ADR`
+- **Q1 = A.** The rule lands as a **new mode beside `lock`**, with its own flow
+  against an app branch. `lock`'s scaffold, variant fan-out and delete-losers
+  steps have no counterpart there. Working name: `revise` (operator may
+  overrule). `→ issue #48`
+- **Q2 = B.** With no mock, the frozen contract is the **behavior ledger plus
+  its replay script, run against the built app**. No lock manifest is pinned to
+  an app template. (why: the only artifact with a working precedent, harmonic's
+  28 stories under `TARGET=app`) `→ issue #48`
+- **Q3 = A.** Merge `ui-craft/predecessor-inventory` as is. It becomes the
+  **fallback path** for repos that cannot run their own app safely, not dead
+  weight. (why: narrowing it later is cheaper than un-dropping it) `→ issue #48`
+- **Q4, partial.** A partly-new surface (new view inside a shipping shell)
+  **starts divergent and ends convergent**: throwaway wireframes are legitimate
+  for exploring the new view, and porting the winner into the shipping shell is
+  **interactive work with a human in the session, not AFK**. Transition point and
+  headless availability still open (Q6, Q7). `→ issue #48`
+- **Q5 = A.** App-branch iteration requires the repo to **declare a safe
+  dev-server entrypoint** in its `CLAUDE.md`/`AGENTS.md`. Absent that
+  declaration, the round falls back to mockup plus predecessor sweep. (why:
+  harmonic has the capability and a blanket prohibition against using it, so an
+  agent reading the repo today would get it wrong) `→ issue #48`
+- **Q6.** The wireframe is **scratch inside the change's own decision record**,
+  not a deliverable. Sanctioned path: open a change (OpenSpec change folder where
+  the repo uses one, as harmonic does), keep a decision ledger in it, build the
+  wireframe there, and work it interactively with the agent. When the decisions
+  settle the change becomes a plan, an agent **lifts the wireframe into a clone of
+  the app**, and iteration continues there under a fresh behavior sweep. Human and
+  agent are in the code together throughout. `→ issue #48`
+- **Q7 = A.** Unattended fleet runs never take the wireframe route on a surface
+  whose shell already ships; they go straight to the app branch. Greenfield
+  surfaces are untouched by this. `→ issue #48`
+- **Q8 = A.** The shipped surface gets **one full behavior inventory, frozen**, on
+  its first revision; later changes diff against it. `→ issue #48`
+- **Q9 = A.** An agent refuses to start the app unless the repo's declared
+  entrypoint names its data source, and stops on any ambiguity. This is the
+  must-prevent: no run that might be reading real or authoritative data.
+  `→ issue #48`
+- **Q10 = A.** harmonic narrows its prohibition to permit the synthetic path
+  explicitly, naming the flag and the database, gated on one supervised run
+  proving no vendor contact. `→ issue` (harmonic)
+- **Q11 = A.** In a repo with no change folder, the wireframe lives beside the
+  scope ledger in `docs/scope/<slug>/`, never in `mockups/`. `→ issue #48`
+- **Q12 = A.** The wireframe is deleted when the change lands; only screenshots
+  survive in the record. (why: a runnable artifact that outlives the change is a
+  second source of truth) `→ issue #48`
+- **Q13 = A.** The lift target is a branch or worktree of the app, changed in
+  place. Live comparison comes from serving the base branch in a second worktree
+  (`spin-worktree`), not from a duplicated route inside the app. `→ issue #48`
+- **Q14 = A.** The frozen inventory runs **before** the design conversation, so
+  the wireframe is drawn against what already exists. `→ issue #48`
+- **Q15 = A.** `lock` refuses on a surface with a shipped embodiment and names
+  `revise`. Same class of error as a `missed` verdict. (why: `lock` step 0
+  already detects a shipped predecessor for chrome ground truth) `→ issue #48`
+- **Q16 = A.** The mode is called **`revise`**. `→ issue #48`
+- **Q17 = B.** The change ships gated on one real end-to-end run of `revise` on a
+  shipped surface, with that run's behavior ledger attached. `→ issue #48`
+
+### Risk contract
+
+- **Must prevent:** an agent starting a repo's app against real, authoritative or
+  vendor-connected data; a wireframe treated as a fidelity artifact or a lock
+  target; a shipped behavior dropped without a dated sanction naming a person and
+  quoting their reason.
+- **Must recover:** nothing automatically.
+- **Accepted failure:** a repo with no declared entrypoint falls back to mockup
+  plus predecessor sweep, which is slower and weaker, and that cost is visible
+  rather than silent. A frozen inventory that goes stale because the surface
+  changed outside `revise` is caught by the next revision's diff, not
+  automatically.
+- **Unsupported:** surfaces whose app cannot be run locally at all; any repo whose
+  declared entrypoint does not name its data source.
+- **Evidence owed:** the structural validator, plus one real end-to-end `revise`
+  run on a shipped surface with its behavior ledger and replay output attached to
+  the PR.
+- **Why:** the mode instructs agents to start real applications, and this pack's
+  rules ship into a repo producing advisory insulin-dosing guidance.
+- **Disposition:** copied verbatim into issue #48 at admission.
+
+- ADR home: this repo has no `docs/adr/` and no OpenSpec, so the charter default
+  applies: `docs/adr/adr-48-never-mock-a-shipped-surface.md`. `inline`
+
+## Open questions
+
+- None. Frontier empty as of 2026-08-19.
+
+## Spawned tasks
+
+- harmonic: narrow the `serve`/`fetch` prohibition per Q10, gated on a supervised
+  no-vendor-contact run. Not yet filed.
+- harmonic: committed generator + provenance-stamped synthetic `.db`. Gates any
+  harmonic use of this rule. Not yet filed.
+- Issue #48 is the durable home; frozen brief and risk contract copied into it.
+- ADR written: `docs/adr/adr-48-never-mock-a-shipped-surface.md`.
+- Push and open a PR for `ui-craft/predecessor-inventory` (Q3 = A). Operator's
+  call to publish; not pushed.


### PR DESCRIPTION
Records the rule that a surface the app already ships is revised by iterating
the running app, never rebuilt as a from-scratch mockup. The rule was accepted
in conversation on 2026-08-19 and lived nowhere.

* ADR 48 carries the rule, the `revise` mode it lands as, and what a repo owes
  before app-branch iteration is available to it.
* The scope ledger carries the seventeen decisions behind it, the facts checked
  against harmonic, and the risk contract.
* `docs/adr/` is new here. The repo had no decision-record home, so this follows
  the charter default rather than starting an OpenSpec tree.

Nothing in `skills/` changes yet. The build is issue #48, and it ships gated on
one real end-to-end run of the new mode.

Refs #48.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
