### PR TITLE
fix(ticket): count only sessions that referenced the ticket, not its digits

### DIFF
--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -83,11 +84,29 @@ def user_text(entry: dict) -> str:
     )
 
 
+def typed_reference(ticket_id: str) -> "re.Pattern[str]":
+    """Match the id as a reference to the ticket, not as digits inside something else.
+
+    A bare substring test counts any session whose prose happens to contain the
+    digits: a percentage (62.67%), a hex task id, a commit sha, a line range
+    (SKILL.md:8, 62-64), or another repository's pull request (dotfiles/pull/62).
+    Those sessions never worked the ticket, and their peaks skew the slicing
+    rubric they are recorded to calibrate. So the neighbours decide: an
+    alphanumeric, underscore, hyphen, or slash on either side means the id is
+    part of something longer, and a digit across a decimal point means a number.
+    A sentence-final "62." still counts.
+    """
+    return re.compile(
+        rf"(?<![0-9A-Za-z_/-])(?<!\d\.){re.escape(ticket_id)}(?![0-9A-Za-z_/-])(?!\.\d)"
+    )
+
+
 def scan_transcript(path: Path, ticket_id: str) -> Optional[dict]:
     raw = path.read_bytes()
     if ticket_id.encode() not in raw:
         return None
 
+    reference = typed_reference(ticket_id)
     typed = False
     peak = 0
     subagent_peak = 0
@@ -102,7 +121,7 @@ def scan_transcript(path: Path, ticket_id: str) -> Optional[dict]:
             continue
         if started is None and entry.get("timestamp"):
             started = entry["timestamp"]
-        if not typed and ticket_id in user_text(entry):
+        if not typed and reference.search(user_text(entry)):
             typed = True
         if entry.get("type") != "assistant":
             continue

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -95,6 +95,13 @@ def typed_reference(ticket_id: str) -> "re.Pattern[str]":
     alphanumeric, underscore, hyphen, or slash on either side means the id is
     part of something longer, and a digit across a decimal point means a number.
     A sentence-final "62." still counts.
+
+    The slash costs a link: an id written only as an issue or pull-request URL
+    is not counted, because nothing here knows which repository a URL points at
+    and the observed false match was another repository's pull/62. Across five
+    ticket ids in this machine's transcripts, every session that linked a ticket
+    also typed its id, so the trade buys a measured false positive for a
+    hypothetical false negative.
     """
     return re.compile(
         rf"(?<![0-9A-Za-z_/-])(?<!\d\.){re.escape(ticket_id)}(?![0-9A-Za-z_/-])(?!\.\d)"

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -168,6 +168,49 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(payload["session_count"], 0)
         self.assertEqual(payload["sessions"], [])
 
+    def test_scan_excludes_digits_that_only_appear_inside_something_else(self):
+        self.write_session(
+            "proj-a",
+            "session-1",
+            [
+                user_line("Claude Opus 4.6 far ahead (62.67% vs GPT-5.4 nano 32%)"),
+                user_line("task aa95d8d7bd0fc625d finished"),
+                user_line("changes on the branch at commit 624dbe9"),
+                user_line("domain-modeling/SKILL.md:8, 62-64 assume CONTEXT.md"),
+                user_line("landed https://github.com/ConnorGriffin/dotfiles/pull/62"),
+                assistant_line(296_000),
+            ],
+        )
+
+        result = self.ticket("scan", "62")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["session_count"], 0)
+        self.assertEqual(payload["sessions"], [])
+
+    def test_scan_counts_the_ordinary_ways_an_operator_writes_a_ticket_id(self):
+        for index, prose in enumerate(
+            (
+                "let's take a look at #62",
+                "/ticket start 62",
+                "that was settled back in 62.",
+            )
+        ):
+            with self.subTest(prose=prose):
+                session = f"session-{index}"
+                self.write_session(
+                    "proj-a", session, [user_line(prose), assistant_line(125_000)]
+                )
+
+                result = self.ticket("scan", "62", "--project", "proj-a")
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                payload = json.loads(result.stdout)
+                self.assertIn(
+                    session, [entry["session_id"] for entry in payload["sessions"]]
+                )
+
     def test_record_flat_order_above_degradation_band_is_under_sliced(self):
         self.write_session(
             "proj-a",


### PR DESCRIPTION
The ticket telemetry counted a session as having worked a ticket whenever the ticket's digits appeared anywhere in what the operator typed. It now requires the id to stand on its own.

Finalizing ticket 62 recorded it as under-sliced, on a peak of 296,596 tokens taken from a session dated sixteen days before that ticket existed. The recorded verdict then feeds the rubric that decides whether future work gets split across agents.

* An id no longer matches with an alphanumeric, underscore, hyphen, or slash beside it, or across a decimal point. Rejected: a benchmark percentage, a hex task id, a commit sha, a line range, and another repository's pull request carrying the same number.
* Still counted: a hash-prefixed id, an id in a slash command, and an id ending a sentence.
* Scanning ticket 62 against the real transcripts now matches 2 sessions rather than 12, and both are from the day the ticket ran.
* An id written only as an issue or pull-request link is not counted, because the scan cannot tell which repository a link points at. Across five ticket ids on this machine, every session that linked a ticket also typed its id.
* Two tests cover the five rejected shapes and the three accepted ones. Reverting the matcher makes the first fail.

```
validated 25 skills and 248 files
Ran 230 tests in 46.047s

OK (skipped=23)
```

Closes #64

> Written by an AI agent. Verify before relying on it.
