### PR TITLE
ui-craft: sweep the predecessor's behavior, not only the mock's

### DIFF
--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -67,7 +67,7 @@ acting — it defines the flow.
 | Mode | Job | Reference |
 | --- | --- | --- |
 | `lock [surface]` | Explore grounded variants, converge, lock spec + manifest | [reference/lock.md](reference/lock.md) |
-| `behavior-sweep [surface]` | Sweep a locked mock's interactive behavior into a frozen behavior ledger + replay script (after `lock`, before `build`) | [reference/behavior-sweep.md](reference/behavior-sweep.md) |
+| `behavior-sweep [surface]` | Sweep the mock's interactive behavior **and the shipped predecessor's** into a frozen behavior ledger + replay script; an unsanctioned drop fails. Predecessor pass runs **before** `lock`; the rest after `lock`, before `build` | [reference/behavior-sweep.md](reference/behavior-sweep.md) |
 | `build [surface]` | Implement a locked spec; ship the fidelity ledger | [reference/build.md](reference/build.md) |
 | `critique [target]` | Heuristic scoring, slop verdict, persona walkthroughs | [reference/critique.md](reference/critique.md) |
 | `audit [target]` | Technical checks (a11y, contrast, responsive, detector) + lock-fidelity audit when a manifest exists | [reference/audit.md](reference/audit.md) |
@@ -77,15 +77,18 @@ acting — it defines the flow.
 | `init` / `document` | Project context setup / generate DESIGN.md | [reference/init.md](reference/init.md), [reference/document.md](reference/document.md) |
 
 No argument: recommend the 1–3 most useful modes from context (unlocked
-mockups → `lock`; frozen manifest for a surface with interactive behavior and no
+mockups → `lock`; an unlocked mockup for a surface with a `shipped` predecessor
+and no predecessor verdicts → `behavior-sweep`'s predecessor pass **before**
+`lock`; frozen manifest for a surface with interactive behavior and no
 behavior ledger → `behavior-sweep` **before** `build`; open manifest without a
 fidelity ledger → `build`; never critiqued → `critique`), then list the table.
 Never auto-run a mode.
 
 Three artifacts carry the word *ledger*; always qualify it. The **fidelity
 ledger** is one row per manifest term (`build`). The **behavior ledger** is
-`mockups/<surface>.behavior.md`, one entry per story (`behavior-sweep`). The
-**surface ledger** is `mockups/INDEX.md`, one row per surface.
+`mockups/<surface>.behavior.md`, one entry per story plus one permanent entry
+per sanctioned retirement (`behavior-sweep`). The **surface ledger** is
+`mockups/INDEX.md`, one row per surface.
 
 General design invocations with no mode match (e.g. "make this less bland",
 "fix the spacing") run under `critique`-then-fix using
@@ -115,8 +118,8 @@ archetypes.
 **"The repo's sweep protocol" is not `behavior-sweep`.** That phrase means the
 repo's persona-driven QA pass — exploratory, judgment-led, run against a live
 app to find bugs. `behavior-sweep` is a mode of this skill: mechanical, run
-against a **locked mock** before any build, and its output is a contract. Neither
-substitutes for the other.
+against a **locked mock** — and against the surface's shipped predecessor — before
+any build, and its output is a contract. Neither substitutes for the other.
 
 ## Grounding rules (inherited from ui-mockups, apply everywhere)
 
@@ -150,5 +153,6 @@ substitutes for the other.
   are banned because they shift extracted chrome off its shipped pixels.
 - Keep `mockups/INDEX.md` as the surface ledger (one row per surface:
   Surface / Concept / Status / Issue / File). `locked` rows are binding
-  precedent; `shipped` rows defer to the app itself. Every mode that touches
+  precedent; `shipped` rows defer to the app itself, and are also how the next
+  lock finds its predecessor (`behavior-sweep` §2). Every mode that touches
   a lock updates the ledger in the same change — a stale ledger is a defect.

--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -56,6 +56,17 @@ Excluded from the inventory is **not** excluded from the page: the harness and
 every imported module are still **served**, because an unserved import throws
 before any listener registers.
 
+**The exclusion is by purpose, not by position.** Chrome that exists to serve
+the mockup is out; chrome that ships to the reader is in, however the mock came
+by it. A mock that lifts the app's real topbar and footer — and a lock that pins
+them in a term — has put them on the surface, so their behavior is inventoried
+here and diffed in §2 like anything else. Read the exclusion positionally
+instead and that chrome is owned by nobody: the mock sweep waves it through as
+chrome, the predecessor sweep waves it through as not-this-surface, and a lifted
+navigation that quietly lost its behavior passes both. Where another surface's
+frozen ledger already covers the same chrome, cite its stories rather than
+re-ruling them.
+
 **Handlers are not the only source of stories.** The inventory finds everything
 the surface *does*; it cannot find what the surface must *keep true* while doing
 it. Those invariants own no handler, so a handler-complete ledger can still have
@@ -107,29 +118,76 @@ this pass**, and says so in one line in the ledger header naming what was looked
 for and not found. The skip is recorded so it stays a fact about the surface,
 rather than becoming a step everyone learns to wave through.
 
