### PR TITLE
feat(ticket): slice on evidence burden, not only on where the change lands

### DIFF
--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -14,13 +14,16 @@ Slice when **two or more** of these hold. One or zero: the order stays flat.
 | Writes across a trust boundary | The change writes in more than one account, project, or trust boundary |
 | Multiple deliverable artifacts | More than one shippable thing: a library change plus its consumers, a workflow plus the scripts it calls, code plus a runbook |
 | Live run inside the ticket | Acceptance requires running the artifact against real infrastructure before the pull request, so what the run exposes is corrected in the same session |
+| Split-path evidence | Acceptance requires proving the same behavior on more than one code path that a single run cannot both exercise (a platform or feature-flag branch), so each path costs its own harness |
 
 The traits are proxies for context load, not for effort. A long-but-uniform change
 (twenty near-identical grants in one target) fires nothing and stays flat, while a
 short change that writes across two accounts and imports live resources fires
 twice and gets sliced. The first four ask where the code lands. The fifth asks
 whether the ticket also has to operate it, which costs a discovery-and-fix cycle
-per surprise plus whatever the run itself takes.
+per surprise plus whatever the run itself takes. The sixth asks what it costs to
+prove the change: a diff of two lines can owe two harnesses when the paths it
+touches cannot both run at once, and building the second one is the work.
 
 ## Anchor table
 


### PR DESCRIPTION
The slicing rubric decides whether a ticket runs as one order or several. It asked only where a change lands. It now also asks what proving the change costs.

Ticket 62 was two keyword arguments on two subprocess launches, and it stayed flat because one trait fired. The work was not the diff. The worker helper picks its launch path by platform, so one test run reaches one path and the other needed a hand-built harness, designed in triage and run again during implementation. Finalize recorded the ticket as under-sliced.

* A sixth trait fires when acceptance needs the same behavior proven on more than one code path that a single run cannot both exercise.
* Two traits still mean slice, so no threshold moves and the recording helper's constants are unchanged.
* No anchor row. Ticket 62's measured peak came from a session that also carried unrelated work, so the number overstates that ticket and does not belong in a calibration table.

```
validated 25 skills and 248 files
Ran 228 tests in 49.630s

OK (skipped=23)
```

Closes #68

> Written by an AI agent. Verify before relying on it.
