### PR TITLE
Add ui-craft revise for shipped surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 
 | Skill | Purpose | Extra requirement |
 | --- | --- | --- |
-| [`ui-craft`](skills/ui-craft/SKILL.md) | Full surface lifecycle: revise shipped UI in the running app, lock greenfield specs, build, critique, audit, polish, re-settle | `drive-local-webapp` for rendered review; parallel-agent support is recommended |
+| [`ui-craft`](skills/ui-craft/SKILL.md) | Full surface lifecycle: revise shipped UI in the running app, lock greenfield specs, build, critique, audit, polish, re-settle | `drive-local-webapp` for rendered review; `spin-worktree` for live base comparison; parallel-agent support is recommended |
 | [`drive-local-webapp`](skills/drive-local-webapp/SKILL.md) | Drive and screenshot a local web app with headless Chromium | Node.js 20+; installs Playwright locally |
 | [`cbm-onboard`](skills/cbm-onboard/SKILL.md) | Index a repository with codebase-memory-mcp and keep it current | `codebase-memory-mcp` on `PATH` |
 | [`spin-worktree`](skills/spin-worktree/SKILL.md) | Create isolated Git worktrees for issue and PR work | Git; GitHub CLI only for `--pr` discovery |
@@ -35,7 +35,8 @@ standard [`skills` CLI](https://github.com/vercel-labs/skills):
 ```sh
 npx skills add ConnorGriffin/skills \
   --skill ui-craft \
-  --skill drive-local-webapp
+  --skill drive-local-webapp \
+  --skill spin-worktree
 ```
 
 Install another skill by itself:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 
 | Skill | Purpose | Extra requirement |
 | --- | --- | --- |
-| [`ui-craft`](skills/ui-craft/SKILL.md) | Full surface lifecycle: lock a visual spec, build to it, critique with personas, audit against the lock, polish, re-settle | `drive-local-webapp` for rendered review; parallel-agent support is recommended |
+| [`ui-craft`](skills/ui-craft/SKILL.md) | Full surface lifecycle: revise shipped UI in the running app, lock greenfield specs, build, critique, audit, polish, re-settle | `drive-local-webapp` for rendered review; parallel-agent support is recommended |
 | [`drive-local-webapp`](skills/drive-local-webapp/SKILL.md) | Drive and screenshot a local web app with headless Chromium | Node.js 20+; installs Playwright locally |
 | [`cbm-onboard`](skills/cbm-onboard/SKILL.md) | Index a repository with codebase-memory-mcp and keep it current | `codebase-memory-mcp` on `PATH` |
 | [`spin-worktree`](skills/spin-worktree/SKILL.md) | Create isolated Git worktrees for issue and PR work | Git; GitHub CLI only for `--pr` discovery |

--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -30,14 +30,15 @@ class, function signature, or module boundary, this is the wrong skill.
 Before routing any design change:
 
 3. Resolve whether the app already embodies the surface (`shipped` or
-   `greenfield`). For a shipped surface, inspect its `CLAUDE.md` / `AGENTS.md`
-   dev-server declaration and classify it as `absent`, `complete`, `incomplete`
-   or `ambiguous`; classify its named data source as `manufactured`, `synthetic`
-   or `unknown`.
+   `greenfield`). For a shipped surface, classify local runnability as `runnable`
+   or `unavailable`; inspect its `CLAUDE.md` / `AGENTS.md` dev-server declaration
+   and classify it as `absent`, `complete`, `incomplete` or `ambiguous`; classify
+   its named data source as `manufactured`, `synthetic` or `unknown`.
 4. Run `node $UI_CRAFT_SKILL_DIR/scripts/route.mjs --embodiment <state>
-   --declaration <state> --data-source <kind>` and obey its mode. A `refuse`
-   result is blocking. `lock-fallback` is the recorded predecessor fallback in
-   `reference/revise.md`, not ordinary `lock` permission.
+   --runnability <state> --declaration <state> --data-source <kind>` and obey its
+   mode. A `refuse` result is blocking. `lock-fallback` is the recorded
+   predecessor fallback in `reference/revise.md`, not ordinary `lock`
+   permission.
 
 For `revise`, `lock`, `build`, and general design invocations only:
 

--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -27,18 +27,30 @@ class, function signature, or module boundary, this is the wrong skill.
    PRODUCT.md / DESIGN.md directly, and continue — the scripts are
    accelerators, not gates.
 
+Before routing any design change:
+
+3. Resolve whether the app already embodies the surface (`shipped` or
+   `greenfield`). For a shipped surface, inspect its `CLAUDE.md` / `AGENTS.md`
+   dev-server declaration and classify it as `absent`, `complete`, `incomplete`
+   or `ambiguous`; classify its named data source as `manufactured`, `synthetic`
+   or `unknown`.
+4. Run `node $UI_CRAFT_SKILL_DIR/scripts/route.mjs --embodiment <state>
+   --declaration <state> --data-source <kind>` and obey its mode. A `refuse`
+   result is blocking. `lock-fallback` is the recorded predecessor fallback in
+   `reference/revise.md`, not ordinary `lock` permission.
+
 For `revise`, `lock`, `build`, and general design invocations only:
 
-3. Read the project's design system: tokens, theme, one representative
+5. Read the project's design system: tokens, theme, one representative
    component or page. Use what's there when it works. **The shipped app wins
    over any mock scaffold**: when a repo carries both an app stylesheet and a
    `mockups/` theme, the app is chrome ground truth for every surface that
    has shipped. `revise` operates on that app directly; `lock` mode's step-0
    pre-flight (reference/lock.md) refuses to replace it with a fresh mock.
-4. Read the matching register reference: `reference/brand.md` when design IS
+6. Read the matching register reference: `reference/brand.md` when design IS
    the product (marketing, landing, portfolio), `reference/product.md` when
    design SERVES the product (app UI, dashboards, tools).
-5. New project with no committed tokens: run
+7. New project with no committed tokens: run
    `node $UI_CRAFT_SKILL_DIR/scripts/palette.mjs` for a brand seed.
 
 ## The contract follows the surface

--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: ui-craft
-description: Lifecycle for user-facing surfaces — lock a visual spec from grounded HTML mockups, build to a lock with fidelity evidence, critique/audit/polish a UI, or re-settle a locked term. Use for any request to design, review, or verify rendered UI (screens, dashboards, flows, components). Not for backend-only work or module/API design ("interface" in the code sense — use codebase-design for that).
+description: Lifecycle for user-facing surfaces — revise a shipped surface in the running app, lock a greenfield visual spec, build to a lock, critique/audit/polish a UI, or re-settle a locked term. Use for any request to design, review, or verify rendered UI (screens, dashboards, flows, components). Not for backend-only work or module/API design ("interface" in the code sense — use codebase-design for that).
 ---
 
 # UI craft
 
-One skill for the whole life of a user-facing surface: **lock** a visual spec,
-**build** to it, **critique** it, **audit** it, **polish** it, **re-settle** it.
+One skill for the whole life of a user-facing surface: **revise** a shipped
+surface in place, **lock** a greenfield visual spec, **build** to it,
+**critique** it, **audit** it, **polish** it, **re-settle** it.
 Parts absorbed from `impeccable` (Apache-2.0, by Paul Bakaus — see the repo
 NOTICE).
 
@@ -26,38 +27,46 @@ class, function signature, or module boundary, this is the wrong skill.
    PRODUCT.md / DESIGN.md directly, and continue — the scripts are
    accelerators, not gates.
 
-For `lock`, `build`, and general design invocations only:
+For `revise`, `lock`, `build`, and general design invocations only:
 
 3. Read the project's design system: tokens, theme, one representative
    component or page. Use what's there when it works. **The shipped app wins
    over any mock scaffold**: when a repo carries both an app stylesheet and a
    `mockups/` theme, the app is chrome ground truth for every surface that
-   has shipped — `lock` mode's step-0 pre-flight (reference/lock.md) resolves
-   this and gates the round on a chrome fidelity check.
+   has shipped. `revise` operates on that app directly; `lock` mode's step-0
+   pre-flight (reference/lock.md) refuses to replace it with a fresh mock.
 4. Read the matching register reference: `reference/brand.md` when design IS
    the product (marketing, landing, portfolio), `reference/product.md` when
    design SERVES the product (app UI, dashboards, tools).
 5. New project with no committed tokens: run
    `node $UI_CRAFT_SKILL_DIR/scripts/palette.mjs` for a brand seed.
 
-## The lock is the contract
+## The contract follows the surface
 
-A surface that has been through `lock` has, next to its mockup:
+For a greenfield surface that has been through `lock`, the contract is:
 
 - a `★ LOCKED` header in the mockup HTML, and
 - a **lock manifest** — `mockups/<surface>.lock.md` — the checkable inventory
-  every other mode reads. Format in `reference/lock.md`.
+  `build` reads. Format in `reference/lock.md`.
+
+For a surface the app already ships, `revise` bans a from-scratch mock. Its
+contract is the frozen **behavior ledger** plus its replay script, exercised
+against the built app. The app branch is the visual artifact; screenshots record
+the review, but no lock manifest is pinned to an app template.
 
 Rules that bind every mode:
 
-- **No arbitration in private.** If two locked artifacts disagree, or a locked
-  term collides with the app's shipped design system beyond what the
-  manifest's precedence line settles, stop and ask. Implementer judgment never
-  silently overrides a lock.
-- **Deviation = re-settle.** Any build or refactor that changes a locked term
-  goes through `re-settle` (dated, sanctioned, recorded) — never a quiet diff.
-- **Evidence over green gates.** A surface is done when every manifest term
-  has evidence, not when the test suite passes.
+- **No arbitration in private.** If two locked artifacts disagree, a locked
+  term collides with the app's shipped design system beyond what the manifest's
+  precedence line settles, or a revision drops shipped behavior, stop and ask.
+  Implementer judgment never silently overrides a contract.
+- **Deviation is recorded.** Any build or refactor that changes a locked term
+  goes through `re-settle`; any revision that changes shipped behavior amends
+  the frozen behavior ledger. Both paths are dated and sanctioned, never quiet.
+- **Evidence over green gates.** A locked surface is done when every manifest
+  term has evidence; a revision is done when every behavior story replayed and
+  every affected state has before/after evidence. A green suite alone is never
+  the finish line.
 
 ## Modes
 
@@ -66,8 +75,9 @@ acting — it defines the flow.
 
 | Mode | Job | Reference |
 | --- | --- | --- |
-| `lock [surface]` | Explore grounded variants, converge, lock spec + manifest | [reference/lock.md](reference/lock.md) |
-| `behavior-sweep [surface]` | Sweep the mock's interactive behavior **and the shipped predecessor's** into a frozen behavior ledger + replay script; an unsanctioned drop fails. Predecessor pass runs **before** `lock`; the rest after `lock`, before `build` | [reference/behavior-sweep.md](reference/behavior-sweep.md) |
+| `revise [surface]` | Inventory shipped behavior, then iterate the running app on a branch; never mock the shipped surface from scratch | [reference/revise.md](reference/revise.md) |
+| `lock [surface]` | Explore grounded variants for a greenfield surface, converge, lock spec + manifest | [reference/lock.md](reference/lock.md) |
+| `behavior-sweep [surface]` | Freeze interactive behavior into a ledger + replay script. `revise` runs it against the built app before design; the lock fallback also diffs a shipped predecessor before locking | [reference/behavior-sweep.md](reference/behavior-sweep.md) |
 | `build [surface]` | Implement a locked spec; ship the fidelity ledger | [reference/build.md](reference/build.md) |
 | `critique [target]` | Heuristic scoring, slop verdict, persona walkthroughs | [reference/critique.md](reference/critique.md) |
 | `audit [target]` | Technical checks (a11y, contrast, responsive, detector) + lock-fidelity audit when a manifest exists | [reference/audit.md](reference/audit.md) |
@@ -76,16 +86,18 @@ acting — it defines the flow.
 | `consensus [question]` | Settle a contested design decision via a 3-persona vote-and-negotiate panel (advisory; requires repo personas) | [reference/consensus.md](reference/consensus.md) |
 | `init` / `document` | Project context setup / generate DESIGN.md | [reference/init.md](reference/init.md), [reference/document.md](reference/document.md) |
 
-No argument: recommend the 1–3 most useful modes from context (unlocked
-mockups → `lock`; an unlocked mockup for a surface with a `shipped` predecessor
-and no predecessor verdicts → `behavior-sweep`'s predecessor pass **before**
-`lock`; frozen manifest for a surface with interactive behavior and no
-behavior ledger → `behavior-sweep` **before** `build`; open manifest without a
-fidelity ledger → `build`; never critiqued → `critique`), then list the table.
-Never auto-run a mode.
+No argument: recommend the 1–3 most useful modes from context (a shipped
+surface → `revise`; a greenfield surface or explicitly recorded safe-start
+fallback → `lock`; an unlocked fallback mock with no predecessor verdicts →
+`behavior-sweep`'s predecessor pass **before** `lock`; frozen manifest for a
+greenfield surface with interactive behavior and no behavior ledger →
+`behavior-sweep` **before** `build`; open manifest without a fidelity ledger →
+`build`; never critiqued → `critique`), then list the table. Never auto-run a
+mode.
 
 Three artifacts carry the word *ledger*; always qualify it. The **fidelity
-ledger** is one row per manifest term (`build`). The **behavior ledger** is
+ledger** is one row per manifest term (`build`; `revise` has none). The
+**behavior ledger** is
 `mockups/<surface>.behavior.md`, one entry per story plus one permanent entry
 per sanctioned retirement (`behavior-sweep`). The **surface ledger** is
 `mockups/INDEX.md`, one row per surface.
@@ -118,8 +130,9 @@ archetypes.
 **"The repo's sweep protocol" is not `behavior-sweep`.** That phrase means the
 repo's persona-driven QA pass — exploratory, judgment-led, run against a live
 app to find bugs. `behavior-sweep` is a mode of this skill: mechanical, run
-against a **locked mock** — and against the surface's shipped predecessor — before
-any build, and its output is a contract. Neither substitutes for the other.
+against the **built app** before a revision, or against a locked mock plus its
+shipped predecessor on the explicit fallback path. Its output is a contract.
+Neither substitutes for the other.
 
 ## Grounding rules (inherited from ui-mockups, apply everywhere)
 

--- a/skills/ui-craft/SKILL.md
+++ b/skills/ui-craft/SKILL.md
@@ -103,8 +103,9 @@ per sanctioned retirement (`behavior-sweep`). The **surface ledger** is
 `mockups/INDEX.md`, one row per surface.
 
 General design invocations with no mode match (e.g. "make this less bland",
-"fix the spacing") run under `critique`-then-fix using
-[reference/design-rules.md](reference/design-rules.md).
+"fix the spacing") route by embodiment: shipped surface → `revise`-then-fix;
+greenfield surface → `critique`-then-fix. Use
+[reference/design-rules.md](reference/design-rules.md) for the craft pass.
 
 ## Design rules (all modes)
 

--- a/skills/ui-craft/agents/openai.yaml
+++ b/skills/ui-craft/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "UI Craft"
-  short_description: "Lock, build, critique, audit, and polish user-facing surfaces."
-  default_prompt: "Use $ui-craft for this surface: lock a visual spec, build to a lock with fidelity evidence, critique with personas, audit against the lock, or run the polish gate."
+  short_description: "Revise shipped UI; lock, build, and review greenfield surfaces."
+  default_prompt: "Use $ui-craft for this surface: revise shipped UI in the running app, lock a greenfield visual spec, build to a lock with fidelity evidence, critique with personas, audit, or run the polish gate."

--- a/skills/ui-craft/reference/audit.md
+++ b/skills/ui-craft/reference/audit.md
@@ -95,7 +95,7 @@ For each issue, document:
 - **Impact**: How it affects users
 - **WCAG/Standard**: Which standard it violates (if applicable)
 - **Recommendation**: How to fix it
-- **Suggested command**: Which ui-craft mode addresses it (`critique` for design-level issues, `polish` for fix passes, `resettle` for locked-term changes, `document` for missing DESIGN.md)
+- **Suggested command**: Which ui-craft mode addresses it (`revise` for shipped-surface changes, `critique` for greenfield design issues, `polish` for fix passes, `resettle` for locked-term changes, `document` for missing DESIGN.md)
 
 ### Patterns & Systemic Issues
 
@@ -114,7 +114,7 @@ List recommended commands in priority order (P0 first, then P1, then P2):
 1. **[P?] `/command-name`**: Brief description (specific context from audit findings)
 2. **[P?] `/command-name`**: Brief description (specific context)
 
-**Rules**: Only recommend ui-craft modes (`critique`, `polish`, `resettle`, `document`, or a targeted fix under the general invocation). Map findings to the most appropriate mode. End with `/ui-craft polish` as the final step if any fixes were recommended.
+**Rules**: Only recommend ui-craft modes (`revise`, `critique`, `polish`, `resettle`, `document`, or a targeted fix under the general invocation). A shipped-surface change routes to `revise`; map the remaining findings to the most appropriate mode. End with `/ui-craft polish` as the final step if any fixes were recommended.
 
 After presenting the summary, tell the user:
 
@@ -174,4 +174,3 @@ This is the check that catches drift no green gate notices.
 Run this audit after any refactor that touches a locked surface's render
 path, not only at ship time — late refactors are how already-correct visuals
 regress.
-

--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -336,9 +336,10 @@ Spec:
   reads exactly like a feature nobody ever had; the point of running it at all is
   that a reader of the output sees a shipped behavior was deliberately dropped
   and by whom. The script **fails closed on a retired function whose sanction tag
-  is missing**, exactly as it does on a missing driver. Reinstating the behavior
-  deletes the absence assertion **in the `resettle` change set that moves the
-  ledger entry back to STORY**, never on its own.
+  is missing**, exactly as it does on a missing driver. Under `revise`, the
+  ledger amendment that moves the entry back to STORY also deletes the absence
+  assertion. On fallback, the `resettle` change set makes both changes. The
+  assertion is never deleted on its own.
 - **The script fails closed.** Missing browser dependencies (driver module,
   vendored assets, executable) exit nonzero — never `skip`. A skipped run exits 0,
   and a green step that executed zero stories is precisely the silent skip this

--- a/skills/ui-craft/reference/behavior-sweep.md
+++ b/skills/ui-craft/reference/behavior-sweep.md
@@ -1,17 +1,24 @@
 # Mode: behavior-sweep
 
-Sweep a locked surface's **interactive behavior** into a contract before anyone
-builds it. Runs after `lock`, before `build`, for any surface that has
-behavior — handlers, gestures, hover states, keyboard paths, resize response.
-Its one backward-looking pass, the **predecessor inventory** (§2), runs *before*
-the lock closes instead; `lock.md` §9 gates on it and argues the ordering.
+Sweep a surface's **interactive behavior** into a contract before design changes
+it. It has two routes:
 
-The lock manifest describes what the surface *looks like*. It reliably fails to
-describe what the surface *does*: a drag that only works from an edge, a
-readout that latches on chart hover, an inspector that re-scopes with selection.
-Those behaviors are in the mock's code and nowhere in the manifest, so a build
-invents them. The behavior ledger closes that gap; the replay script keeps it
-closed.
+- **`revise` (default for a shipped surface):** inventory and exercise the base
+  app before the design conversation. The ledger plus its app-only replay script
+  is the frozen contract; no lock manifest exists.
+- **`lock` fallback or legacy lock:** sweep the locked mock after `lock`, before
+  `build`. Its one backward-looking pass, the **predecessor inventory** (§2),
+  runs before the lock closes; `lock.md` §9 gates on it.
+
+Both routes cover handlers, gestures, hover states, keyboard paths and resize
+response. Unless a section says otherwise, “target” below means the base app for
+`revise` and the locked mock for the fallback route.
+
+A lock manifest describes what a mock *looks like*, but reliably fails to
+describe what it *does*. A shipping app has the opposite advantage: preserving
+it is the default, and a deletion appears in the branch diff. In both routes the
+behavior ledger makes the executable contract explicit; the replay script keeps
+it closed.
 
 Two root failures this mode exists to make impossible, one per direction:
 
@@ -21,11 +28,12 @@ Two root failures this mode exists to make impossible, one per direction:
 > Something dropped the predecessor's behavior, and no checker was looking in
 > that direction.
 
-Input: the ★ LOCKED mockup(s), `mockups/<surface>.lock.md`, every module the
-mock imports, and — where the surface replaces something — the **predecessor's
-own source and running build** (§2). `<surface>` is always the **basename of the
-lock manifest** — every artifact below inherits that one name. No agent picks a
-nickname.
+Input for `revise`: the base app's source and running build at the recorded SHA,
+plus any existing ledger and replay script. Input for fallback: the ★ LOCKED
+mockup(s), `mockups/<surface>.lock.md`, every imported module, and the
+predecessor's own source and running build (§2). On fallback, `<surface>` is the
+basename of the lock manifest. Under `revise`, it is the stable surface name
+already used by `mockups/INDEX.md` or the app route. No agent picks a nickname.
 
 **Proportionality.** Sweep depth scales with the handler inventory: a surface
 whose inventory fits on one screen may fold the passes below into a single
@@ -35,7 +43,7 @@ any size.
 
 ## 1. Inventory (static — this is not evidence)
 
-Enumerate every behavior the mock registers:
+Enumerate every behavior the target registers:
 
 - `addEventListener` calls (click, mousedown/move/up, keydown, resize, …);
 - chart/graphics-library instance handlers (e.g. an ECharts `on()` /
@@ -44,17 +52,17 @@ Enumerate every behavior the mock registers:
 - inline `on*=` attributes;
 - CSS that *encodes behavior* — `:hover`, `:focus`, `:active`, transitions.
 
-**Including handlers registered inside imported modules**, which the host HTML
+**Including handlers registered inside imported modules**, which the host module
 never shows. A chart module that installs four instance handlers when given an
 `onHover` callback is four inventory rows; missing them is how a latched readout
 gets reinvented.
 
-**Excluded by name:** mock-harness chrome — the theme toggle, the mock bar, the
-variant switcher — is not the surface's behavior and never enters the inventory
-or the contract. Name the excluded file(s) explicitly in the ledger header.
-Excluded from the inventory is **not** excluded from the page: the harness and
-every imported module are still **served**, because an unserved import throws
-before any listener registers.
+On the fallback route, **exclude mock-harness chrome by name** — the theme
+toggle, mock bar and variant switcher are not surface behavior. Name the excluded
+files in the ledger header. Excluded from the inventory is not excluded from the
+page: the harness and every imported module are still served, because an
+unserved import throws before any listener registers. `revise` has no mock
+harness exclusion; chrome the app ships is behavior like anything else.
 
 **The exclusion is by purpose, not by position.** Chrome that exists to serve
 the mockup is out; chrome that ships to the reader is in, however the mock came
@@ -89,7 +97,14 @@ passed. Each story replayed one view, alone, where a uniform offset is invisible
 
 Static reading produces the inventory. It never produces a story.
 
-## 2. Predecessor inventory (static + live — the diff run backwards)
+## 2. Predecessor inventory (fallback and legacy locks only)
+
+`revise` does not run this mock-to-predecessor diff: its target is the base app
+itself, so §1 and §3 inventory the shipped behavior directly. This section is
+the retained fallback when `revise` cannot safely start the app, and the repair
+path for locks that predate `revise`. Fallback never authorizes an app start. If
+no separately declared safe harness can supply the live predecessor, keep every
+unexercised row as QUESTION; do not convert static reading into evidence.
 
 §1 inventories the mock, and **a mock-side inventory cannot see an absence**. A
 behavior the mock never implemented registers no handler, so it produces no row;
@@ -244,29 +259,29 @@ build decision and not a bug fix — see `resettle.md`.
 
 ## 3. Exercise (live — this is the evidence)
 
-Drive the mock in a **real browser engine at the lock's viewport** — viewport set
-explicitly, never a driver default. Perform each behavior for real: hover every
-hoverable, drag from inside an element *and* from its edges, click every control,
-run every keyboard path (Esc, arrows, Tab), resize. Verify in a second engine
-when the behavior is rendering-sensitive.
+Drive the target in a **real browser engine at an explicitly recorded viewport**
+— the lock's viewport on fallback, never a driver default. Perform each behavior
+for real: hover every hoverable, drag from inside an element *and* from its
+edges, click every control, run every keyboard path (Esc, arrows, Tab), resize.
+Verify in a second engine when the behavior is rendering-sensitive.
 
 Two further passes, folded in or run separately per proportionality:
 
-- **Data pass.** Load the mock on *each* authorized fixture, including the
+- **Data pass.** Load the target on *each* authorized fixture, including the
   largest realistic shape the surface will actually see. Record what every
   data-dependent visual *encodes* — clustering, scoping on selection, level
   content, count shapes. A visual whose meaning disappears at real scale
   (uniform glyphs, empty scoping) is a QUESTION, not a build call: a design rule
-  is missing and that is a lock conversation.
+  is missing and must be settled in the design conversation.
 - **Content pass.** For every information surface (detail panels, headers, meta
-  rows, tags) capture the mock's **actual rendered markup and text structure**.
+  rows, tags) capture the target's **actual rendered markup and text structure**.
   The story links to markup, never to the lock term's prose — this is what makes
   "built from the description" detectable at review time.
 
 **Completeness check (mechanical, not judgment):** every inventoried handler maps
-to ≥1 story, **every §2 predecessor row carries a verdict**, and every story was
-observed live. A handler found in code but not reproducible in-browser becomes a
-QUESTION entry — never a silent skip. Handler coverage is not ledger
+to ≥1 story, every applicable §2 predecessor row carries a verdict, and every
+story was observed live. A handler found in code but not reproducible in-browser
+becomes a QUESTION entry — never a silent skip. Handler coverage is not ledger
 completeness: a surface with more than one view, or with any interaction that
 swaps content in place, also owes its invariant stories above. Record them with
 no handler named, since none exists.
@@ -276,25 +291,30 @@ no handler named, since none exists.
 Alongside the ledger, commit a replay script — `frontend/<surface>-behavior.replay.mjs`
 or the repo's equivalent path — that re-runs the sweep mechanically. Hand-driving
 is fine for discovery; a story enters the ledger only once its replay function
-passes against the mock.
+passes against the target.
 
 Spec:
 
 - **One exported async function per story**, `export const S12 = async (page) => { … }`.
-- Each function carries a `// LOCK:<surface>:<n>` tag for every lock term it
-  exercises, so manifest coverage stays greppable.
-- **Two openers, both in the script**: a *mock opener* (serves the mock root, its
-  theme CSS, vendored libraries, and a fixture stub) and an *app opener* (route
-  stubs, auth, navigation). Runnable against mock and app alike is the whole
-  point — the same function is what makes it evidence on both sides.
-- Both openers are **loud on unstubbed or missing requests**. A catch-all
+- On fallback, each function carries a `// LOCK:<surface>:<n>` tag for every lock
+  term it exercises, so manifest coverage stays greppable. Under `revise`, each
+  carries `// STORY:<surface>:<id>` for its behavior-ledger entry; there is no
+  lock term to cite.
+- **Openers follow the route.** `revise` has one app opener parameterized by the
+  server's base URL, so the same stories run against base and revision worktrees.
+  Fallback has two openers in the script: a mock opener (mock root, theme CSS,
+  vendored libraries, fixture stub) and an app opener (route stubs, auth,
+  navigation). The story functions are shared between them.
+- Every opener is **loud on unstubbed or missing requests**. A catch-all
   `200 {}` renders a build that is missing an asset and still passes.