+**Start from the predecessor's own frozen ledger, when it has one.** A surface
+swept under this lifecycle left `mockups/<predecessor>.behavior.md` and
+`frontend/<predecessor>-behavior.replay.mjs` behind: replaying that script
+against the running predecessor is one command, and it returns a validated
+backbone of rows plus live evidence for every story it carries — cheaper than
+hand-driving the same ground, and better evidence than reading it. Look for both
+before opening the source. **Never stop there.** A prior ledger is only as
+complete as the sweep that froze it, and says nothing about what the surface
+grew afterwards: the run that found the drawn window inherited 28 executable
+stories, and still had to find a keyboard cursor, a histogram, a crumb ladder
+and lane dimming by hand. The ledger seeds the inventory; it never bounds it.
+
 **What it inventories.** The PREDECESSOR's behavior, by §1's rules exactly —
 `addEventListener`, chart/graphics-library instance handlers, observers, inline
 `on*=`, and CSS that encodes behavior — read from the shipped code, never from
 memory of using the app. **Including handlers registered inside imported modules
 the host HTML never shows.** That clause is load-bearing: it is exactly where
 the drawn window's grab handles were registered, and a host-HTML-only sweep
-misses them a second time. Then **exercise the predecessor live** (§3's rules,
-same viewport): a gesture assembled across three handlers reads as one row only
-from the running surface, and suppression conditions — a handle that does not
-appear in one state — exist nowhere in the source as a row at all.
+misses them a second time.
+
+Then **exercise both sides live** (§3's rules, same viewport). The predecessor,
+because a gesture assembled across three handlers is legible as one behavior
+only from the running surface, and suppression conditions — a handle that does
+not appear in one state — exist nowhere in the source at all. And the mock,
+because §3 has not run yet when this pass does, so the mock side of the diff
+rests on nothing unless this pass drives it — and **"the mock" stops being one
+artifact the moment it reuses a shipped painter**. A Diagnose mock's evidence
+table was extracted whole from production and plainly emits row titles and
+chevrons; two lock terms assert the surface shows neither. Both were true — the
+surface strips them after paint. Either source read alone gives the wrong
+verdict, and only the running mock settles it.
+
+**Row grain.** A row is the unit the operator rules on, so split by decision,
+not by listener: **two behaviors are one row when neither can be ruled on
+alone, and separate rows when either could survive without the other.**
+Listeners have no fixed ratio to rows in either direction — a drawn selection
+window registered across five listeners carries several separately retirable
+behaviors (draw by dragging, resize from a handle, which way the window grows,
+its precedence over the presets), while one keydown listener running a keyboard
+cursor carries one row per key whose fate is separable. This is where §1's grain
+and this one legitimately differ: that inventory is keyed to handlers because
+its output is coverage — every handler maps to ≥1 story — and this one is keyed
+to decisions because its output is a ruling. Where a split is genuinely
+arguable, split. An over-split row costs the operator one sentence ruling both
+together; an under-split row hides a behavior nobody ever chose to drop, which
+is the entire defect. The row count is this pass's headline number, and two
+agents sweeping the same surface are meant to arrive at the same one.
 
 **The diff.** Every predecessor row gets exactly one verdict against the mock:
 
 - **kept** — the mock implements it. It is already a §1 story or it becomes one;
   the two inventories meet in that single ledger entry.
+- **deferred** — the mock does not implement it, and a lock term contracts the
+  build to. Neither `kept` (there is nothing to observe on the mock) nor
+  `missed` (nothing was dropped): a term saying a control is real but not
+  exercisable by this fixture is *implemented* by a build that wires it, not
+  violated. The test is whether an app shipping **without** the behavior would
+  violate the named term. If it would not, that term does not contract the
+  behavior and the row is `missed`. A `deferred` row's evidence is app-side
+  only — the port PR that turns the app-opener leg green is where it is proved,
+  and no mock evidence can close it.
 - **retired** — the mock deliberately does not implement it, and a human ruled
   that it goes. Requires the **sanction line** below.
 - **missed** — the mock does not implement it and nobody decided that. **A
   `missed` row fails the sweep.**
 
-`missed` is the default verdict, and a row leaves it only by being built or by
-being sanctioned. "It was probably intentional" is `missed`. A retirement
-argued by the agent that wrote the mock is `missed`. An inventory that ends with
+`missed` is the default verdict, and a row leaves it only by being built, by
+being contracted in a named term, or by being sanctioned. "It was probably
+intentional" is `missed`. A retirement argued by the agent that wrote the mock
+is `missed`. An inventory that ends with
 no `missed` rows because the sweep could not find the predecessor's source is
 `missed` for every row it could not read.
 
@@ -147,6 +205,35 @@ behavior was vestigial, not by the operator's silence when asked. A behavior
 that reaches `retired` without a human's name and date on it is the exact defect
 this pass exists to prevent, and in the ledger it is indistinguishable from a
 `missed` one — which is why it fails as one.
+
+**A ruling recorded somewhere else is not a sanction — and is not nothing,
+either.** Run this pass against a lock that has already merged and some rows
+will turn out to have been genuinely ruled on, in a dated lock term or an issue
+resolution, but written up by whoever drafted that artifact: the words are not
+the operator's, so the sanction line cannot be filled from them. Annotate the
+row and leave the verdict where it is:
+
+```
+ruled-elsewhere: <artifact> · <locator> · "<the ruling as written there>"
+```
+
+The row stays `missed`. It still blocks the lock, still blocks the freeze, and
+still goes to the QUESTION round; the annotation decides nothing except which
+pile it lands in when it gets there — confirm and quote, rather than rule from
+scratch. Keep that distinction: it is the difference between six rows the
+operator answers in a sentence each and thirty-seven he has to think about, and
+collapsing the six into the thirty-seven is how a ruling session gets long
+enough to defer.
+
+**A lock term is never promoted to a sanction, however verbatim the quote.**
+That is the obvious shortcut and it is the one loophole that would empty this
+pass, because the lock is precisely the artifact that encodes a retirement by
+omission: let it sanction its own omissions and the check goes circular, its
+evidence being the thing under check. The Diagnose lock ran to sixty terms
+describing five inert preset buttons, and every one of those terms was true.
+None of them was a decision to drop the drawn window, because nobody had yet
+noticed there was one to drop. A term records what the surface has; a sanction
+records what the operator chose to lose, and only he can say that.
 
 **Ordering.** This pass runs **before the lock closes**, alone among the mode's
 passes; `lock.md` §9 makes it a lock precondition and argues why. It needs the
@@ -284,6 +371,10 @@ R3 · Dragging in the plot body drew a custom selection window; two handles
   status:   retired (permanent)
 ```
 
+A `deferred` row is not a third block. It is a STORY like any other, naming the
+term it defers to on its `lock:` line and `app opener only` on its `evidence:`
+line, so the build's fidelity ledger can see that mock evidence was never owed.
+
 Sweep screenshots and clips live in `mockups/sweep/<surface>/`. Register both the
 ledger and that directory in `mockups/INDEX.md`, per resettle's
 INDEX-moves-with-the-lock rule.
@@ -291,7 +382,9 @@ INDEX-moves-with-the-lock rule.
 Entry types are exactly three: **STORY** (observed behavior), **QUESTION** (a
 behavior or meaning gap the operator must rule on), and **RETIRED** (a
 predecessor behavior deliberately dropped, with its sanction). **RETIRED is not
-a waiver** — it is the record a waiver would have replaced.
+a waiver** — it is the record a waiver would have replaced. A §2 row still at
+`missed`, including one carrying `ruled-elsewhere`, is a QUESTION entry until
+the operator rules it.
 
 **Retired entries are permanent.** The ledger stops being a record of only what
 the surface does and becomes a record of what it does **and what it deliberately
@@ -329,8 +422,13 @@ Answers are recorded inline under their QUESTION entries.
 that pass does. Every row still at `missed` or at an unsanctioned `retired` goes
 in it, each stating what the predecessor did, where it was registered, and what
 the mock offers instead — a retirement is ruled there or it is not ruled at all.
-Answers become `kept` (build it, or `resettle` the lock if it has already closed)
-or `retired` with the sanction line written down as given.
+Rows carrying `ruled-elsewhere` are listed first and apart, each quoting the
+ruling it cites, because on those the operator is confirming a decision he
+already made and dictating a sentence for it, not weighing a new one; mixed into
+the pile they flatten the one distinction that makes the round short. Answers
+become `kept` (build it, or `resettle` the lock if it has already closed),
+`deferred` against a named term, or `retired` with the sanction line written
+down as given.
 
 ## 7. Freeze
 
@@ -357,7 +455,9 @@ contract; building against it is a blocking finding. Regenerating any pinned
 fixture after freeze requires a recorded reason under the header. **A ledger
 carrying a `missed` row cannot be frozen** — the freeze is what makes a verdict
 table binding, and freezing an undecided drop is how the retirement becomes
-contract without anyone choosing it.
+contract without anyone choosing it. A row annotated `ruled-elsewhere` is a
+`missed` row for that purpose: the annotation routes it, it does not decide it.
+A `deferred` row freezes like any story.
 
 **Ledger + lock manifest together are the build contract.** The manifest alone is
 insufficient, in three ways: behaviors and meanings its terms never encoded,

--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -3,6 +3,8 @@
 Sweep a locked surface's **interactive behavior** into a contract before anyone
 builds it. Runs after `lock`, before `build`, for any surface that has
 behavior — handlers, gestures, hover states, keyboard paths, resize response.
+Its one backward-looking pass, the **predecessor inventory** (§2), runs *before*
+the lock closes instead; `lock.md` §9 gates on it and argues the ordering.
 
 The lock manifest describes what the surface *looks like*. It reliably fails to
 describe what the surface *does*: a drag that only works from an edge, a
@@ -11,19 +13,25 @@ Those behaviors are in the mock's code and nowhere in the manifest, so a build
 invents them. The behavior ledger closes that gap; the replay script keeps it
 closed.
 
-Root failure this mode exists to make impossible:
+Two root failures this mode exists to make impossible, one per direction:
 
 > Something approximated the locked artifact instead of using it, and a checker
 > accepted the approximation.
 
-Input: the ★ LOCKED mockup(s), `mockups/<surface>.lock.md`, and every module the
-mock imports. `<surface>` is always the **basename of the lock manifest** —
-every artifact below inherits that one name. No agent picks a nickname.
+> Something dropped the predecessor's behavior, and no checker was looking in
+> that direction.
+
+Input: the ★ LOCKED mockup(s), `mockups/<surface>.lock.md`, every module the
+mock imports, and — where the surface replaces something — the **predecessor's
+own source and running build** (§2). `<surface>` is always the **basename of the
+lock manifest** — every artifact below inherits that one name. No agent picks a
+nickname.
 
 **Proportionality.** Sweep depth scales with the handler inventory: a surface
-whose inventory fits on one screen may fold the three passes below into a single
-sitting. The **ledger**, the **completeness check**, and the **QUESTION round**
-are never waived, at any size.
+whose inventory fits on one screen may fold the passes below into a single
+sitting. The **ledger**, the **completeness check**, the **predecessor diff**
+wherever a predecessor exists, and the **QUESTION round** are never waived, at
+any size.
 
 ## 1. Inventory (static — this is not evidence)
 
@@ -70,7 +78,84 @@ passed. Each story replayed one view, alone, where a uniform offset is invisible
 
 Static reading produces the inventory. It never produces a story.
 
-## 2. Exercise (live — this is the evidence)
+## 2. Predecessor inventory (static + live — the diff run backwards)
+
+§1 inventories the mock, and **a mock-side inventory cannot see an absence**. A
+behavior the mock never implemented registers no handler, so it produces no row;
+a computed-style harness and a chart-option diff have no opinion about an
+interaction that is not there either. Every other check in the lifecycle reads
+the mock, so all of them are blind in the same direction. This pass is the only
+one that reads the other artifact.
+
+A Diagnose workstation was explored as a grounded mock over ten rounds,
+critiqued by a persona panel, put through a 52-run technical audit, and locked
+as a 60-term contract. The app it replaced let the reader **drag in the plot
+body to draw a custom selection window**, resize it from two titled grab
+handles, and ran one grammar where an explicit choice — a preset press or a drag
+— outranked the default window. The mock drew five inert preset buttons and
+nothing else. Nobody noticed at any round, so the lock froze the retirement of a
+shipped interaction as contract, and a build agent reading that lock would have
+shipped the retirement faithfully. It was caught by eye, on a screenshot, after
+the lock merged. Nothing was skipped — the sequence had no step that looked
+backwards.
+
+**When it applies.** Whenever the surface has a shipped ancestor: a `shipped`
+row in `mockups/INDEX.md` for this surface or the one it replaces, a lock
+manifest whose `Supersedes:` line names a prior lock, or a surface being
+replaced in the running app. **A greenfield surface with no predecessor skips
+this pass**, and says so in one line in the ledger header naming what was looked
+for and not found. The skip is recorded so it stays a fact about the surface,
+rather than becoming a step everyone learns to wave through.
+
+**What it inventories.** The PREDECESSOR's behavior, by §1's rules exactly —
+`addEventListener`, chart/graphics-library instance handlers, observers, inline
+`on*=`, and CSS that encodes behavior — read from the shipped code, never from
+memory of using the app. **Including handlers registered inside imported modules
+the host HTML never shows.** That clause is load-bearing: it is exactly where
+the drawn window's grab handles were registered, and a host-HTML-only sweep
+misses them a second time. Then **exercise the predecessor live** (§3's rules,
+same viewport): a gesture assembled across three handlers reads as one row only
+from the running surface, and suppression conditions — a handle that does not
+appear in one state — exist nowhere in the source as a row at all.
+
+**The diff.** Every predecessor row gets exactly one verdict against the mock:
+
+- **kept** — the mock implements it. It is already a §1 story or it becomes one;
+  the two inventories meet in that single ledger entry.
+- **retired** — the mock deliberately does not implement it, and a human ruled
+  that it goes. Requires the **sanction line** below.
+- **missed** — the mock does not implement it and nobody decided that. **A
+  `missed` row fails the sweep.**
+
+`missed` is the default verdict, and a row leaves it only by being built or by
+being sanctioned. "It was probably intentional" is `missed`. A retirement
+argued by the agent that wrote the mock is `missed`. An inventory that ends with
+no `missed` rows because the sweep could not find the predecessor's source is
+`missed` for every row it could not read.
+
+**The sanction line.** A `retired` verdict carries, in its ledger entry:
+
+```
+sanction: <who ruled it> · <date> · "<why, in their own words>"
+```
+
+`<who>` is a person, named. `<date>` is the day they ruled. The reason is
+**quoted, not paraphrased** — the same evidence standard the two drop paths in
+§5 already hold. **An unsanctioned retirement fails the sweep, and there is no
+waiver for it**: not by proportionality, not by an agent's judgment that the
+behavior was vestigial, not by the operator's silence when asked. A behavior
+that reaches `retired` without a human's name and date on it is the exact defect
+this pass exists to prevent, and in the ledger it is indistinguishable from a
+`missed` one — which is why it fails as one.
+
+**Ordering.** This pass runs **before the lock closes**, alone among the mode's
+passes; `lock.md` §9 makes it a lock precondition and argues why. It needs the
+finalist only as a diff target, never a frozen mock. Its verdict table is
+carried into the ledger when the sweep proper runs after the lock. A `missed`
+verdict discovered *after* a lock has merged is a `resettle` trigger, not a
+build decision and not a bug fix — see `resettle.md`.
+
+## 3. Exercise (live — this is the evidence)
 
 Drive the mock in a **real browser engine at the lock's viewport** — viewport set
 explicitly, never a driver default. Perform each behavior for real: hover every
@@ -92,13 +177,14 @@ Two further passes, folded in or run separately per proportionality:
   "built from the description" detectable at review time.
 
 **Completeness check (mechanical, not judgment):** every inventoried handler maps
-to ≥1 story, and every story was observed live. A handler found in code but not
-reproducible in-browser becomes a QUESTION entry — never a silent skip. Handler
-coverage is not ledger completeness: a surface with more than one view, or with
-any interaction that swaps content in place, also owes its invariant stories
-above. Record them with no handler named, since none exists.
+to ≥1 story, **every §2 predecessor row carries a verdict**, and every story was
+observed live. A handler found in code but not reproducible in-browser becomes a
+QUESTION entry — never a silent skip. Handler coverage is not ledger
+completeness: a surface with more than one view, or with any interaction that
+swaps content in place, also owes its invariant stories above. Record them with
+no handler named, since none exists.
 
-## 3. The replay script (committed)
+## 4. The replay script (committed)
 
 Alongside the ledger, commit a replay script — `frontend/<surface>-behavior.replay.mjs`
 or the repo's equivalent path — that re-runs the sweep mechanically. Hand-driving
@@ -135,6 +221,17 @@ Spec:
   **built app** (knock the feature out) or a **scratch copy** of the mock, never
   the ★ LOCKED mock in place. A transient edit to the contract artifact risks an
   unrestored diff, which is the quiet deviation `resettle` exists to forbid.
+- **A retired behavior gets a replay function too, and it is never silent.** The
+  function asserts the absence — no grab handle in the DOM, the gesture does
+  nothing — and **prints its sanction line on every run**, from a
+  `// RETIRED:<who>:<date>` tag beside the `LOCK:` tags. An absence asserted
+  without the sanction on screen quietly makes the retirement permanent, and
+  reads exactly like a feature nobody ever had; the point of running it at all is
+  that a reader of the output sees a shipped behavior was deliberately dropped
+  and by whom. The script **fails closed on a retired function whose sanction tag
+  is missing**, exactly as it does on a missing driver. Reinstating the behavior
+  deletes the absence assertion **in the `resettle` change set that moves the
+  ledger entry back to STORY**, never on its own.
 - **The script fails closed.** Missing browser dependencies (driver module,
   vendored assets, executable) exit nonzero — never `skip`. A skipped run exits 0,
   and a green step that executed zero stories is precisely the silent skip this
@@ -156,9 +253,10 @@ Spec:
   surface's logic exists twice and is hand-synced, and that drifts — one port branch
   carried three divergent wordings of a single copy-pasted note builder.
 
-## 4. The behavior ledger
+## 5. The behavior ledger
 
-One entry per story, in `mockups/<surface>.behavior.md`:
+One entry per story — and one per sanctioned retirement — in
+`mockups/<surface>.behavior.md`:
 
 ```
 S12 · Dragging a window's edge resizes it; edges are full-height ±5px grab
@@ -172,12 +270,36 @@ S12 · Dragging a window's edge resizes it; edges are full-height ±5px grab
              re-settle requested)
 ```
 
+A retirement from §2 takes the same shape, keyed `R`:
+
+```
+R3 · Dragging in the plot body drew a custom selection window; two handles
+     titled "Drag to resize" resized it, growing away from the edge not being
+     dragged.
+  predecessor: frontend/day-chart.js:812-980 (installBrush), shipped app
+  verdict:  retired
+  sanction: Connor · 2026-08-18 · "the presets cover every window I use; the
+            drawn window goes."
+  replay:   fn R3 asserts absence and prints this sanction line
+  status:   retired (permanent)
+```
+
 Sweep screenshots and clips live in `mockups/sweep/<surface>/`. Register both the
 ledger and that directory in `mockups/INDEX.md`, per resettle's
 INDEX-moves-with-the-lock rule.
 
-Entry types are exactly two: **STORY** (observed behavior) and **QUESTION** (a
-behavior or meaning gap the operator must rule on).
+Entry types are exactly three: **STORY** (observed behavior), **QUESTION** (a
+behavior or meaning gap the operator must rule on), and **RETIRED** (a
+predecessor behavior deliberately dropped, with its sanction). **RETIRED is not
+a waiver** — it is the record a waiver would have replaced.
+
+**Retired entries are permanent.** The ledger stops being a record of only what
+the surface does and becomes a record of what it does **and what it deliberately
+stopped doing**; the retired entries with their sanctions are the audit trail,
+and they stay through every later sweep, port and lock of that surface. Deleting
+one leaves either an unrecorded reinstatement or a second undocumented
+retirement, and no way to tell which — the same illegible state the pass exists
+to prevent, arrived at from the other side.
 
 **There is no waiver entry type.** A drop is always a dated, operator-sanctioned
 record, by one of exactly two paths:
@@ -190,9 +312,12 @@ record, by one of exactly two paths:
   quoted.
 
 Both paths carry the date and the sanction. A drop path that skips the record is
-exactly how a dropped term recurs.
+exactly how a dropped term recurs. A §2 retirement lands as a RETIRED entry
+either way; where the retired behavior also touches a manifest row, the
+`resettle` is what carries the manifest side, and its date and sanction are the
+same ones.
 
-## 5. QUESTION round (one numbered round)
+## 6. QUESTION round (one numbered round)
 
 Batch every QUESTION to the operator in **one numbered round** at the end of the
 sweep — behavior gaps, meaning-lost-at-scale findings, irreproducible handlers,
@@ -200,13 +325,21 @@ and any fixture-set authorization the gate will need (shapes and in-band labelin
 authorized together; see the data defaults in SKILL.md's grounding rules).
 Answers are recorded inline under their QUESTION entries.
 
-## 6. Freeze
+**§2's verdicts get their own round, and it happens before the lock**, since
+that pass does. Every row still at `missed` or at an unsanctioned `retired` goes
+in it, each stating what the predecessor did, where it was registered, and what
+the mock offers instead — a retirement is ruled there or it is not ruled at all.
+Answers become `kept` (build it, or `resettle` the lock if it has already closed)
+or `retired` with the sanction line written down as given.
+
+## 7. Freeze
 
 Operator approval stamps a header line on the ledger:
 
 ```
 ★ FROZEN <date> · base <sha> · generator <sha> · window <start>..<end>
   · fixtures <name: sha256-prefix, …>   (tripwire, not contract)
+  · predecessor <ref, or "none — greenfield">   · retired <n>
 ```
 
 - The pinned **inputs** (generator commit, data window) are a **provenance
@@ -221,9 +354,14 @@ Operator approval stamps a header line on the ledger:
 
 A `behavior.md` without the `★ FROZEN` header is a sweep in progress, not a
 contract; building against it is a blocking finding. Regenerating any pinned
-fixture after freeze requires a recorded reason under the header.
+fixture after freeze requires a recorded reason under the header. **A ledger
+carrying a `missed` row cannot be frozen** — the freeze is what makes a verdict
+table binding, and freezing an undecided drop is how the retirement becomes
+contract without anyone choosing it.
 
 **Ledger + lock manifest together are the build contract.** The manifest alone is
-insufficient: behaviors and meanings its terms never encoded, plus terms no
-assertion ever exercised, are the two gaps. The ledger closes the first; behavior
-replay in `build` closes the second.
+insufficient, in three ways: behaviors and meanings its terms never encoded,
+terms no assertion ever exercised, and behaviors the predecessor had that neither
+artifact mentions because neither was looking backwards. The ledger's stories
+close the first; behavior replay in `build` closes the second; §2's verdicts and
+their RETIRED entries close the third.

--- a/skills/ui-craft/reference/build.md
+++ b/skills/ui-craft/reference/build.md
@@ -145,6 +145,12 @@ mock opener exercises the mock and proves nothing about the port.
 
 - Each story's ledger `status` moves to `ported` → `replayed-pass` /
   `replayed-fail` / `re-settle requested`. **`replayed-fail` blocks.**
+- **RETIRED entries replay too, and their sanction prints.** Their absence
+  assertions run against the built app like any story, each printing the who and
+  the date that sanctioned the drop, so a retirement never becomes a silent green
+  line. A RETIRED entry whose behavior is *present* in the build is a
+  `replayed-fail`: the port restored something a human ruled gone, which is a
+  deviation in the same way dropping a locked term is.
 - The script's fail-closed rule holds here: a green step that executed zero
   stories is a failure, so confirm the run **reported its applicable story
   count**, not merely that the step ran.

--- a/skills/ui-craft/reference/lock.md
+++ b/skills/ui-craft/reference/lock.md
@@ -53,7 +53,9 @@ single variant until the fidelity gate passes:
 Read `mockups/INDEX.md` (create if absent; one row per surface, columns
 Surface / Concept / Status / Issue / File). `locked` entries are binding
 precedent for adjacent surfaces; for `shipped` entries the app is ground
-truth, not old mockup markup.
+truth, not old mockup markup. A `shipped` row covering this surface or the one
+it replaces is also what **triggers the predecessor pass** (§9.3) — note it here,
+where it is cheap, rather than discovering it at lock time.
 
 ### 2. Grounding kit
 
@@ -127,6 +129,14 @@ SKILL.md); name the first concrete element that stalls each walkthrough and
 fix it. Then run the `audit` technical checks (contrast, keyboard focus,
 overflow, target sizes) on the finalist.
 
+**Where the surface has a predecessor, run the predecessor inventory on the
+finalist here** ([behavior-sweep.md](behavior-sweep.md) §2) and take its
+QUESTION round to the operator with the rest of this gate's findings. This is
+the last point at which a dropped interaction is still a design conversation
+rather than an amendment to a merged contract. The personas walk the mock and the
+audit measures the mock; neither can catch what the mock does not contain,
+because neither is looking at anything else.
+
 ### 9. Lock
 
 Locking is complete only when ALL of these exist:
@@ -138,8 +148,30 @@ Locking is complete only when ALL of these exist:
    prior locks being superseded. Any contradiction is resolved *now*, by the
    user (interactive) or explicitly in the header (headless) — never left
    for the implementer to arbitrate.
-3. **The lock manifest** — `mockups/<surface>.lock.md` (format below).
-4. Losing variants and their screenshots deleted — but never the scaffold
+3. **The predecessor diff, wherever the surface has a predecessor.** If a
+   `shipped` row in `mockups/INDEX.md` covers this surface or the one it
+   replaces, or a prior lock is being superseded, or the running app already
+   does this job, then `behavior-sweep`'s **predecessor inventory**
+   ([behavior-sweep.md](behavior-sweep.md) §2) has run and every predecessor
+   behavior carries a verdict: `kept`, or `retired` with its sanction line. **A
+   `missed` row blocks the lock**, and an unsanctioned `retired` row is a
+   `missed` row. A greenfield surface records the one-line skip and moves on.
+
+   **This one pass precedes the lock; the rest of the sweep follows it — and the
+   ordering is the whole point.** The rest needs a frozen mock, so it cannot run
+   earlier; this pass needs the finalist only as a diff target, so it can. Lock
+   first and the record inverts: **the lock is what turns a retirement into
+   contract**, so a pass that runs afterwards is not deciding anything, it is
+   transcribing a decision the project already made by omission — and every
+   later mode reads the lock, so the omission is now the spec. A real Diagnose
+   lock froze the retirement of a shipped drag-to-draw selection window its mock
+   had simply never implemented. Ten exploration rounds, a persona panel and a
+   52-run audit all read the mock, and a mock-side reading cannot see an absence;
+   the operator caught it by eye on a screenshot after the lock merged. Nothing
+   in that sequence was skipped. The sequence had no step that looked backwards,
+   and this is that step.
+4. **The lock manifest** — `mockups/<surface>.lock.md` (format below).
+5. Losing variants and their screenshots deleted — but never the scaffold
    files (`_theme.css`, `_shell.js`, `SCAFFOLD.md`), which the locked mock
    links and other surfaces share; `mockups/INDEX.md` set to `locked`,
    pointing at mock + manifest; the implementation issue references both.
@@ -161,7 +193,7 @@ header stays the narrative; the manifest is the contract.
 
 ```markdown
 # Lock manifest — <surface>
-Locked: <date> by <who>   Mocks: <files, incl. the scaffold files the mock links (_theme.css, _shell.js)>   Supersedes: <prior lock or —>
+Locked: <date> by <who>   Mocks: <files, incl. the scaffold files the mock links (_theme.css, _shell.js)>   Supersedes: <prior lock, the shipped surface it replaces + its source path, or —>
 
 ## Precedence
 <One sentence: which artifact wins for component-level styling when the mock
@@ -184,6 +216,13 @@ low-tail fill fires". A fixture that cannot show a term cannot prove it.>
 <Legend chips, labels, button text — copied exactly from the mock, so text
 drift is a diff, not a judgment call.>
 ```
+
+**`Supersedes:` is how the predecessor stays findable.** The surface ledger
+identifies it by its `shipped` row — and that row flips to `locked` in this same
+change, so from then on this line is the only record of what this surface
+replaced. Name the shipped surface and where its behavior is registered, not just
+a prior lock; a bare `—` on a replacement surface reads as greenfield to the next
+round, and a greenfield surface skips the predecessor pass.
 
 Rules for writing terms:
 

--- a/skills/ui-craft/reference/lock.md
+++ b/skills/ui-craft/reference/lock.md
@@ -153,9 +153,12 @@ Locking is complete only when ALL of these exist:
    replaces, or a prior lock is being superseded, or the running app already
    does this job, then `behavior-sweep`'s **predecessor inventory**
    ([behavior-sweep.md](behavior-sweep.md) §2) has run and every predecessor
-   behavior carries a verdict: `kept`, or `retired` with its sanction line. **A
-   `missed` row blocks the lock**, and an unsanctioned `retired` row is a
-   `missed` row. A greenfield surface records the one-line skip and moves on.
+   behavior carries a verdict: `kept`, `deferred` to a term this manifest states
+   and an omitting build would violate, or `retired` with its sanction line. **A
+   `missed` row blocks the lock.** So does an unsanctioned `retired` row, and so
+   does one whose only sanction is a term of this very manifest — a lock cannot
+   sanction the omissions it is itself freezing. A greenfield surface records the
+   one-line skip and moves on.
 
    **This one pass precedes the lock; the rest of the sweep follows it — and the
    ordering is the whole point.** The rest needs a frozen mock, so it cannot run

--- a/skills/ui-craft/reference/resettle.md
+++ b/skills/ui-craft/reference/resettle.md
@@ -7,6 +7,29 @@ A re-settle is sanctioned by the user (interactive) or, in headless runs, by
 an explicit instruction in the work order. An agent may *propose* one at any
 time; it may never *apply* one on its own judgment.
 
+## A post-lock `missed` verdict lands here
+
+When `behavior-sweep`'s predecessor inventory ([behavior-sweep.md](behavior-sweep.md)
+§2) returns a `missed` verdict on a lock that has already merged — a shipped
+behavior the lock neither kept nor sanctioned as retired — **this is the path**,
+whether it surfaced during the build, in an audit, or by eye on a screenshot.
+It is not a build call and not a bug fix: the merged lock currently says the
+behavior is gone, so restoring it quietly is the private arbitration the lock
+exists to forbid, and dropping it quietly is the original defect a second time.
+
+The operator rules it, and the ruling lands as one of two change sets:
+
+- **kept** — re-settle the terms that have to describe the behavior. Usually
+  there is no row to amend, because the lock was silent about it; then the
+  re-settle **adds** the term and says in the mock header's `RE-SETTLED TERM`
+  block that it restores a predecessor behavior the lock omitted. The behavior
+  ledger gains its STORY and the replay script its function, in the same set.
+- **retired** — no term moves. The sanction line is written into the behavior
+  ledger's RETIRED entry (§2's format), dated and quoted, and the entry's
+  absence assertion is added to the replay script.
+
+Either way it is dated and recorded, and the ledger keeps the trail.
+
 ## Steps
 
 1. Name the term (manifest number), the change, and who sanctioned it.
