### PR TITLE
ticket: carry agentflow's brief, review-disposition, and mergeability rules

### DIFF
--- a/skills/drivers/ticket/references/brief-quality.md
+++ b/skills/drivers/ticket/references/brief-quality.md
@@ -1,0 +1,12 @@
+# Brief quality
+
+Apply this checklist while drafting the work order. It sharpens the order; it does
+not add an issue-body rewrite.
+
+* Separate verified facts, each with its evidence, from intent or assumptions.
+* State current behavior separately from desired behavior.
+* Name the key interfaces and traps the implementer must explore or preserve.
+* Describe the caller-facing interface shape, or say that the change is internal
+  to an existing interface.
+* Make every Done when criterion observable and regression-proof.
+* State explicit out-of-scope work in Boundaries.

--- a/skills/drivers/ticket/references/review-actions.md
+++ b/skills/drivers/ticket/references/review-actions.md
@@ -1,0 +1,12 @@
+# Review actions
+
+Ground each finding before choosing exactly one disposition.
+
+* **Fix before completion.** It breaks the work order; fix and verify it in this
+  pull request.
+* **Necessary follow-up.** It is real but outside the order; file a ticket with
+  evidence, desired outcome, and a checked duplicate search. Keep it out of this
+  pull request.
+* **Ask the maintainer.** A real choice remains; surface it before editing.
+* **Discard as preference.** It is unsupported reviewer taste; make no change and
+  say why in the reply.

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -52,6 +52,10 @@ of either shape carries a `Review depth:` line
 
 ## Work order
 