-- Both openers **assert the rendered state equals the requested one**, so state
+- Every opener **asserts the rendered state equals the requested one**, so state
   addressability drift (a `?state=` param the mock silently ignores) is loud
   rather than a quietly identical render.
-- **Selector parity is a port obligation, not a script concern.** Replay-against-both
-  only holds if the ported markup keeps the mock's selectors; a rename that
-  breaks a replay selector is a **port defect**.
+- **On fallback, selector parity is a port obligation, not a script concern.**
+  Replay-against-both only holds if the ported markup keeps the mock's selectors;
+  a rename that breaks a replay selector is a port defect. Under `revise`, update
+  a selector only with the behavior change it represents and prove the old replay
+  failed first.
 - **Drive every story through the affordance a reader would use.** A story about
   reaching, leaving, or returning to a state is only evidence if the replay gets
   there the way a person does — clicking the control, typing in the field. Browser
@@ -304,10 +324,10 @@ Spec:
   an event view restores it" story stayed green, because the replay returned with
   `goBack()`. When a story's verb is navigational, assert the control exists and is
   visible, then use it.
-- Replay functions inherit `build.md`'s prove-red-once rule — proven against the
-  **built app** (knock the feature out) or a **scratch copy** of the mock, never
-  the ★ LOCKED mock in place. A transient edit to the contract artifact risks an
-  unrestored diff, which is the quiet deviation `resettle` exists to forbid.
+- **Prove every replay can fail once.** Under `revise`, knock the feature out on
+  the revision branch, observe the right failure, then restore it. On fallback,
+  use the built app or a scratch copy of the mock, never the ★ LOCKED mock in
+  place. A transient edit to a contract artifact risks an unrestored diff.
 - **A retired behavior gets a replay function too, and it is never silent.** The
   function asserts the absence — no grab handle in the DOM, the gesture does
   nothing — and **prints its sanction line on every run**, from a