@@ -22,7 +45,9 @@ time; it may never *apply* one on its own judgment.
      story cites the term — rewrite the entry and record the reason under its
      `★ FROZEN` header, since the freeze pins a contract that would otherwise go
      silently stale. A mid-build resettle that leaves the frozen ledger untouched
-     is incomplete;
+     is incomplete. **RETIRED entries are amended in place, never deleted**: a
+     reinstated behavior moves back to STORY in this change set and its
+     retirement stays visible above it as the record of what was reversed;
    - `mockups/INDEX.md` if the surface's status or files changed (columns
      Surface / Concept / Status / Issue / File) — it registers the behavior
      ledger and the sweep-evidence directory `mockups/sweep/<surface>/` too.

--- a/skills/ui-craft/reference/resettle.md
+++ b/skills/ui-craft/reference/resettle.md
@@ -17,6 +17,11 @@ It is not a build call and not a bug fix: the merged lock currently says the
 behavior is gone, so restoring it quietly is the private arbitration the lock
 exists to forbid, and dropping it quietly is the original defect a second time.
 
+This is also where the pass lands when it runs late — against a lock that closed
+before anyone was looking backwards. Expect a pile rather than a row: the first
+predecessor inventory run against a merged 60-term lock returned 43 unruled
+retirements, one drawn selection window accounting for seventeen of them.
+
 The operator rules it, and the ruling lands as one of two change sets:
 
 - **kept** — re-settle the terms that have to describe the behavior. Usually
