### PR TITLE
Record the skill taxonomy and review front-door decisions

### DIFF
--- a/docs/adr/adr-51-skill-taxonomy.md
+++ b/docs/adr/adr-51-skill-taxonomy.md
@@ -1,0 +1,48 @@
+# ADR 51 — Workflow and tool categories inside `skills/`
+
+## Context
+
+The pack holds two kinds of skill under one flat directory. Some skills route to, or
+drive, other skills: `scope` classifies uncertainty and hands off, `orchestrate` delegates
+every piece of work, `wayfinder` charts an effort and hands subtrees onward. Others do one
+job themselves: `spin-worktree` cuts a worktree, `drive-local-webapp` drives a browser,
+`pr-body` scores a body. A reader browsing `skills/` cannot tell which is which without
+opening the skill, and the README table carries the distinction only implicitly.
+
+Three ways to express the distinction were considered.
+
+A top-level `workflows/` directory beside `skills/` reads well, but two facts count
+against it. The install CLI treats `skills/` and its subdirectories as standard discovery
+locations, walking a container up to three levels, which covers a catalog with one or two
+category levels; a top-level directory of a different name is reached only by the
+last-resort recursive scan. And `.claude/workflows/` already denotes orchestration
+scripts, a different artifact entirely, so the name is taken in the reader's mind before
+this pack uses it.
+
+Category folders inside `skills/` land in a layout the installer already supports, at the
+cost of rewriting every path in the README, `scripts/validate.py`, CI, and the cross-skill
+and cross-doc relative links.
+
+Metadata only, with frontmatter declaring a kind and the README grouping accordingly,
+costs nothing and moves nothing, but leaves the directory listing as uninformative as it
+is today.
+
+## Decision
+
+Skills live in category folders inside `skills/`: `skills/workflows/<name>` for skills
+that route to or drive other skills, and `skills/tools/<name>` for skills that do one job
+themselves. The move is mechanical; no skill's instructions change in the same diff.
+
+## Consequences
+
+The directory listing now answers the question the README answered before, and the install
+CLI keeps first-class discovery rather than falling back to a recursive scan. The name
+collision with orchestration scripts never arises.
+
+Every path in the repository moves once. `scripts/validate.py` gains a category level in
+its skill root and expected set, CI's compile step follows the helper, and relative links
+into `docs/` gain a level. Anyone with a pinned path into `skills/<name>/` breaks at the
+same moment, which is why the move lands alone rather than alongside new skills.
+
+The categories are a judgment, not a schema. A skill that both routes and does work sits
+in `workflows/`, because the routing is the part a reader needs to find.

--- a/docs/adr/adr-52-review-front-door.md
+++ b/docs/adr/adr-52-review-front-door.md
@@ -1,0 +1,57 @@
+# ADR 52 — `/review` as a routing front door with a config route table
+
+## Context
+
+Review is not one activity. Changed code wants a standards-and-spec pass; a plan wants
+adversarial reading before anything is built; a document wants named perspectives; pending
+changes sometimes want a security pass; an infrastructure plan wants a blast-radius read
+before an apply. Each of those already exists as its own skill, shipped here, shipped with
+the agent, or installed privately.
+
+Until now `/review` named exactly one of them, the standards-and-spec pass on changed
+code, which `code-review` has since superseded with a per-item verdict that terminates a
+round. So the pack has an entry point whose name promises the general case and whose
+behavior delivers one specific case, while the other reviews are reachable only by
+knowing their skill names.
+
+`scope` already solved this shape for work that is not ready to build: classify the
+dominant uncertainty, route to exactly one specialist, do none of the specialist's work.
+
+The routes are not a fixed set. This pack ships four. An installation may register a
+review type the pack has never heard of, including one whose skill cannot be published.
+Hardcoding routes in the skill's prose would force every such installation to keep a
+private copy of the front door, which is the divergence this pack is trying to remove.
+
+## Decision
+
+`/review` becomes the front door. It classifies the subject in front of it and routes to
+exactly one review skill, doing no reviewing itself. Today's `review` skill retires into
+it.
+
+Routes are data. The skill reads a route table from config, where each row names the
+route, the skill it invokes, and what it is for. Registering a review type is a row, not a
+fork.
+
+Three outcomes stay distinguishable: a registered route whose skill is installed runs; a
+registered route whose skill is missing stops, names the skill, and says how to install
+it; a subject that matches no route says exactly that. There is no fallback to a nearby
+review.
+
+## Consequences
+
+A person types one command and reaches the right review, and the pack gains a place to put
+the next review type without touching the front door's instructions.
+
+The stop-on-missing rule is the load-bearing part. A silent downgrade would turn a
+requested security review into a code review that reports clean, which is worse than no
+review, because it produces a passing verdict nobody should trust. That failure mode is
+why the missing-skill case is a stop rather than a degradation, and why "not installed"
+and "not a route here" are reported as different things.
+
+The config route table is a new artifact to keep correct: a row pointing at a skill that
+was renamed produces a stop rather than a route, and the message must make that
+diagnosable.
+
+Retiring `review` breaks anyone invoking it for the changed-code case. They get the front
+door instead, which routes them to `code-review`, so the path survives even though the
+skill does not.


### PR DESCRIPTION
Records two decisions taken while scoping the ticket workflow extraction, ahead of the changes that carry them out (#51, #52).

* Skills move into workflow and tool categories inside the skills directory. A top-level workflows directory was rejected because the install CLI reaches it only by its last-resort recursive scan, and because that name already denotes orchestration scripts.
* The review command becomes a front door that classifies its subject and routes to one review type. Routes come from a config table, so an installation can register a review type this pack does not ship, including one whose skill stays private.
* A route whose skill is missing stops and names it. There is no fallback to a nearby review, because a requested security review that quietly becomes a code review returns a passing verdict nobody should trust.

No skill instructions change here. Both decisions are carried out by the issues they name.

This PR was written in part with the assistance of generative AI.