@@ -326,7 +346,7 @@ Spec:
 - Wire the script into CI **explicitly**. Test globs discover `*.test.js`, not a
   `.replay.mjs`; a browser job that hand-lists its files gets a hand-added step in
   the same change.
-- **The mock's CI leg is temporary: it runs from lock until the surface ships, and
+- **On fallback, the mock's CI leg is temporary: it runs from lock until the surface ships, and
   then it is deleted.** While the port is being built the mock is the contract
   artifact and the `TARGET=mock` leg is what guards it; once the app-opener leg is
   green the app is the contract artifact and the mock leg guards nothing the app
@@ -345,6 +365,14 @@ Spec:
 One entry per story — and one per sanctioned retirement — in
 `mockups/<surface>.behavior.md`:
 
+Under `revise`, `source:` points to the shipping module and `evidence:` points to
+the app-only replay. Its first frozen version is a full inventory of the base
+app. Before each later revision, replay and re-inventory the base: new observed
+behavior becomes a STORY; a prior story missing from the base becomes a QUESTION
+until a named person supplies a dated, quoted sanction. Re-freeze that diff
+before design begins. This is the next-revision stale-ledger check, not automatic
+recovery.
+
 ```
 S12 · Dragging a window's edge resizes it; edges are full-height ±5px grab
       zones; Esc clears the window.
@@ -353,7 +381,7 @@ S12 · Dragging a window's edge resizes it; edges are full-height ±5px grab
   lock:     terms 6, 7, 21
   data:     any
   evidence: replay fn S12 + screenshot ref
-  status:   (build phase fills: ported | replayed-pass | replayed-fail |
+  status:   (revision/build phase fills: ported | replayed-pass | replayed-fail |
              re-settle requested)
 ```
 
