### PR TITLE
fix(orchestrate): close a Codex worker's stdin so it cannot hang pre-session

### DIFF
--- a/docs/scope/orchestrate-codex-stdin-liveness.md
+++ b/docs/scope/orchestrate-codex-stdin-liveness.md
@@ -1,0 +1,41 @@
+# Scope ledger — orchestrate: Codex background dispatch stdin hang and liveness
+
+Routed by /scope → interview mode. Ticket:
+[#62](https://github.com/ConnorGriffin/skills/issues/62).
+
+## Grounding facts
+
+- `references/dispatch-codex.md` carries no raw `codex exec` template; every
+  dispatch goes through `skills/drivers/orchestrate/scripts/codex-worker.py`.
+- Both launch paths in that helper leave stdin inherited:
+  `gated_process()` (`subprocess.Popen`, stdout/stderr piped, no `stdin=`) and
+  `run_portable()` (`subprocess.run`, same omission). A backgrounded coordinator
+  hands them whatever stdin it holds.
+- `codex exec --help` (v0.144.x, homebrew): the prompt argument does not stop
+  stdin being read — "If stdin is piped and a prompt is also provided, stdin is
+  appended as a `<stdin>` block". So an open, never-closing stdin blocks before
+  session start.
+- Reproduced 2026-08-19 in this session: `codex exec` with a `socketpair` fd as
+  stdin printed `Reading additional input from stdin...`, held 0:00.08 CPU at
+  12s, and wrote no rollout. The same command with `stdin=subprocess.DEVNULL`
+  completed inside 20s and wrote
+  `~/.codex/sessions/2026/08/19/rollout-2026-08-19T23-20-38-*.jsonl`.
+- `codex-worker.py verify` is a teardown check (process group empty), not a
+  liveness check; the helper has no liveness command today.
+- `tests/test_behavior.py` already drives the helper through its CLI against a
+  fake `codex` binary, so a regression test has a home.
+- Other places naming a `codex exec` invocation:
+  `references/benchmark/README.md:87`, `docs/orchestrate-spec.md:16,81`,
+  `docs/scope/orchestrate-codex-headroom.md:19`,
+  `skills/drivers/orchestrate/SKILL.md:63,105`.
+
+## Decisions
+
+## Open questions
+
+- Q1 scope of fix: helper code plus documented rule, or documented rule only.
+- Q2 liveness: written coordinator rule, or a helper subcommand.
+- Q3 document inventory: which of the other `codex exec` sites the change covers.
+
+## Spawned tasks
+

--- a/docs/scope/orchestrate-codex-stdin-liveness.md
+++ b/docs/scope/orchestrate-codex-stdin-liveness.md
@@ -31,11 +31,49 @@ Routed by /scope → interview mode. Ticket:
 
 ## Decisions
 
+- Fix the helper and document the rule, not one or the other: `codex-worker.py`
+  closes stdin on both launch paths, and `references/dispatch-codex.md` states
+  the rule where dispatch is described. The adapter carries no shell template to
+  annotate, so a written rule alone would protect nobody dispatching the
+  supported way. — `inline`
+- Liveness stays a written coordinator rule (CPU time growing plus a rollout
+  file), not a new helper subcommand. `verify` already owns the process-family
+  surface, and a second probe command would be a seam with one caller. —
+  `inline`
+- Document inventory is the adapter only. The other `codex exec` sites describe
+  foreground or probe runs, which the reproduction showed behave normally. —
+  `inline`
+
+### Risk contract
+
+- **Must prevent:** a dispatched worker that blocks forever before session start
+  while the coordinator believes it is working.
+- **Must recover:** nothing automatically; the coordinator stops and reports.
+- **Accepted failure:** a worker that hangs *after* session start is out of
+  scope and still needs the operator's `stop`/`verify` path.
+- **Unsupported:** deliberately piping a prompt through stdin to the helper; the
+  helper takes its prompt as an argument only.
+- **Evidence owed:** a regression test that drives `codex-worker.py start`
+  through its CLI with an inherited open stdin and a fake codex that reads stdin
+  to EOF, failing before the fix and passing after.
+- **Why:** the helper is the shared dispatch path every fleet coordinator
+  inherits, so a deadlock here is silent and expensive.
+- **Disposition:** `inline` — copied into the work order on
+  [#62](https://github.com/ConnorGriffin/skills/issues/62).
+
+### Spike — run 2026-08-19, scratchpad, not committed
+
+Copied `codex-worker.py`, applied the two `stdin=subprocess.DEVNULL` edits, and
+ran `start` under a `socketpair` stdin against a fake codex that calls
+`sys.stdin.read()` before emitting JSONL:
+
+```
+patched=False: HUNG (10s timeout) - stdin inherited
+patched=True: exit=0 stdout='{"session_id": "worker-1", ...}'
+```
+
 ## Open questions
 
-- Q1 scope of fix: helper code plus documented rule, or documented rule only.
-- Q2 liveness: written coordinator rule, or a helper subcommand.
-- Q3 document inventory: which of the other `codex exec` sites the change covers.
+None; Q1-Q3 settled above.
 
 ## Spawned tasks
-

--- a/skills/drivers/orchestrate/references/dispatch-codex.md
+++ b/skills/drivers/orchestrate/references/dispatch-codex.md
@@ -29,8 +29,9 @@ A PID appearing in `ps` proves nothing. A healthy worker accrues CPU time
 within a minute and writes `~/.codex/sessions/<date>/rollout-*.jsonl` at session
 start. Before trusting a long-running worker, check that `ps -o time` is growing
 and that the rollout file exists; a worker with neither hung before session
-start. Such a worker burned no tokens, and recovery is to relaunch into a fresh
-directory so a late-waking zombie cannot clobber the new run.
+start. Such a worker burned no tokens. The coordinator stops it through the
+recovery below and reports; it may then relaunch into a fresh directory, so a
+late-waking zombie cannot clobber the new run.
 
 ## Interrupted workers
 

--- a/skills/drivers/orchestrate/references/dispatch-codex.md
+++ b/skills/drivers/orchestrate/references/dispatch-codex.md
@@ -13,9 +13,24 @@ control checkout. Persist one state file per worker. Use `resume` with that
 state file for retry findings and ordinary follow-ups; it restores the captured
 model, sandbox, and canonical cwd rather than taking replacements.
 
+The helper closes a worker's stdin itself. Any hand-rolled background `codex
+exec` must redirect stdin from /dev/null (or pipe a prompt deliberately and let
+it reach EOF): an inherited open stdin is a permanent pre-session hang, because
+codex reads stdin for an appended `<stdin>` block and blocks until EOF even when
+the prompt was passed as an argument.
+
 On success the helper emits one public JSON object. Read its `final_message`
 field as the current worker's answer; do not infer an answer from its session or
 headroom metadata.
+
+## Worker liveness
+
+A PID appearing in `ps` proves nothing. A healthy worker accrues CPU time
+within a minute and writes `~/.codex/sessions/<date>/rollout-*.jsonl` at session
+start. Before trusting a long-running worker, check that `ps -o time` is growing
+and that the rollout file exists; a worker with neither hung before session
+start. Such a worker burned no tokens, and recovery is to relaunch into a fresh
+directory so a late-waking zombie cannot clobber the new run.
 
 ## Interrupted workers
 

--- a/skills/drivers/orchestrate/scripts/codex-worker.py
+++ b/skills/drivers/orchestrate/scripts/codex-worker.py
@@ -305,7 +305,8 @@ def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str],
     )
     process = subprocess.Popen(
         [sys.executable, "-c", wrapper, str(gate_read), str(cwd), json.dumps(command)],
-        text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=(gate_read,),
+        text=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        pass_fds=(gate_read,),
     )
     os.close(gate_read)
     return process, gate_write
@@ -375,6 +376,7 @@ def run_portable(
         command,
         cwd=Path(state["cwd"]),
         text=True,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -298,6 +299,8 @@ class CodexWorkerTests(unittest.TestCase):
             "    pathlib.Path(os.environ['FAKE_CODEX_CHILD']).write_text(str(child.pid))\n"
             "    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
             "    while True: time.sleep(1)\n"
+            "if os.environ.get('FAKE_CODEX_READ_STDIN') == '1':\n"
+            "    sys.stdin.read()\n"
             "sys.stdout.write(os.environ.get('FAKE_CODEX_OUTPUT', ''))\n"
             "sys.exit(int(os.environ.get('FAKE_CODEX_EXIT', '0')))\n",
             encoding="utf-8",
@@ -838,8 +841,54 @@ class CodexWorkerTests(unittest.TestCase):
         self.assertFalse(self.arguments.exists())
 
 
+    def test_a_worker_launched_with_an_open_stdin_does_not_hang_before_session_start(self):
+        self.environment["FAKE_CODEX_READ_STDIN"] = "1"
+        self.environment["FAKE_CODEX_OUTPUT"] = (
+            '{"type":"thread.started","thread_id":"worker-1"}\n'
+            + json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "worker answer"},
+                }
+            )
+            + "\n"
+        )
+        held, other = socket.socketpair()
+        process = None
+        try:
+            process = subprocess.Popen(
+                [
+                    "python3", str(CODEX_WORKER), "start",
+                    "--codex", str(self.binary),
+                    "--state", str(self.state),
+                    "--model", "Terra",
+                    "--sandbox", "read-only",
+                    "--cwd", str(self.worktree),
+                    "do the work",
+                ],
+                cwd=ROOT,
+                env=self.environment,
+                stdin=held.fileno(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                self.fail("the worker hung waiting on an inherited open stdin")
+            self.assertEqual(process.returncode, 0, stderr)
+            self.assertIn("worker answer", stdout)
+        finally:
+            if process is not None and process.poll() is None:
+                process.kill()
+                process.communicate()
+            held.close()
+            other.close()
+
+
 class OrchestrateCodexPolicyTests(unittest.TestCase):
-    def test_codex_headroom_and_single_rung_policy_are_explicit(self):
+    def test_codex_dispatch_policy_rules_are_explicit(self):
         skill = (ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md").read_text(
             encoding="utf-8"
         )
@@ -857,6 +906,13 @@ class OrchestrateCodexPolicyTests(unittest.TestCase):
         self.assertIn("cannot switch to Claude workers", dispatch)
         self.assertIn("headroom at or below 5%", dispatch)
         self.assertIn("Each admitted v0 route is one", dispatch)
+        self.assertIn("The helper closes a worker's stdin itself.", dispatch)
+        self.assertIn("must redirect stdin from /dev/null", dispatch)
+        self.assertIn("an inherited open stdin is a permanent pre-session hang", dispatch)
+        self.assertIn("## Worker liveness", dispatch)
+        self.assertIn("A PID appearing in `ps` proves nothing.", dispatch)
+        self.assertIn("`ps -o time` is growing", dispatch)
+        self.assertIn("rollout-*.jsonl", dispatch)
 
 
 class WorkerLifecycleContractTests(unittest.TestCase):


### PR DESCRIPTION
Closes a Codex worker's input channel at launch, so a worker dispatched in the background can no longer block forever before its session starts.

A worker that inherited an open input channel waited for that channel to close, which never happened. It consumed no processor time, wrote no session log, and spent no budget, and the coordinator could not tell it apart from a worker doing the work.

* Both launch paths in the dispatch helper hand the worker a closed input channel.
* A regression test drives the helper through its command line with an open input channel and a fake codex that reads input to the end. Without the fix on the gated path it times out at 30 seconds; with it, exit 0 in 0.3 seconds.
* The portable launch path, which runs only off macOS, behaves the same way: the same 30 second timeout without the fix, exit 0 with it, and a state file recording unsupported process-family semantics, which only that path writes.
* The dispatch guide gains two rules. Any hand-rolled background launch redirects input from `/dev/null`, and a long-running worker counts as live only when its processor time is growing and its session log exists, not when a process list still shows it.
* The liveness rule sends a coordinator that finds a hung worker through the existing stop and report path before it relaunches, so the stalled worker is not left running.
* Out of scope: workers that hang after a session starts, which the existing stop and verify path already covers, and the other places in the pack that name a foreground command.

```
validated 25 skills and 248 files
Ran 228 tests in 40.906s

OK (skipped=23)
```

Closes #62

> Written by an AI agent. Verify before relying on it.