@@ -26,7 +31,11 @@ The operator rules it, and the ruling lands as one of two change sets:
   ledger gains its STORY and the replay script its function, in the same set.
 - **retired** — no term moves. The sanction line is written into the behavior
   ledger's RETIRED entry (§2's format), dated and quoted, and the entry's
-  absence assertion is added to the replay script.
+  absence assertion is added to the replay script. Where the merged lock already
+  spoke to the retirement, that citation rides along as the row's
+  `ruled-elsewhere` annotation and nothing more: it is what turns the ruling into
+  a one-sentence confirmation instead of a fresh decision, and it is never the
+  sanction itself.
 
 Either way it is dated and recorded, and the ledger keeps the trail.
 


### PR DESCRIPTION
Adds the one pass in the surface lifecycle that reads the artifact being
replaced instead of the mockup. Every other check reads the mockup, and a
mockup-side check cannot see a behavior that was never built: it registers no
handler, so it produces no row.

* `behavior-sweep` gains the predecessor inventory. Every behavior the shipped
  surface has gets a verdict of kept, deferred, or retired with a sanction that
  names a person, the date, and their own quoted reason.
* The pass runs before the lock closes, not after. A lock is what turns a
  retirement into contract, so a pass that runs afterwards transcribes a
  decision rather than making one.
* An unruled drop blocks the lock. So does a retirement sanctioned only by a
  term of the lock being written, which would let a lock sanction its own
  omissions.
* Retired behaviors replay against the built app like any other story, printing
  who sanctioned the drop, and a retired behavior found present in the build
  fails.
* A drop found after the lock merged goes through `resettle`, which is where the
  operator rules it either way.

The pass ran once, against harmonic's merged 60-term lock, and returned 43
unruled retirements out of 55 behaviors, one drawn selection window accounting
for seventeen. The second commit is that run's corrections.

Issue #48 makes this the fallback path: where a repo can run its own app safely,
a shipped surface is revised on an app branch and this pass is not what protects
it. Where a repo cannot, this is what protects it.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