@@ -371,9 +399,11 @@ R3 · Dragging in the plot body drew a custom selection window; two handles
   status:   retired (permanent)
 ```
 
-A `deferred` row is not a third block. It is a STORY like any other, naming the
-term it defers to on its `lock:` line and `app opener only` on its `evidence:`
-line, so the build's fidelity ledger can see that mock evidence was never owed.
+On fallback, a `deferred` row is not a third block. It is a STORY like any other,
+naming the term it defers to on its `lock:` line and `app opener only` on its
+`evidence:` line, so the build's fidelity ledger can see that mock evidence was
+never owed. `revise` has no `deferred` verdict because there is no manifest to
+defer to.
 
 Sweep screenshots and clips live in `mockups/sweep/<surface>/`. Register both the
 ledger and that directory in `mockups/INDEX.md`, per resettle's
@@ -389,7 +419,7 @@ the operator rules it.
 **Retired entries are permanent.** The ledger stops being a record of only what
 the surface does and becomes a record of what it does **and what it deliberately
 stopped doing**; the retired entries with their sanctions are the audit trail,
-and they stay through every later sweep, port and lock of that surface. Deleting
+and they stay through every later sweep, revision, port and lock of that surface. Deleting
 one leaves either an unrecorded reinstatement or a second undocumented
 retirement, and no way to tell which — the same illegible state the pass exists
 to prevent, arrived at from the other side.
@@ -418,7 +448,7 @@ and any fixture-set authorization the gate will need (shapes and in-band labelin
 authorized together; see the data defaults in SKILL.md's grounding rules).
 Answers are recorded inline under their QUESTION entries.
 
-**§2's verdicts get their own round, and it happens before the lock**, since
+**On fallback, §2's verdicts get their own round, and it happens before the lock**, since
 that pass does. Every row still at `missed` or at an unsanctioned `retired` goes
 in it, each stating what the predecessor did, where it was registered, and what
 the mock offers instead — a retirement is ruled there or it is not ruled at all.
@@ -435,7 +465,7 @@ down as given.
 Operator approval stamps a header line on the ledger:
 
 ```