+Before filling either shape, apply
+[brief quality](../references/brief-quality.md). It is a drafting checklist, not
+an extra ticket-comment format.
+
 ```
 WORK ORDER <ticket-id>: <ticket summary>
 Open as: <model> / <effort>.

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -37,25 +37,33 @@ long ago and the pull request is one diff.
    checks, and any new verification output CI posted. List them before touching
    code.
 
-5. **Judge, then fix.** For each item: fix it, or push back with a reasoned reply.
-   Never silently ignore one. What blocks is what breaks the order's Done when
-   clause; [references/review-depth.md](../references/review-depth.md) governs that
-   call, and the order's stamped depth (Full when any chunk was Full) sets how far
-   to look. Scope discipline: a review comment that expands scope beyond the work
-   order gets a reply naming it out of scope and, if it is real, a suggestion to
-   file a ticket. The order is still the contract.
+5. **Judge, then fix.** Ground every item and classify it with
+   [references/review-actions.md](../references/review-actions.md). Never silently
+   ignore one. What blocks is what breaks the order's Done when clause;
+   [references/review-depth.md](../references/review-depth.md) governs that call,
+   and the order's stamped depth (Full when any chunk was Full) sets how far to
+   look. The order is still the contract.
 
-6. **Re-verify.** Re-run the order's verification command after changes, same rules
-   as `start`: the output must match the order's expectation. Re-read the repo's
-   `AGENTS.md` or `CLAUDE.md` and audit the changes you are about to push against
-   it, including any completion checklist it defines. Fix violations before pushing.
+6. **Refresh mergeability.** Before handing the pull request back for human merge,
+   `git fetch origin`, refresh `baseRefName` and `mergeStateStatus` with `gh pr
+   view`, then rebase once onto `origin/<baseRefName>`. Do not retry the rebase. If
+   GitHub reports a conflict or the rebase has a semantic conflict you cannot
+   resolve safely, abort it and stop; surface the conflict to the human rather than
+   force a resolution.
 
-7. **Push and respond.** Push to the same branch. Reply to each addressed comment on
+7. **Re-verify and re-review.** Re-run the order's verification command after the
+   changes and rebase, same rules as `start`: the output must match the order's
+   expectation. Re-read the repo's `AGENTS.md` or `CLAUDE.md` and audit the changes
+   you are about to push against it, including any completion checklist it defines.
+   Fix violations, then run `/review` at the order's stamped review depth. Fix
+   confirmed findings and repeat verification if code changed.
+
+8. **Push and respond.** Push to the same branch. Reply to each addressed comment on
    the pull request, resolving or answering it. Update the repo's change record if
    its checklist moved, and update its decision record if a decision changed during
    review.
 
-8. **Status.** Comment on the ticket (attribution first) only if the round
+9. **Status.** Comment on the ticket (attribution first) only if the round
    materially changed the plan. Routine fix-and-push rounds need no ticket comment.
 
 ## Refusals

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -72,10 +72,11 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    diff against the order, the other against the repo's documented conventions. Run
    it at the order's stamped `Review depth:`, reading
    [references/review-depth.md](../references/review-depth.md) for what each depth
-   checks and what counts as blocking. Fix confirmed findings, re-run the
-   verification loop if code changed, then review once more. Two rounds maximum;
-   findings still open after round two go into the pull request body as known
-   issues, never silently dropped.
+   checks and what counts as blocking. Classify every grounded finding with
+   [references/review-actions.md](../references/review-actions.md). Fix confirmed
+   findings, re-run the verification loop if code changed, then review once more.
+   Two rounds maximum; findings still open after round two go into the pull request
+   body as known issues, never silently dropped.
 
 10. **Fold the change record into the baseline in the order's last pull request.**
     When the pull request being opened is the order's final one (single-pull-request

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -121,7 +121,8 @@ scope and spec documents committed in that worktree.
    its sensitivity floor first; the floor overrides any judgment about how small
    the change looks.
 
-10. **Draft the work order.** Fill
+10. **Draft the work order.** Apply
+    [references/brief-quality.md](../references/brief-quality.md), then fill
     [templates/work-order.md](../templates/work-order.md), the flat shape or the
     chunked shape per step 8, and run that page's two authoring checks before the
     draft leaves this step. Each fenced block must be self-sufficient for a fresh

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 TICKET_SCRIPT = ROOT / "skills" / "drivers" / "ticket" / "scripts" / "ticket.py"
+TICKET_DIRECTORY = ROOT / "skills" / "drivers" / "ticket"
 
 
 def run(command: list[str], *, cwd: Path, env: Optional[dict[str, str]] = None):
@@ -62,6 +63,38 @@ def assistant_line(
             },
         }
     )
+
+
+class TicketSkillContractTests(unittest.TestCase):
+    def test_triage_requires_the_brief_quality_checklist(self):
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
+        checklist = TICKET_DIRECTORY / "references" / "brief-quality.md"
+
+        self.assertTrue(checklist.is_file())
+        self.assertIn("[references/brief-quality.md](../references/brief-quality.md)", triage)
+
+    def test_revise_requires_the_four_review_action_dispositions(self):
+        revise = (TICKET_DIRECTORY / "verbs" / "revise.md").read_text(encoding="utf-8")
+        actions = (TICKET_DIRECTORY / "references" / "review-actions.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("[references/review-actions.md](../references/review-actions.md)", revise)
+        for disposition in (
+            "Fix before completion",
+            "Necessary follow-up",
+            "Ask the maintainer",
+            "Discard as preference",
+        ):
+            self.assertIn(disposition, actions)
+
+    def test_revise_requires_a_base_currency_and_mergeability_refresh(self):
+        revise = (TICKET_DIRECTORY / "verbs" / "revise.md").read_text(encoding="utf-8")
+
+        self.assertIn("mergeStateStatus", revise)
+        self.assertIn("rebase once", revise)
+        self.assertIn("stamped review depth", revise)
+        self.assertIn("semantic conflict", revise)
 
 
 class TicketTelemetryTests(unittest.TestCase):


### PR DESCRIPTION
The agentflow daemon is being retired, so the process it ran unattended now runs interactively through
`ticket`. Most of that process was already here. Three things were not, and all three are worth keeping
without a daemon behind them.

**A work order now has to separate what was verified from what was intended.** The order template asked for
Context / Do / Done when, which lets an assumption ride into execution dressed as a fact. A drafting checklist
(`references/brief-quality.md`) now asks triage to split verified facts from intent, current behavior from
desired, name the interfaces and traps the implementer must not break, describe the caller-facing shape, and
state out-of-scope explicitly. It sharpens the order; it does not add a second comment format.

**A review finding now gets one of four dispositions instead of "fix it or push back".** Fix before completion,
file a necessary follow-up, ask the maintainer, or discard as reviewer preference. The two middle ones are the
point: a real finding outside the order becomes a filed ticket rather than silent scope creep, and a genuine
choice reaches the human instead of being decided by the agent. `revise` and `start` both classify this way.

**`revise` refreshes mergeability before handing the pull request back.** It fetches, rebases once onto the
pull request's own base, re-runs verification and the stamped review depth, and stops if GitHub reports a
conflict or the rebase turns semantic — rather than forcing a resolution nobody reviewed. One rebase, no retry.

## What to check

Read `references/brief-quality.md` and `references/review-actions.md` — both are short, and both are meant to be
read by the agent mid-verb, so padding is the failure mode. Then check that the revise verb's new step sits in a
sensible place in the order of operations: refresh mergeability *after* fixing findings and *before* re-verifying,
so what gets verified is what a human would merge.

## Testing

Three behavior contracts in `tests/test_ticket.py`, one per change. `python3 scripts/validate.py` (25 skills, 247
files) and `tests.test_ticket` (16 tests) pass. The full gate reports 32 errors in `tests.test_behavior` that are
pre-existing on `main` under Python 3.9.6 — `TemporaryDirectory(ignore_cleanup_errors=)` needs 3.10. Reproduced on
an untouched checkout of `main` at the identical count; this branch does not change it.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