-★ FROZEN <date> · base <sha> · generator <sha> · window <start>..<end>
+★ FROZEN <date> · base <sha> · generator <sha or n/a> · window <start>..<end or n/a>
   · fixtures <name: sha256-prefix, …>   (tripwire, not contract)
   · predecessor <ref, or "none — greenfield">   · retired <n>
 ```
@@ -450,8 +480,12 @@ Operator approval stamps a header line on the ledger:
   regeneration. A hash over data that grows daily is unreproducible tomorrow by
   construction.
 
+A `revise` header names the base app SHA and the exact safe data source even when
+no generator or time window applies. A fallback header names the predecessor ref
+as before.
+
 A `behavior.md` without the `★ FROZEN` header is a sweep in progress, not a
-contract; building against it is a blocking finding. Regenerating any pinned
+contract; revising or building against it is a blocking finding. Regenerating any pinned
 fixture after freeze requires a recorded reason under the header. **A ledger
 carrying a `missed` row cannot be frozen** — the freeze is what makes a verdict
 table binding, and freezing an undecided drop is how the retirement becomes
@@ -459,9 +493,8 @@ contract without anyone choosing it. A row annotated `ruled-elsewhere` is a
 `missed` row for that purpose: the annotation routes it, it does not decide it.
 A `deferred` row freezes like any story.
 
-**Ledger + lock manifest together are the build contract.** The manifest alone is
-insufficient, in three ways: behaviors and meanings its terms never encoded,
-terms no assertion ever exercised, and behaviors the predecessor had that neither
-artifact mentions because neither was looking backwards. The ledger's stories
-close the first; behavior replay in `build` closes the second; §2's verdicts and
-their RETIRED entries close the third.
+On fallback, **ledger + lock manifest together are the build contract**. The
+manifest alone is insufficient: the ledger's stories cover behavior and meaning,
+behavior replay in `build` exercises it, and §2's verdicts preserve predecessor
+behavior. Under `revise`, **the ledger plus its replay script is the contract**;
+the built branch is the visual artifact and no lock manifest is created.

--- a/skills/ui-craft/reference/build.md
+++ b/skills/ui-craft/reference/build.md
@@ -4,6 +4,12 @@ Implement a locked visual spec. The finish line is **every manifest term has
 evidence** — not "the gates are green". A build that passes every test while
 diverging from the lock is a failed build.
 
+This mode ports a greenfield lock or the explicitly recorded safe-start
+fallback. It does **not** revise a surface the app already ships. That work stays
+in `revise`, where the running branch is the visual artifact and the frozen
+behavior ledger plus app-only replay script is the contract. Do not manufacture a
+lock manifest or fidelity ledger for an app template in order to enter `build`.
+
 Input: the ★ LOCKED mockup(s) and `mockups/<surface>.lock.md`. If the
 manifest is missing, stop and create it first (run the manifest-extraction
 part of `lock` mode against the existing header — do not build from prose).

--- a/skills/ui-craft/reference/critique.md
+++ b/skills/ui-craft/reference/critique.md
@@ -134,7 +134,7 @@ For each issue, tag with **P0-P3 severity** (see [Issue Severity below](#issue-s
 - **[P?] What**: Name the problem clearly
 - **Why it matters**: How this hurts users or undermines goals
 - **Fix**: What to do about it (be concrete)
-- **Suggested command**: Which command could address this (ui-craft modes only: `polish` for fix passes, `audit` for measurable checks, `resettle` for locked-term changes, `document` for a missing DESIGN.md, or a targeted fix under the general invocation)
+- **Suggested command**: Which command could address this (ui-craft modes only: `revise` for shipped-surface changes, `polish` for greenfield fix passes, `audit` for measurable checks, `resettle` for locked-term changes, `document` for a missing DESIGN.md, or a targeted greenfield fix under the general invocation)
 
 #### Persona Red Flags
 > *Consult the [Personas reference](#persona-based-design-testing) below.*
@@ -236,14 +236,16 @@ List recommended commands in priority order, based on the user's answers:
 ...
 
 **Rules for recommendations**:
-- Only recommend ui-craft modes: `polish`, `audit`, `resettle`, `document`, or a targeted fix under the general invocation
+- Only recommend ui-craft modes: `revise`, `polish`, `audit`, `resettle`, `document`, or a targeted greenfield fix under the general invocation
+- Route every shipped-surface change through `revise`; `polish` and targeted fixes apply directly only to greenfield work
 - Order by the user's stated priorities first, then by impact
 - Each item's description should carry enough context that the command knows what to focus on
 - Map each Priority Issue to the appropriate command
 - Skip commands that would address zero issues
 - If the user chose a limited scope, only include items within that scope
 - If the user marked areas as off-limits, exclude commands that would touch those areas
-- End with `/ui-craft polish` as the final step if any fixes were recommended
+- End greenfield recommendations with `/ui-craft polish`; a shipped-surface set
+  stays under `/ui-craft revise` through its own review-and-land gate
 
 After presenting the summary, tell the user:
 

--- a/skills/ui-craft/reference/lock.md
+++ b/skills/ui-craft/reference/lock.md
@@ -1,8 +1,10 @@
 # Mode: lock
 
-Explore a surface as several genuinely different, repository-grounded HTML
-mockups, converge with the reviewer, and end with a **lock** that a build
-agent cannot silently drift from: a ★ LOCKED mockup plus a lock manifest.
+Explore a greenfield surface as several genuinely different,
+repository-grounded HTML mockups, converge with the reviewer, and end with a
+**lock** that a build agent cannot silently drift from: a ★ LOCKED mockup plus a
+lock manifest. A surface the app already ships uses `revise`, except for the
+explicit safe-start fallback below.
 
 ## Review mode
 
@@ -17,9 +19,28 @@ agent cannot silently drift from: a ★ LOCKED mockup plus a lock manifest.
 
 ### 0. Pre-flight — chrome ground truth (MANDATORY, before any concept work)
 
-A lock round dies at review when its chrome doesn't match the app the reviewer
-uses every day. Run these checks before the ledger, and do not fan out a
-single variant until the fidelity gate passes:
+A from-scratch mock of a shipped surface is banned. Before any concept work,
+check `mockups/INDEX.md`, the app routes and the shipping render modules. If the
+app already embodies this surface or the shell containing it, **refuse `lock`
+and name `revise`**. This is a blocking verdict, the same class as a `missed`
+predecessor behavior.
+
+There is one exception: `revise` pre-flight may have recorded that the repo has
+no dev-server declaration and routed the change here as the accepted fallback.
+That record must name the absent declaration and state that mockup plus
+predecessor inventory is weaker than app-branch iteration. A declared entrypoint
+that omits its data source is unsupported, not fallback. Without the fallback
+record, `lock` never proceeds on a shipped embodiment.
+
+The fallback does not authorize starting the app. Any live predecessor or chrome
+evidence must come through a separately declared safe harness; otherwise record
+the missing evidence and let the predecessor QUESTION gate block rather than
+guessing.
+
+On a greenfield surface, or on that recorded fallback, a lock round dies at
+review when its chrome doesn't match the app the reviewer uses every day. Run
+these checks before the ledger, and do not fan out a single variant until the
+fidelity gate passes:
 
 1. **Resolve the material ground truth for chrome.** If any locked surface has
    shipped — check `mockups/INDEX.md` for `shipped` rows and the log for port
@@ -40,7 +61,8 @@ single variant until the fidelity gate passes:
    which is ground truth — silence here is the defect that lets the next
    round anchor wrong.
 3. **Round-zero fidelity gate.** Render the empty shell/chrome (no concept
-   content) and put it beside a screenshot of the running app. Chrome —
+   content) and put it beside a screenshot of the safely running app, or an
+   operator-provided base capture on fallback. Chrome —
    ground color, fonts, control sizes, radii, bar heights — must be
    indistinguishable BEFORE variants are briefed; save the pair as evidence.
    A reviewer should never have to argue the background color mid-round.
@@ -53,9 +75,10 @@ single variant until the fidelity gate passes:
 Read `mockups/INDEX.md` (create if absent; one row per surface, columns
 Surface / Concept / Status / Issue / File). `locked` entries are binding
 precedent for adjacent surfaces; for `shipped` entries the app is ground
-truth, not old mockup markup. A `shipped` row covering this surface or the one
-it replaces is also what **triggers the predecessor pass** (§9.3) — note it here,
-where it is cheap, rather than discovering it at lock time.
+truth, not old mockup markup. On the recorded fallback path, a `shipped` row
+covering this surface or the one it replaces also **triggers the predecessor
+pass** (§9.3) — note it here, where it is cheap, rather than discovering it at
+lock time. Outside that fallback, the row triggers the refusal above.
 
 ### 2. Grounding kit
 
@@ -129,8 +152,8 @@ SKILL.md); name the first concrete element that stalls each walkthrough and
 fix it. Then run the `audit` technical checks (contrast, keyboard focus,
 overflow, target sizes) on the finalist.
 
-**Where the surface has a predecessor, run the predecessor inventory on the
-finalist here** ([behavior-sweep.md](behavior-sweep.md) §2) and take its
+**On the recorded fallback path, run the predecessor inventory on the finalist
+here** ([behavior-sweep.md](behavior-sweep.md) §2) and take its
 QUESTION round to the operator with the rest of this gate's findings. This is
 the last point at which a dropped interaction is still a design conversation
 rather than an amendment to a merged contract. The personas walk the mock and the
@@ -148,7 +171,7 @@ Locking is complete only when ALL of these exist:
    prior locks being superseded. Any contradiction is resolved *now*, by the
    user (interactive) or explicitly in the header (headless) — never left
    for the implementer to arbitrate.
-3. **The predecessor diff, wherever the surface has a predecessor.** If a
+3. **The predecessor diff on the recorded fallback or a legacy lock.** If a
    `shipped` row in `mockups/INDEX.md` covers this surface or the one it
    replaces, or a prior lock is being superseded, or the running app already
    does this job, then `behavior-sweep`'s **predecessor inventory**
@@ -186,8 +209,9 @@ app-opener replay leg green — never in a follow-up issue, which is how a surfa
 stays `locked` long after it merged. The mock, its screenshots, the manifest and
 the behavior ledger stay as the design record, and the ledger's stories keep
 running against the built app forever; post-ship hotfixes owe no mock pass and no
-mock sync, and a later `resettle` starts from the shipping app rather than a
-runnable mock.
+mock sync, and later design work starts with `revise` from the shipping app
+rather than a runnable mock. `resettle` remains only for terms in the archived
+lock.
 
 ## Lock manifest format
 

--- a/skills/ui-craft/reference/resettle.md
+++ b/skills/ui-craft/reference/resettle.md
@@ -3,6 +3,12 @@
 Amend a locked term. This is the only legitimate path for changing anything a
 lock manifest lists — including genuine improvements discovered mid-build.
 
+`revise` has no lock manifest, so behavior changes on a shipped app branch do
+not come here unless they also amend a still-binding legacy lock term. `revise`
+records added, changed and retired behavior directly in the frozen behavior
+ledger, with the same dated sanction rules. Never invent a term merely to route
+an app revision through `resettle`.
+
 A re-settle is sanctioned by the user (interactive) or, in headless runs, by
 an explicit instruction in the work order. An agent may *propose* one at any
 time; it may never *apply* one on its own judgment.

--- a/skills/ui-craft/reference/revise.md
+++ b/skills/ui-craft/reference/revise.md
@@ -1,0 +1,196 @@
+# Mode: revise
+
+Revise a surface the app already ships by changing the running app on a branch.
+**Never rebuild that surface as a from-scratch mock.** In the app, a behavior
+survives unless the diff deletes it; in a mock, absence has no representation.
+
+The contract is the surface's frozen **behavior ledger** plus its replay script,
+run against the built app. The branch is the visual artifact. Review screenshots
+record what changed, but no lock manifest or fidelity ledger is pinned to an app
+template.
+
+This mode is for a shipped embodiment of the surface, including a new view inside
+a shell that already ships. A wholly greenfield surface uses `lock`.
+
+## Route map
+
+- [Review mode](#review-mode)
+- [0. Prove the app is safe to start](#0-prove-the-app-is-safe-to-start)
+- [1. Establish the base](#1-establish-the-base)
+- [2. Freeze shipped behavior before design](#2-freeze-shipped-behavior-before-design)
+- [3. Choose convergent or divergent work](#3-choose-convergent-or-divergent-work)
+- [4. Iterate the running app](#4-iterate-the-running-app)
+- [5. Review and land](#5-review-and-land)
+
+## Review mode
+
+- **Interactive:** the human and agent may explore divergent wireframes together,
+  then iterate the app branch live.
+- **Headless (AgentFlow):** go straight to an app branch. Never start a divergent
+  wireframe phase for a surface whose shell ships. If the work cannot be settled
+  without that conversation, stop and return the decision rather than inventing
+  it.
+
+## 0. Prove the app is safe to start
+
+Read the repo's `CLAUDE.md` / `AGENTS.md` before running any server. App-branch
+iteration is allowed only when that file declares:
+
+1. the exact safe dev-server entrypoint; and
+2. the data source that entrypoint reads.
+
+Resolve the named source before starting the process. For `revise`, it must be a
+manufactured fixture or synthetic database. A command that may read real,
+production or authoritative data, fetch from a vendor, select a database
+implicitly, or leave the source ambiguous is unsafe. **Do not run it to discover
+what it does.** This mode's stricter risk contract overrides any repo-scoped
+real-data inversion used for other evidence.
+
+Record the declaration path, quoted command, named data source, and source
+provenance in the change's decision record.
+
+- **No dev-server declaration:** record the accepted fallback and run
+  `lock`'s mockup flow plus `behavior-sweep`'s predecessor inventory. This is the
+  only path by which `lock` may accept a shipped surface. The record says that
+  the result is weaker because absence is visible only through the predecessor
+  pass. Fallback does not authorize starting the app; any live predecessor
+  evidence must already satisfy a separately declared safe harness.
+- **The app cannot run locally at all, or a declared entrypoint names no data
+  source:** `revise` is unsupported. Do not start the app and do not improvise a
+  new entrypoint. An incomplete declaration is not the same as no declaration.
+- **The declaration is ambiguous:** stop. Ambiguity is not permission and is
+  never resolved by a trial run.
+
+## 1. Establish the base
+
+Fetch the default branch, branch or create a worktree from its exact tip, and
+record the base SHA. The revision changes the real app in place; never build a
+duplicate route that carries a second implementation of the surface.
+
+When live before/after comparison matters, use `spin-worktree` to serve the base
+branch from a second worktree. Give the two servers distinct ports and the same
+safe data bytes. A second route inside the revision branch is not a comparison:
+it duplicates the surface and can drift with it.
+
+Capture the base surface at every state, viewport and theme the change may touch.
+Screenshots stay in the change's decision record or its external review evidence;
+sensitive renders obey SKILL.md's publish rules.
+
+## 2. Freeze shipped behavior before design
+
+Run `behavior-sweep` against the **base app**, before discussing a replacement
+layout or writing a wireframe. On the surface's first revision, make one full
+source-and-live inventory and freeze it as:
+
+- `mockups/<surface>.behavior.md`; and
+- `frontend/<surface>-behavior.replay.mjs`, or the repo's equivalent test path.
+
+The directory name does not turn the ledger into a mock: no mock artifact exists
+on this path. The replay script has an app opener only and runs every story
+against the built app. Create `mockups/INDEX.md` if absent and register the
+shipped surface, ledger and replay path there.
+
+On every later revision:
+
+1. replay the frozen ledger against the base app;
+2. inventory the base source and live surface again;
+3. diff the observed inventory against the ledger; and
+4. amend and re-freeze the ledger before design.
+
+New shipped behavior becomes a STORY with a replay function. A ledger story no
+longer present on the base is an unsanctioned retirement until a named person
+rules it with the date and their quoted reason. This is how a stale inventory is
+caught at the next revision rather than silently trusted.
+
+No design conversation starts while a story is unreplayable, an observed
+behavior has no story, or a retirement lacks its sanction. The QUESTION round in
+`behavior-sweep` owns those decisions.
+
+## 3. Choose convergent or divergent work
+
+**Convergent work** changes the app branch directly: refinements within the
+shipping surface's current information and interaction model, or a direction the
+work order has already settled.
+
+**Divergent work** may use throwaway wireframes, including for a new view inside
+the shipping shell, under all of these constraints:
+
+- human and agent work the wireframe together; it is never an unattended phase;
+- it lives in the change's own decision record — its OpenSpec change folder when
+  the repo uses OpenSpec, otherwise `docs/scope/<slug>/`;
+- it never lives in `mockups/`;
+- it says `WIREFRAME — NO FIDELITY CLAIM — NOT LOCKABLE` at its top;
+- it may explore structure and interaction, but makes no claim to match the app;
+  and
+- the runnable wireframe is deleted when the change lands. Only screenshots and
+  the decisions they evidence survive.
+
+Do not run `lock` on the wireframe, produce a lock manifest for it, or cite it as
+fidelity evidence. A wireframe is a conversation aid, not a second surface.
+
+When the decisions settle, lift them into the app branch or worktree and continue
+there. Re-run the behavior sweep against the base app immediately before the
+lift, so the branch starts from a fresh frozen contract.
+
+## 4. Iterate the running app
+
+Serve the revision branch through the declared safe entrypoint and inspect it in
+a real browser. Use the app's shipping tokens, components, chart library and data
+shape; do not translate the wireframe's temporary styling into a new design
+system.
+
+Work in short, reviewable rounds:
+
+1. change the app branch;
+2. replay every frozen story against the built app;
+3. render the affected states, viewports and themes;
+4. compare them with the base-worktree renders; and
+5. take the running branch to the human for the next decision in interactive
+   mode.
+
+The replay must report its applicable story count. Zero stories, a missing
+driver, an unstubbed request, or a story that does not reach the requested state
+is failure, never skip.
+
+### Behavior changes
+
+- **Preserved:** the existing story and replay function stay green.
+- **Added:** add a STORY and replay function in the same change.
+- **Changed:** amend the STORY, record the dated decision under the frozen
+  header, and prove the old replay fails before the new one passes.
+- **Retired:** require `sanction: <person> · <date> · "<their reason>"`, retain a
+  permanent RETIRED entry, and replace the positive replay with an absence
+  assertion that prints the sanction on every run.
+
+A dropped or changed behavior without that record blocks the revision. There is
+no lock term to `resettle`; the ledger amendment is the decision record.
+
+## 5. Review and land
+
+The PR evidence includes:
+
+- the frozen behavior ledger, with the base SHA and data provenance;
+- raw replay output against the built revision, including the story count and
+  every retirement sanction;
+- before/after renders from the base and revision worktrees for every affected
+  state, viewport and theme; and
+- the decision-record screenshots for any divergent wireframe, with the
+  wireframe itself deleted.
+
+Review the running app, not source alone. Run the repo persona sweep when one
+exists, then `audit` and `polish` against the revision branch. A visual change is
+judged against the stated decision and the before/after renders; it does not
+invent a lock manifest after the fact.
+
+Before landing, confirm:
+
+- every frozen story replayed against the built app;
+- every added or changed behavior is represented in the ledger;
+- every retirement has a dated, named, quoted sanction and a loud absence test;
+- no wireframe or duplicated comparison route survives; and
+- the safe-start declaration and exact data source still match what produced the
+  evidence.
+
+The updated ledger and replay script run against the app from then on. A later
+change made outside `revise` is not repaired automatically; the next revision's
+base diff exposes it.

--- a/skills/ui-craft/scripts/route.mjs
+++ b/skills/ui-craft/scripts/route.mjs
@@ -1,14 +1,23 @@
 const VALID_EMBODIMENTS = new Set(['greenfield', 'shipped']);
 const VALID_DECLARATIONS = new Set(['absent', 'complete', 'incomplete', 'ambiguous']);
+const VALID_RUNNABILITY = new Set(['runnable', 'unavailable']);
 const SAFE_DATA_SOURCES = new Set(['manufactured', 'synthetic']);
 
-export function routeSurface({ embodiment, declaration, dataSource }) {
+export function routeSurface({ embodiment, runnability, declaration, dataSource }) {
   if (!VALID_EMBODIMENTS.has(embodiment)) {
     return refusal('embodiment must be greenfield or shipped');
   }
 
   if (embodiment === 'greenfield') {
     return { mode: 'lock', reason: 'the app has no shipped embodiment' };
+  }
+
+  if (!VALID_RUNNABILITY.has(runnability)) {
+    return refusal('runnability must be runnable or unavailable');
+  }
+
+  if (runnability === 'unavailable') {
+    return refusal('revise is unsupported when the app cannot run locally');
   }
 
   if (!VALID_DECLARATIONS.has(declaration)) {
@@ -43,12 +52,13 @@ function parseArgs(argv) {
     const flag = argv[index];
     const value = argv[index + 1];
     if (!flag?.startsWith('--') || value === undefined) {
-      throw new Error('usage: route.mjs --embodiment <greenfield|shipped> --declaration <absent|complete|incomplete|ambiguous> --data-source <manufactured|synthetic|unknown>');
+      throw new Error('usage: route.mjs --embodiment <greenfield|shipped> --runnability <runnable|unavailable> --declaration <absent|complete|incomplete|ambiguous> --data-source <manufactured|synthetic|unknown>');
     }
     parsed[flag.slice(2)] = value;
   }
   return {
     embodiment: parsed.embodiment,
+    runnability: parsed.runnability,
     declaration: parsed.declaration,
     dataSource: parsed['data-source'],
   };

--- a/skills/ui-craft/scripts/route.mjs
+++ b/skills/ui-craft/scripts/route.mjs
@@ -1,0 +1,66 @@
+const VALID_EMBODIMENTS = new Set(['greenfield', 'shipped']);
+const VALID_DECLARATIONS = new Set(['absent', 'complete', 'incomplete', 'ambiguous']);
+const SAFE_DATA_SOURCES = new Set(['manufactured', 'synthetic']);
+
+export function routeSurface({ embodiment, declaration, dataSource }) {
+  if (!VALID_EMBODIMENTS.has(embodiment)) {
+    return refusal('embodiment must be greenfield or shipped');
+  }
+
+  if (embodiment === 'greenfield') {
+    return { mode: 'lock', reason: 'the app has no shipped embodiment' };
+  }
+
+  if (!VALID_DECLARATIONS.has(declaration)) {
+    return refusal('declaration must be absent, complete, incomplete, or ambiguous');
+  }
+
+  if (declaration === 'absent') {
+    return {
+      mode: 'lock-fallback',
+      reason: 'no dev-server declaration; record the weaker predecessor fallback',
+    };
+  }
+
+  if (declaration !== 'complete') {
+    return refusal('the declared entrypoint is incomplete or ambiguous');
+  }
+
+  if (!SAFE_DATA_SOURCES.has(dataSource)) {
+    return refusal('revise requires a manufactured fixture or synthetic database');
+  }
+
+  return { mode: 'revise', reason: `safe ${dataSource} data source declared` };
+}
+
+function refusal(reason) {
+  return { mode: 'refuse', reason };
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith('--') || value === undefined) {
+      throw new Error('usage: route.mjs --embodiment <greenfield|shipped> --declaration <absent|complete|incomplete|ambiguous> --data-source <manufactured|synthetic|unknown>');
+    }
+    parsed[flag.slice(2)] = value;
+  }
+  return {
+    embodiment: parsed.embodiment,
+    declaration: parsed.declaration,
+    dataSource: parsed['data-source'],
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const result = routeSurface(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (result.mode === 'refuse') process.exitCode = 2;
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -23,9 +23,10 @@ ROOT = Path(__file__).resolve().parents[1]
 CBM_SCRIPT = ROOT / "skills" / "cbm-onboard" / "scripts" / "cbm-onboard.sh"
 SPIN_SCRIPT = ROOT / "skills" / "spin-worktree" / "scripts" / "spin-worktree.py"
 CODEX_WORKER = ROOT / "skills" / "orchestrate" / "scripts" / "codex-worker.py"
-UI_CRAFT_SKILL = ROOT / "skills" / "ui-craft" / "SKILL.md"
 UI_CRAFT_AUDIT = ROOT / "skills" / "ui-craft" / "reference" / "audit.md"
+UI_CRAFT_CRITIQUE = ROOT / "skills" / "ui-craft" / "reference" / "critique.md"
 UI_CRAFT_SWEEP = ROOT / "skills" / "ui-craft" / "reference" / "behavior-sweep.md"
+UI_CRAFT_ROUTE = ROOT / "skills" / "ui-craft" / "scripts" / "route.mjs"
 README = ROOT / "README.md"
 BEGIN_IGNORE = "# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
 BEGIN_HOOK = "# >>> cbm-onboard managed reindex >>>"
@@ -163,14 +164,40 @@ class CbmOnboardTests(unittest.TestCase):
 
 class UiCraftContractTests(unittest.TestCase):
     def test_shipped_surface_routing_contract_is_closed(self):
-        skill = UI_CRAFT_SKILL.read_text(encoding="utf-8")
         audit = UI_CRAFT_AUDIT.read_text(encoding="utf-8")
+        critique = UI_CRAFT_CRITIQUE.read_text(encoding="utf-8")
         sweep = UI_CRAFT_SWEEP.read_text(encoding="utf-8")
         readme = README.read_text(encoding="utf-8")
 
-        self.assertIn("surface → `revise`", skill)
-        self.assertIn("shipped surface → `revise`-then-fix", skill)
+        cases = (
+            (("greenfield", "absent", "unknown"), 0, "lock"),
+            (("shipped", "complete", "synthetic"), 0, "revise"),
+            (("shipped", "complete", "manufactured"), 0, "revise"),
+            (("shipped", "absent", "unknown"), 0, "lock-fallback"),
+            (("shipped", "incomplete", "unknown"), 2, "refuse"),
+            (("shipped", "ambiguous", "unknown"), 2, "refuse"),
+            (("shipped", "complete", "real"), 2, "refuse"),
+        )
+        for arguments, exit_code, mode in cases:
+            with self.subTest(arguments=arguments):
+                result = run(
+                    [
+                        "node",
+                        str(UI_CRAFT_ROUTE),
+                        "--embodiment",
+                        arguments[0],
+                        "--declaration",
+                        arguments[1],
+                        "--data-source",
+                        arguments[2],
+                    ],
+                    cwd=ROOT,
+                )
+                self.assertEqual(result.returncode, exit_code, result.stderr)
+                self.assertEqual(json.loads(result.stdout)["mode"], mode)
+
         self.assertIn("`revise` for shipped-surface changes", audit)
+        self.assertIn("Route every shipped-surface change through `revise`", critique)
         self.assertRegex(sweep, r"Under `revise`, the\s+ledger amendment")
         self.assertIn("--skill spin-worktree", readme)
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -23,6 +23,10 @@ ROOT = Path(__file__).resolve().parents[1]
 CBM_SCRIPT = ROOT / "skills" / "cbm-onboard" / "scripts" / "cbm-onboard.sh"
 SPIN_SCRIPT = ROOT / "skills" / "spin-worktree" / "scripts" / "spin-worktree.py"
 CODEX_WORKER = ROOT / "skills" / "orchestrate" / "scripts" / "codex-worker.py"
+UI_CRAFT_SKILL = ROOT / "skills" / "ui-craft" / "SKILL.md"
+UI_CRAFT_AUDIT = ROOT / "skills" / "ui-craft" / "reference" / "audit.md"
+UI_CRAFT_SWEEP = ROOT / "skills" / "ui-craft" / "reference" / "behavior-sweep.md"
+README = ROOT / "README.md"
 BEGIN_IGNORE = "# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
 BEGIN_HOOK = "# >>> cbm-onboard managed reindex >>>"
 
@@ -104,7 +108,6 @@ class CbmOnboardTests(unittest.TestCase):
             "#!/bin/sh\nexit 0\n",
         )
         self.assertFalse((self.repo / ".git" / "hooks" / "post-commit").exists())
-
     def test_preserves_unmatched_markers_foreign_hook_and_is_idempotent(self):
         run(
             ["git", "config", "core.hooksPath", ".custom-hooks"],
@@ -156,6 +159,20 @@ class CbmOnboardTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("SKIP hook installation", result.stderr)
         self.assertEqual(hook.read_text(encoding="utf-8"), original)
+
+
+class UiCraftContractTests(unittest.TestCase):
+    def test_shipped_surface_routing_contract_is_closed(self):
+        skill = UI_CRAFT_SKILL.read_text(encoding="utf-8")
+        audit = UI_CRAFT_AUDIT.read_text(encoding="utf-8")
+        sweep = UI_CRAFT_SWEEP.read_text(encoding="utf-8")
+        readme = README.read_text(encoding="utf-8")
+
+        self.assertIn("surface → `revise`", skill)
+        self.assertIn("shipped surface → `revise`-then-fix", skill)
+        self.assertIn("`revise` for shipped-surface changes", audit)
+        self.assertRegex(sweep, r"Under `revise`, the\s+ledger amendment")
+        self.assertIn("--skill spin-worktree", readme)
 
 
 class SpinWorktreeTests(unittest.TestCase):

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -170,13 +170,14 @@ class UiCraftContractTests(unittest.TestCase):
         readme = README.read_text(encoding="utf-8")
 
         cases = (
-            (("greenfield", "absent", "unknown"), 0, "lock"),
-            (("shipped", "complete", "synthetic"), 0, "revise"),
-            (("shipped", "complete", "manufactured"), 0, "revise"),
-            (("shipped", "absent", "unknown"), 0, "lock-fallback"),
-            (("shipped", "incomplete", "unknown"), 2, "refuse"),
-            (("shipped", "ambiguous", "unknown"), 2, "refuse"),
-            (("shipped", "complete", "real"), 2, "refuse"),
+            (("greenfield", "unavailable", "absent", "unknown"), 0, "lock"),
+            (("shipped", "runnable", "complete", "synthetic"), 0, "revise"),
+            (("shipped", "runnable", "complete", "manufactured"), 0, "revise"),
+            (("shipped", "runnable", "absent", "unknown"), 0, "lock-fallback"),
+            (("shipped", "runnable", "incomplete", "unknown"), 2, "refuse"),
+            (("shipped", "runnable", "ambiguous", "unknown"), 2, "refuse"),
+            (("shipped", "runnable", "complete", "real"), 2, "refuse"),
+            (("shipped", "unavailable", "complete", "synthetic"), 2, "refuse"),
         )
         for arguments, exit_code, mode in cases:
             with self.subTest(arguments=arguments):
@@ -186,10 +187,12 @@ class UiCraftContractTests(unittest.TestCase):
                         str(UI_CRAFT_ROUTE),
                         "--embodiment",
                         arguments[0],
-                        "--declaration",
+                        "--runnability",
                         arguments[1],
-                        "--data-source",
+                        "--declaration",
                         arguments[2],
+                        "--data-source",
+                        arguments[3],
                     ],
                     cwd=ROOT,
                 )


### PR DESCRIPTION
## Summary

- add `ui-craft revise` for changing a shipped surface by iterating the running app on a branch
- route requests about existing shipped UI into revise and refuse to proceed when the surface has no runnable start path
- keep the lock, predecessor ledger, behavior sweep, revision evidence, and resettling lifecycle consistent with the existing UI craft vocabulary

## Why

The lifecycle covered designing, building, critiquing, and auditing surfaces, but it had no explicit path for revising an application that already exists. That gap encouraged agents to rebuild a mock from scratch or treat a shipped-surface change as an ungoverned implementation pass.

Revise now starts from the running product, preserves settled decisions and predecessor sanctions, and requires evidence against the actual application before the change is handed to review.

## Impact

Agents can invoke one mode for shipped UI changes and get a bounded workflow that inspects the branch, starts the declared app safely, inventories prior evidence, locks the revision, iterates the real surface, and records convergence. Requests that cannot name a runnable shipped surface fail closed instead of being misrouted into speculative UI work.

## What to check

- shipped-surface requests select revise, while new-surface requests still select the existing design/build modes
- revise never substitutes a fresh mock for the running application
- prior lock terms and behavior rows remain governed through predecessor rulings and resettling
- the workflow refuses an unrunnable target before claiming revision evidence

## Real-app evidence

The first complete revise run is recorded in Harmonic’s [frozen finding-to-evidence behavior ledger](https://github.com/harmonichq/harmonic/blob/main/mockups/finding-evidence-routing.behavior.md).

The declared synthetic no-fetch server reached `/health`, and the [raw real-server behavior-ledger job](https://github.com/harmonichq/harmonic/actions/runs/32301094183/job/96223604085) completed with:

```text
ok S01
ok S02
ok S03
ok S04
ok S05
ok S06
ok S07
ok S08
ok S09
ok S10
ok S11
ok S12
ok S13
ok S14
ok S15
ok S16
ok S17
ok S18
ok S19
ok S20
ok S21
ok S22
ok S23
ok S24
ok S25
ok S26 — RETIRED — Connor Griffin · 2026-08-19 · "Decided by Connor Griffin in a ruling session on 2026-08-19."
ok D1
ok D2
ok D3

app: 29 of 29 stories passed
```

Harmonic’s pre-existing fixture-backed browser contract was repaired separately in draft [harmonichq/harmonic#51](https://github.com/harmonichq/harmonic/pull/51). Its backend, frontend, fixture-backed Diagnose suite, real-server behavior ledger, all other browser legs, and aggregate browser gate are green.

## Validation

- structural validator: 23 skills / 227 files
- behavior and PR-body gate: 199 passed, 23 skipped
- push gate: 4 commits DCO-compliant

Closes #48.