### PR TITLE
feat(ticket): record which session worked a ticket instead of guessing it

### DIFF
--- a/docs/adr/adr-70-claimed-session-attribution.md
+++ b/docs/adr/adr-70-claimed-session-attribution.md
@@ -1,0 +1,62 @@
+# ADR 70 — Ticket telemetry records attribution instead of inferring it
+
+Date: 2026-08-20
+Status: accepted
+Issue: https://github.com/ConnorGriffin/skills/issues/70
+
+## Context
+
+The ticket telemetry answers one question: which sessions worked this ticket, and
+what did they peak at. The peak feeds the slicing rubric, which decides whether
+future work runs as one order or several.
+
+It answered the first half by searching every local transcript for the ticket's
+id in operator prose. That is inference, and it failed in both directions within
+a single day of use:
+
+- Ticket 62 recorded a peak of 296,596 tokens from a session dated sixteen days
+  before the ticket existed. A bare substring test matched a benchmark
+  percentage, a hex task id, a commit sha, a line range, and another
+  repository's pull request number.
+- Tightening the match to a delimited reference ([#64]) fixed those, and then
+  ticket 64 recorded `no-data` while ticket 68 recorded a peak of 36,470 from an
+  unrelated session in another directory. The sessions that did the work were
+  invisible, because an agent had filed both tickets and the operator never
+  typed either id.
+- `--project` was a substring filter, so a worktree directory whose name
+  contained the repository's name counted as the repository.
+
+Each fix refined the guess. None of them could stop being a guess, because the
+prose a session contains is not evidence of what that session worked on.
+
+## Decision
+
+The verbs record their own attribution. `ticket.py claim <ticket-id>` writes one
+line naming the session, its agent, and its working directory; every verb claims
+its session as an early step. `scan` and `record` read those claims and resolve
+each session's transcript by exact id.
+
+The matching machinery is deleted rather than kept as a fallback: the reference
+regex, the operator-typed text extractor, the substring prefilter, and the
+`--project` flag. A fallback would reintroduce the failure mode on exactly the
+tickets where claims are absent, and silently, which is how the first bad record
+was written.
+
+A session id comes from the agent's own environment (`CLAUDE_CODE_SESSION_ID`,
+`CODEX_SESSION_ID`) or from `--session` with `--agent`, so a coordinator can
+claim on behalf of a dispatched worker. Which agent wrote a session is part of
+the claim because it decides both where the transcript lives and how context is
+counted: a Claude transcript sums three usage fields per turn, while a Codex
+rollout reports one input total that already contains its cached part.
+
+## Consequences
+
+- A ticket worked before this landed has no claims and reports `no-data`.
+  Existing telemetry records and the rubric's anchor rows stay as they are; the
+  numbers already taken do not become recoverable.
+- A claim whose transcript has been deleted is reported under `unreadable`
+  rather than counted as a session that cost nothing.
+- Claiming is not a gate. A verb whose claim fails says so in one line and
+  continues, because a measurement must never block the work it measures.
+- The telemetry can now undercount only by a verb failing to claim, which is a
+  visible absence, rather than by matching the wrong session, which was not.

--- a/docs/adr/adr-70-claimed-session-attribution.md
+++ b/docs/adr/adr-70-claimed-session-attribution.md
@@ -44,7 +44,10 @@ was written.
 
 A session id comes from the agent's own environment (`CLAUDE_CODE_SESSION_ID`,
 `CODEX_SESSION_ID`) or from `--session` with `--agent`, so a coordinator can
-claim on behalf of a dispatched worker. Which agent wrote a session is part of
+claim on behalf of a dispatched worker. Two visible ids are a refusal rather
+than a preference order: a worker launched from another agent's session
+inherits that session's variable, and choosing between them would record the
+coordinator's transcript against the worker's ticket. Which agent wrote a session is part of
 the claim because it decides both where the transcript lives and how context is
 counted: a Claude transcript sums three usage fields per turn, while a Codex
 rollout reports one input total that already contains its cached part.

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -66,8 +66,9 @@ substitutes a lighter check for the depth the order stamped.
 2. **Claim the session.** Immediately after the ticket summary, run
    `python3 <ticket-skill-directory>/scripts/ticket.py claim <ticket-id>`, so the
    sessions that worked this ticket are recorded as they work it rather than
-   guessed from prose afterwards. An agent whose session id is not in its own
-   environment passes `--session` and `--agent`. A claim that fails is said in one
+   guessed from prose afterwards. Pass `--session` and `--agent` whenever the
+   environment cannot answer on its own: no session id in it, or more than one,
+   which is what a worker launched from another agent's session sees. A claim that fails is said in one
    line and never blocks the verb: telemetry is a measurement, not a gate.
 
 3. **Attribution first.** Every comment this skill posts opens with a one-line

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -63,7 +63,14 @@ substitutes a lighter check for the depth the order stamped.
    `<ticket-id> <verb>` when the harness offers a chapter tool, so the user can
    scroll back to it. Skip the chapter silently when it does not.
 
-2. **Attribution first.** Every comment this skill posts opens with a one-line
+2. **Claim the session.** Immediately after the ticket summary, run
+   `python3 <ticket-skill-directory>/scripts/ticket.py claim <ticket-id>`, so the
+   sessions that worked this ticket are recorded as they work it rather than
+   guessed from prose afterwards. An agent whose session id is not in its own
+   environment passes `--session` and `--agent`. A claim that fails is said in one
+   line and never blocks the verb: telemetry is a measurement, not a gate.
+
+3. **Attribution first.** Every comment this skill posts opens with a one-line
    quote block. With an operator name configured:
 
    > Written by an AI agent operating for `<operator>`. Verify before relying on it.
@@ -76,12 +83,12 @@ substitutes a lighter check for the depth the order stamped.
    key, or an empty value all mean the nameless form. Then the content. Never post
    an unattributed comment.
 
-3. **The lock is the only entry to execution.** A work order is a ticket comment
+4. **The lock is the only entry to execution.** A work order is a ticket comment
    whose body contains a fenced block starting `WORK ORDER`. `start` and `revise`
    locate it by scanning the ticket's comments newest-first; the newest one wins.
    No order, no execution: refuse and route to `/ticket triage <ticket-id>`.
 
-4. **One worktree, one branch, per ticket, for the whole lifecycle.** `triage`
+5. **One worktree, one branch, per ticket, for the whole lifecycle.** `triage`
    cuts the branch and worktree through `spin-worktree`; `start` and `revise`
    reuse them; `finalize` tears them down. The first action of any verb, before
    grounding or any repo read, is to cut or reuse the ticket's worktree, which is
@@ -96,24 +103,24 @@ substitutes a lighter check for the depth the order stamped.
    chunk merges back into it, so the ticket still ends with one branch and one
    pull request ([references/coordinator-mode.md](references/coordinator-mode.md)).
 
-5. **Working state lives on the ticket.** No plan files and no scratch
+6. **Working state lives on the ticket.** No plan files and no scratch
    directories on the branch. The branch carries shipping code plus the repo's own
    change record, nothing else.
 
-6. **Ground in what the repo already says.** Read the repo's own decision and
+7. **Ground in what the repo already says.** Read the repo's own decision and
    change records, `docs/`, and recent `git log` before forming opinions. Read the
    standing-decisions source named below when a project configured one.
 
-7. **Status transitions.** Verbs move the ticket: `triage` to triaged, `start` to
+8. **Status transitions.** Verbs move the ticket: `triage` to triaged, `start` to
    in progress when the branch is cut, `start` to pending review when the pull
    request opens, `finalize` to done. Status is the contract's one non-fatal
    operation: when a move is unavailable or fails, say so in one line and
    continue. Never retry a failed move and never force a workaround.
 
-8. **Stop at the pull request boundary.** Opening the pull request ends `start`.
+9. **Stop at the pull request boundary.** Opening the pull request ends `start`.
    Merging is human. `finalize` only runs after a human merged.
 
-9. **Fresh-session contract.** `start` assumes no memory of triage. Everything it
+10. **Fresh-session contract.** `start` assumes no memory of triage. Everything it
    needs must be on the ticket, in the description plus the work order. If it is
    not there, that is a triage defect: refuse and say what is missing.
 

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -85,23 +85,30 @@ def detect_session(explicit: Optional[str], agent: Optional[str]) -> tuple[str, 
     agent wrote a session decides where its transcript lives and how its context
     is counted.
     """
-    running = next(
-        ((name, os.environ[variable]) for name, variable in SESSION_VARIABLES if os.environ.get(variable)),
-        None,
-    )
-    if explicit:
-        if agent:
-            return agent, explicit
-        if running:
-            return running[0], explicit
-        names = " or ".join(name for name, _ in SESSION_VARIABLES)
-        raise TelemetryError(f"--session needs --agent ({names}) outside a known agent")
-    if agent:
+    visible = [
+        (name, os.environ[variable])
+        for name, variable in SESSION_VARIABLES
+        if os.environ.get(variable)
+    ]
+    names = " or ".join(name for name, _ in SESSION_VARIABLES)
+    if agent and not explicit:
         raise TelemetryError("--agent needs --session")
-    if running:
-        return running
-    names = " or ".join(variable for _, variable in SESSION_VARIABLES)
-    raise TelemetryError(f"no session id: pass --session, or run where {names} is set")
+    if agent:
+        return agent, explicit
+    # A Codex worker launched from a Claude session inherits that session's
+    # variable, so two visible ids mean the environment cannot say which agent
+    # is running. Guessing there records the coordinator's transcript against
+    # the worker's ticket.
+    if len(visible) > 1:
+        raise TelemetryError(f"more than one agent session in the environment: pass --agent ({names})")
+    if explicit:
+        if visible:
+            return visible[0][0], explicit
+        raise TelemetryError(f"--session needs --agent ({names}) outside a known agent")
+    if visible:
+        return visible[0]
+    variables = " or ".join(variable for _, variable in SESSION_VARIABLES)
+    raise TelemetryError(f"no session id: pass --session, or run where {variables} is set")
 
 
 def read_claims(ticket_id: str) -> list[dict]:
@@ -115,7 +122,7 @@ def read_claims(ticket_id: str) -> list[dict]:
             claim = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if claim.get("ticket_id") == ticket_id:
+        if claim.get("ticket_id") == ticket_id and claim.get("session_id"):
             claims.append(claim)
     return claims
 
@@ -132,16 +139,17 @@ def append_claim(claim: dict) -> Optional[Path]:
     return CLAIMS_PATH
 
 
-def transcript_for(claim: dict, projects_dir: Path) -> Optional[Path]:
-    """Find one claimed session's transcript by its id, never by its contents."""
-    session_id = claim.get("session_id", "")
-    if not session_id:
-        return None
+def transcripts_for(claim: dict, projects_dir: Path) -> list[Path]:
+    """Find a claimed session's transcripts by id, never by their contents.
+
+    A resumed session writes more than one file, so this returns every match
+    and the caller takes the peak across them. Picking one would report
+    whichever the filesystem happened to sort first.
+    """
+    session_id = claim["session_id"]
     if claim.get("agent") == "codex":
-        matches = sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
-    else:
-        matches = sorted(projects_dir.glob(f"*/{session_id}.jsonl"))
-    return matches[0] if matches else None
+        return sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
+    return sorted(projects_dir.glob(f"*/{session_id}.jsonl"))
 
 
 def claude_peaks(raw: bytes) -> tuple[Optional[str], int, int]:
@@ -194,42 +202,37 @@ def codex_peaks(raw: bytes) -> tuple[Optional[str], int, int]:
 
 
 def session_cost(claim: dict, projects_dir: Path) -> dict:
-    path = transcript_for(claim, projects_dir)
-    session = {
-        "session_id": claim.get("session_id"),
+    paths = transcripts_for(claim, projects_dir)
+    read = codex_peaks if claim.get("agent") == "codex" else claude_peaks
+    started = None
+    peak = 0
+    subagent_peak = 0
+    for path in paths:
+        first, own, sub = read(path.read_bytes())
+        started = min(x for x in (started, first) if x) if (started or first) else None
+        peak = max(peak, own)
+        subagent_peak = max(subagent_peak, sub)
+    return {
+        "session_id": claim["session_id"],
         "agent": claim.get("agent"),
         "project": claim.get("project"),
-        "started": claim.get("claimed_at"),
-        "peak_context": 0,
-        "subagent_peak": 0,
-        "transcript": None,
+        "started": started or claim.get("claimed_at"),
+        "peak_context": peak,
+        "subagent_peak": subagent_peak,
+        "transcripts": [str(path) for path in paths],
     }
-    if path is None:
-        return session
-    started, peak, subagent_peak = (
-        codex_peaks(path.read_bytes())
-        if claim.get("agent") == "codex"
-        else claude_peaks(path.read_bytes())
-    )
-    session.update(
-        started=started or session["started"],
-        peak_context=peak,
-        subagent_peak=subagent_peak,
-        transcript=str(path),
-    )
-    return session
 
 
 def scan(ticket_id: str, projects_dir: Path) -> dict:
     sessions = [session_cost(claim, projects_dir) for claim in read_claims(ticket_id)]
     sessions.sort(key=lambda session: session["started"] or "")
-    measured = [session for session in sessions if session["transcript"]]
+    measured = [session for session in sessions if session["transcripts"]]
     return {
         "ticket_id": ticket_id,
         "session_count": len(measured),
         "claim_count": len(sessions),
         "unreadable": [
-            session["session_id"] for session in sessions if not session["transcript"]
+            session["session_id"] for session in sessions if not session["transcripts"]
         ],
         "peak_context": max((session["peak_context"] for session in measured), default=0),
         "subagent_peak": max((session["subagent_peak"] for session in measured), default=0),
@@ -247,6 +250,12 @@ def verdict(actual: dict, chunked: bool, chunks: int) -> tuple[str, str]:
     is the work and counts.
     """
     if actual["session_count"] == 0:
+        if actual["claim_count"]:
+            return (
+                "no-data",
+                f"{actual['claim_count']} session(s) claimed this ticket and their "
+                "transcripts are gone, so nothing could be measured",
+            )
         return "no-data", "no session claimed this ticket, so nothing measured it"
     own = max(session["peak_context"] for session in actual["sessions"])
     if not chunked:
@@ -298,9 +307,13 @@ def command_record(arguments: argparse.Namespace) -> int:
         "chunked": arguments.chunked,
         "chunks": arguments.chunks,
         "session_count": actual["session_count"],
+        "claim_count": actual["claim_count"],
+        "unreadable": actual["unreadable"],
         "peak_context": actual["peak_context"],
         "subagent_peak": actual["subagent_peak"],
-        "session_peaks": [session["peak_context"] for session in actual["sessions"]],
+        "session_peaks": [
+            session["peak_context"] for session in actual["sessions"] if session["transcripts"]
+        ],
         "verdict": call,
         "reason": reason,
         "recorded_at": datetime.now(timezone.utc).isoformat(),

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -59,6 +59,21 @@ def validate_ticket_id(value: str) -> str:
     return value
 
 
+def validate_session_id(value: str) -> str:
+    """A session id is pasted in from elsewhere and reaches a filesystem glob.
+
+    An id carrying glob syntax matches transcripts the claim never named:
+    `--session '*'` resolved to every transcript on the machine and reported
+    their maximum as one session's peak.
+    """
+    if not value or any(character.isspace() for character in value):
+        raise TelemetryError("session id must be a single token with no whitespace")
+    forbidden = set("*?[]/\\")
+    if forbidden & set(value):
+        raise TelemetryError("session id must not contain glob or path characters")
+    return value
+
+
 def context_size(usage: dict) -> int:
     return sum(
         int(usage.get(field) or 0)
@@ -326,7 +341,10 @@ def command_record(arguments: argparse.Namespace) -> int:
 
 def command_claim(arguments: argparse.Namespace) -> int:
     ticket_id = validate_ticket_id(arguments.ticket_id)
-    agent, session_id = detect_session(arguments.session, arguments.agent)
+    agent, session_id = detect_session(
+        validate_session_id(arguments.session) if arguments.session else None,
+        arguments.agent,
+    )
     claim = {
         "ticket_id": ticket_id,
         "session_id": session_id,

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Context telemetry for the ticket workflow: measure what a ticket cost.
 
-Scans this agent's own local session transcripts for a ticket id and reports
-peak context per session, then records the actuals so the slicing rubric can
-be retuned against real numbers. Every record carries counts and labels
+Each verb claims its own session against the ticket it is working, so the set
+of sessions that worked a ticket is recorded rather than inferred. Reports
+peak context per claimed session, then records the actuals so the slicing
+rubric can be retuned against real numbers. Every record carries counts and labels
 supplied on the command line: never a transcript excerpt, a prompt, or any
 other prose from a session.
 """
@@ -13,7 +14,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,6 +28,19 @@ TELEMETRY_PATH = Path(
         str(Path.home() / ".config" / "ticket" / "telemetry.jsonl"),
     )
 ).expanduser()
+CLAIMS_PATH = Path(
+    os.environ.get(
+        "TICKET_CLAIMS",
+        str(Path.home() / ".config" / "ticket" / "claims.jsonl"),
+    )
+).expanduser()
+CODEX_SESSIONS_DIR = Path(
+    os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
+).expanduser() / "sessions"
+
+# Which environment variable carries the running session id, per agent. A verb
+# that cannot read one passes --session instead.
+SESSION_VARIABLES = (("claude", "CLAUDE_CODE_SESSION_ID"), ("codex", "CODEX_SESSION_ID"))
 
 # A session past this peaked into the degradation band: it should have been
 # sliced below this line.
@@ -57,68 +70,84 @@ def context_size(usage: dict) -> int:
     )
 
 
-def transcript_files(projects_dir: Path) -> Iterator[Path]:
-    if not projects_dir.exists():
-        raise TelemetryError(f"no transcript directory: {projects_dir}")
-    yield from sorted(projects_dir.glob("*/*.jsonl"))
+def detect_session(explicit: Optional[str], agent: Optional[str]) -> tuple[str, str]:
+    """Name the session this verb is running in, so the claim is a fact.
 
+    The old scan searched every transcript for the ticket id and counted the
+    sessions whose operator prose contained it. That guessed at attribution and
+    got it wrong in both directions: digits inside a percentage or a commit sha
+    counted, while an agent-filed ticket whose id the operator never typed did
+    not. The session working a ticket is known at the moment it works it, so it
+    is recorded here instead.
 
-def user_text(entry: dict) -> str:
-    """Prose the operator typed, excluding tool results.
-
-    A ticket id that appears only inside a tool result was read by an agent,
-    not typed by the operator: that session looked at the ticket, it did not
-    necessarily work it.
+    An agent that publishes its session id in the environment needs no flags. A
+    dispatched worker whose coordinator holds the id passes both, because which
+    agent wrote a session decides where its transcript lives and how its context
+    is counted.
     """
-    if entry.get("type") != "user":
-        return ""
-    content = entry.get("message", {}).get("content")
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return ""
-    return " ".join(
-        str(block.get("text", ""))
-        for block in content
-        if isinstance(block, dict) and block.get("type") == "text"
+    running = next(
+        ((name, os.environ[variable]) for name, variable in SESSION_VARIABLES if os.environ.get(variable)),
+        None,
     )
+    if explicit:
+        if agent:
+            return agent, explicit
+        if running:
+            return running[0], explicit
+        names = " or ".join(name for name, _ in SESSION_VARIABLES)
+        raise TelemetryError(f"--session needs --agent ({names}) outside a known agent")
+    if agent:
+        raise TelemetryError("--agent needs --session")
+    if running:
+        return running
+    names = " or ".join(variable for _, variable in SESSION_VARIABLES)
+    raise TelemetryError(f"no session id: pass --session, or run where {names} is set")
 
 
-def typed_reference(ticket_id: str) -> "re.Pattern[str]":
-    """Match the id as a reference to the ticket, not as digits inside something else.
-
-    A bare substring test counts any session whose prose happens to contain the
-    digits: a percentage (62.67%), a hex task id, a commit sha, a line range
-    (SKILL.md:8, 62-64), or another repository's pull request (dotfiles/pull/62).
-    Those sessions never worked the ticket, and their peaks skew the slicing
-    rubric they are recorded to calibrate. So the neighbours decide: an
-    alphanumeric, underscore, hyphen, or slash on either side means the id is
-    part of something longer, and a digit across a decimal point means a number.
-    A sentence-final "62." still counts.
-
-    The slash costs a link: an id written only as an issue or pull-request URL
-    is not counted, because nothing here knows which repository a URL points at
-    and the observed false match was another repository's pull/62. Across five
-    ticket ids in this machine's transcripts, every session that linked a ticket
-    also typed its id, so the trade buys a measured false positive for a
-    hypothetical false negative.
-    """
-    return re.compile(
-        rf"(?<![0-9A-Za-z_/-])(?<!\d\.){re.escape(ticket_id)}(?![0-9A-Za-z_/-])(?!\.\d)"
-    )
+def read_claims(ticket_id: str) -> list[dict]:
+    if not CLAIMS_PATH.exists():
+        return []
+    claims = []
+    for line in CLAIMS_PATH.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            claim = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if claim.get("ticket_id") == ticket_id:
+            claims.append(claim)
+    return claims
 
 
-def scan_transcript(path: Path, ticket_id: str) -> Optional[dict]:
-    raw = path.read_bytes()
-    if ticket_id.encode() not in raw:
+def append_claim(claim: dict) -> Optional[Path]:
+    """Record one session against one ticket, once."""
+    for existing in read_claims(claim["ticket_id"]):
+        if existing.get("session_id") == claim["session_id"]:
+            return None
+    CLAIMS_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with CLAIMS_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(claim) + "\n")
+    CLAIMS_PATH.chmod(0o600)
+    return CLAIMS_PATH
+
+
+def transcript_for(claim: dict, projects_dir: Path) -> Optional[Path]:
+    """Find one claimed session's transcript by its id, never by its contents."""
+    session_id = claim.get("session_id", "")
+    if not session_id:
         return None
+    if claim.get("agent") == "codex":
+        matches = sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
+    else:
+        matches = sorted(projects_dir.glob(f"*/{session_id}.jsonl"))
+    return matches[0] if matches else None
 
-    reference = typed_reference(ticket_id)
-    typed = False
+
+def claude_peaks(raw: bytes) -> tuple[Optional[str], int, int]:
+    started = None
     peak = 0
     subagent_peak = 0
-    started = None
-
     for line in raw.splitlines():
         if not line.strip():
             continue
@@ -128,8 +157,6 @@ def scan_transcript(path: Path, ticket_id: str) -> Optional[dict]:
             continue
         if started is None and entry.get("timestamp"):
             started = entry["timestamp"]
-        if not typed and reference.search(user_text(entry)):
-            typed = True
         if entry.get("type") != "assistant":
             continue
         size = context_size(entry.get("message", {}).get("usage", {}))
@@ -137,35 +164,75 @@ def scan_transcript(path: Path, ticket_id: str) -> Optional[dict]:
             subagent_peak = max(subagent_peak, size)
         else:
             peak = max(peak, size)
+    return started, peak, subagent_peak
 
-    if not typed:
-        return None
-    return {
-        "session_id": path.stem,
-        "project": path.parent.name,
-        "started": started,
-        "peak_context": peak,
-        "subagent_peak": subagent_peak,
+
+def codex_peaks(raw: bytes) -> tuple[Optional[str], int, int]:
+    """Codex reports one input total per turn, already counting its cached part.
+
+    Summing the cached field back in would double-count it, so this is a
+    maximum over one field rather than the three-field sum a Claude transcript
+    needs. Codex writes no sub-agent turns into a rollout, so that peak is zero.
+    """
+    started = None
+    peak = 0
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if started is None and entry.get("timestamp"):
+            started = entry["timestamp"]
+        payload = entry.get("payload", {})
+        if entry.get("type") != "event_msg" or payload.get("type") != "token_count":
+            continue
+        usage = (payload.get("info") or {}).get("last_token_usage") or {}
+        peak = max(peak, int(usage.get("input_tokens") or 0))
+    return started, peak, 0
+
+
+def session_cost(claim: dict, projects_dir: Path) -> dict:
+    path = transcript_for(claim, projects_dir)
+    session = {
+        "session_id": claim.get("session_id"),
+        "agent": claim.get("agent"),
+        "project": claim.get("project"),
+        "started": claim.get("claimed_at"),
+        "peak_context": 0,
+        "subagent_peak": 0,
+        "transcript": None,
     }
+    if path is None:
+        return session
+    started, peak, subagent_peak = (
+        codex_peaks(path.read_bytes())
+        if claim.get("agent") == "codex"
+        else claude_peaks(path.read_bytes())
+    )
+    session.update(
+        started=started or session["started"],
+        peak_context=peak,
+        subagent_peak=subagent_peak,
+        transcript=str(path),
+    )
+    return session
 
 
-def scan(ticket_id: str, projects_dir: Path, project: Optional[str] = None) -> dict:
-    paths = [
-        path
-        for path in transcript_files(projects_dir)
-        if project is None or project in path.parent.name
-    ]
-    sessions = [
-        session
-        for session in (scan_transcript(path, ticket_id) for path in paths)
-        if session is not None
-    ]
+def scan(ticket_id: str, projects_dir: Path) -> dict:
+    sessions = [session_cost(claim, projects_dir) for claim in read_claims(ticket_id)]
     sessions.sort(key=lambda session: session["started"] or "")
+    measured = [session for session in sessions if session["transcript"]]
     return {
         "ticket_id": ticket_id,
-        "session_count": len(sessions),
-        "peak_context": max((session["peak_context"] for session in sessions), default=0),
-        "subagent_peak": max((session["subagent_peak"] for session in sessions), default=0),
+        "session_count": len(measured),
+        "claim_count": len(sessions),
+        "unreadable": [
+            session["session_id"] for session in sessions if not session["transcript"]
+        ],
+        "peak_context": max((session["peak_context"] for session in measured), default=0),
+        "subagent_peak": max((session["subagent_peak"] for session in measured), default=0),
         "sessions": sessions,
     }
 
@@ -180,7 +247,7 @@ def verdict(actual: dict, chunked: bool, chunks: int) -> tuple[str, str]:
     is the work and counts.
     """
     if actual["session_count"] == 0:
-        return "no-data", "no local transcript was typed against this ticket id"
+        return "no-data", "no session claimed this ticket, so nothing measured it"
     own = max(session["peak_context"] for session in actual["sessions"])
     if not chunked:
         if own >= DEGRADE_PEAK:
@@ -214,14 +281,14 @@ def append_record(record: dict) -> Path:
 
 def command_scan(arguments: argparse.Namespace) -> int:
     ticket_id = validate_ticket_id(arguments.ticket_id)
-    result = scan(ticket_id, arguments.projects_dir, arguments.project)
+    result = scan(ticket_id, arguments.projects_dir)
     print(json.dumps(result, indent=2))
     return 0
 
 
 def command_record(arguments: argparse.Namespace) -> int:
     ticket_id = validate_ticket_id(arguments.ticket_id)
-    actual = scan(ticket_id, arguments.projects_dir, arguments.project)
+    actual = scan(ticket_id, arguments.projects_dir)
     call, reason = verdict(actual, arguments.chunked, arguments.chunks)
     record = {
         "ticket_id": ticket_id,
@@ -244,13 +311,23 @@ def command_record(arguments: argparse.Namespace) -> int:
     return 0
 
 
+def command_claim(arguments: argparse.Namespace) -> int:
+    ticket_id = validate_ticket_id(arguments.ticket_id)
+    agent, session_id = detect_session(arguments.session, arguments.agent)
+    claim = {
+        "ticket_id": ticket_id,
+        "session_id": session_id,
+        "agent": agent,
+        "project": arguments.project or str(Path.cwd()),
+        "claimed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    written = append_claim(claim)
+    print(json.dumps({**claim, "already_claimed": written is None}, indent=2))
+    return 0
+
+
 def add_common_flags(target: argparse.ArgumentParser) -> None:
-    target.add_argument("ticket_id", help="ticket id to look for, exactly as typed by the operator")
-    target.add_argument(
-        "--project",
-        default=None,
-        help="restrict to transcript directories containing this substring",
-    )
+    target.add_argument("ticket_id", help="ticket id, exactly as the tracker names it")
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -262,6 +339,24 @@ def parse_arguments() -> argparse.Namespace:
         help=f"local session transcript root (default {PROJECTS_DIR})",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    claim_parser = subparsers.add_parser(
+        "claim", help="record that this session is working this ticket"
+    )
+    add_common_flags(claim_parser)
+    claim_parser.add_argument(
+        "--session", default=None, help="session id, when the environment carries none"
+    )
+    claim_parser.add_argument(
+        "--agent",
+        choices=[name for name, _ in SESSION_VARIABLES],
+        default=None,
+        help="which agent wrote the session; needed with --session outside a known agent",
+    )
+    claim_parser.add_argument(
+        "--project", default=None, help="working directory to record (default: this one)"
+    )
+    claim_parser.set_defaults(handler=command_claim)
 
     scan_parser = subparsers.add_parser(
         "scan", help="report peak context per session that worked this ticket id"

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -78,8 +78,10 @@ the code host back to the tracker; this verb is that sync.
    pull request they approve. The skill never amends its own rubric, and never edits
    `references/slicing.md` itself.
 
-   `no-data` is not a misprediction. Say the ticket ran outside this machine's
-   transcripts, and draft nothing.
+   `no-data` is not a misprediction, and it has two readings the report keeps
+   apart: no session claimed the ticket, so it ran outside this machine's
+   transcripts, or sessions claimed it and their transcripts are gone. Draft
+   nothing either way.
 
 4. **Abandoned path** (pull request closed unmerged, or the work cancelled): comment
    why, then on explicit user confirmation run the same teardown as step 2f. Never

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -58,14 +58,14 @@ the code host back to the tracker; this verb is that sync.
    * `under-sliced`: a flat order that peaked past the degradation band.
    * `still-degraded`: a chunked order whose chunks were themselves too big.
    * `over-sliced`: chunks that no single agent would have struggled with.
-   * `no-data`: no local transcript matched the ticket, so nothing is judged.
+   * `no-data`: no session claimed this ticket, so nothing measured it.
 
    The helper reads the sessions that claimed this ticket, so nothing is inferred
    from prose and there is nothing to narrow. A claimed session whose transcript
    has been deleted appears under `unreadable`: report it rather than treating it
    as a session that cost nothing.
    `python3 <ticket-skill-directory>/scripts/ticket.py scan <ticket-id>` reports peak
-   context per matching session without recording anything, which is the way to look
+   context per claimed session without recording anything, which is the way to look
    before committing a record.
 
    **On `under-sliced`, `still-degraded`, or `over-sliced`, report the misprediction

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -49,7 +49,7 @@ the code host back to the tracker; this verb is that sync.
      --verb <verb that ran, repeated> \
      --trait <trait that fired, repeated> \
      --depth <stamped depth> \
-     [--chunked --chunks <n>] [--project <substring>]
+     [--chunked --chunks <n>]
    ```
 
    The helper appends one record under `~/.config/ticket/` and returns one verdict:
@@ -60,8 +60,10 @@ the code host back to the tracker; this verb is that sync.
    * `over-sliced`: chunks that no single agent would have struggled with.
    * `no-data`: no local transcript matched the ticket, so nothing is judged.
 
-   Add `--project <substring>` when unrelated sessions in other repos discussed the
-   ticket id and skew the count.
+   The helper reads the sessions that claimed this ticket, so nothing is inferred
+   from prose and there is nothing to narrow. A claimed session whose transcript
+   has been deleted appears under `unreadable`: report it rather than treating it
+   as a session that cost nothing.
    `python3 <ticket-skill-directory>/scripts/ticket.py scan <ticket-id>` reports peak
    context per matching session without recording anything, which is the way to look
    before committing a record.

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -36,16 +36,6 @@ def user_line(text: str, timestamp: str = "2026-01-01T00:00:00Z") -> str:
     )
 
 
-def tool_result_line(text: str, timestamp: str = "2026-01-01T00:00:00Z") -> str:
-    return json.dumps(
-        {
-            "type": "user",
-            "timestamp": timestamp,
-            "message": {"content": [{"type": "tool_result", "content": text}]},
-        }
-    )
-
-
 def codex_meta_line(session_id: str, timestamp: str = "2026-01-01T00:00:00Z") -> str:
     return json.dumps(
         {
@@ -270,6 +260,65 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(payload["session_count"], 0)
         self.assertEqual(payload["unreadable"], ["session-gone"])
 
+        gone = self.ticket(
+            "record", "TICKET-6", "--verb", "start", "--trait", "any", "--depth", "deep"
+        )
+
+        self.assertEqual(json.loads(gone.stdout)["verdict"], "no-data")
+        self.assertIn("transcripts are gone", json.loads(gone.stdout)["reason"])
+        self.assertEqual(self.telemetry_records(), [])
+
+        # A deleted transcript must not reach the durable record as a session
+        # that cost nothing: that is the reading adr-70 rules out.
+        self.worked("TICKET-6", "proj-a", "session-2", [assistant_line(190_000)])
+        recorded = self.ticket(
+            "record", "TICKET-6", "--verb", "start", "--trait", "any", "--depth", "deep"
+        )
+
+        self.assertEqual(recorded.returncode, 0, recorded.stderr)
+        record = self.telemetry_records()[0]
+        self.assertEqual(record["session_peaks"], [190_000])
+        self.assertEqual(record["claim_count"], 2)
+        self.assertEqual(record["unreadable"], ["session-gone"])
+
+    def test_two_visible_agent_sessions_refuse_to_guess_which_is_running(self):
+        # A Codex worker launched from a Claude session inherits that session's
+        # variable. Guessing here would measure the coordinator's transcript.
+        environment = self.environment.copy()
+        environment["CLAUDE_CODE_SESSION_ID"] = "claude-1"
+        environment["CODEX_SESSION_ID"] = "codex-1"
+
+        result = self.ticket("claim", "TICKET-17", environment=environment)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--agent", result.stderr)
+        self.assertFalse(self.claims.exists())
+
+        chosen = self.ticket(
+            "claim", "TICKET-17", "--session", "codex-1", "--agent", "codex",
+            environment=environment,
+        )
+
+        self.assertEqual(chosen.returncode, 0, chosen.stderr)
+        self.assertEqual(json.loads(chosen.stdout)["agent"], "codex")
+
+    def test_a_resumed_session_is_measured_across_every_file_it_wrote(self):
+        directory = self.codex_home / "sessions" / "2026" / "01" / "01"
+        directory.mkdir(parents=True, exist_ok=True)
+        for stamp, peak in (("00-00-00", 5_000), ("11-00-00", 200_000)):
+            (directory / f"rollout-2026-01-01T{stamp}-codex-2.jsonl").write_text(
+                "\n".join([codex_meta_line("codex-2"), codex_token_line(peak)]) + "\n",
+                encoding="utf-8",
+            )
+        self.claim("TICKET-18", "codex-2", agent="codex")
+
+        result = self.ticket("scan", "TICKET-18")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(len(payload["sessions"][0]["transcripts"]), 2)
+        self.assertEqual(payload["peak_context"], 200_000)
+
     def test_record_flat_order_above_degradation_band_is_under_sliced(self):
         self.worked("TICKET-7", "proj-a", "session-1", [assistant_line(200_000)])
 
@@ -422,6 +471,9 @@ class TicketTelemetryTests(unittest.TestCase):
         written = self.telemetry.read_text(encoding="utf-8")
         self.assertNotIn("unrealistic", written)
         self.assertNotIn(secret_prose, written)
+        claimed = self.claims.read_text(encoding="utf-8")
+        self.assertNotIn("unrealistic", claimed)
+        self.assertNotIn(secret_prose, claimed)
 
 
 if __name__ == "__main__":

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -46,6 +46,36 @@ def tool_result_line(text: str, timestamp: str = "2026-01-01T00:00:00Z") -> str:
     )
 
 
+def codex_meta_line(session_id: str, timestamp: str = "2026-01-01T00:00:00Z") -> str:
+    return json.dumps(
+        {
+            "timestamp": timestamp,
+            "type": "session_meta",
+            "payload": {"session_id": session_id, "cwd": "/tmp/worktree"},
+        }
+    )
+
+
+def codex_token_line(
+    input_tokens: int, cached: int = 0, timestamp: str = "2026-01-01T00:00:01Z"
+) -> str:
+    return json.dumps(
+        {
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": input_tokens,
+                        "cached_input_tokens": cached,
+                    }
+                },
+            },
+        }
+    )
+
+
 def assistant_line(
     peak: int, *, subagent: bool = False, timestamp: str = "2026-01-01T00:00:01Z"
 ) -> str:
@@ -103,19 +133,25 @@ class TicketTelemetryTests(unittest.TestCase):
         self.scratch = Path(self.temporary.name)
         self.projects = self.scratch / "projects"
         self.projects.mkdir()
+        self.codex_home = self.scratch / "codex-home"
         self.telemetry = self.scratch / "config" / "ticket" / "telemetry.jsonl"
+        self.claims = self.scratch / "config" / "ticket" / "claims.jsonl"
         self.environment = os.environ.copy()
+        self.environment.pop("CLAUDE_CODE_SESSION_ID", None)
+        self.environment.pop("CODEX_SESSION_ID", None)
         self.environment["CLAUDE_PROJECTS_DIR"] = str(self.projects)
+        self.environment["CODEX_HOME"] = str(self.codex_home)
         self.environment["TICKET_TELEMETRY"] = str(self.telemetry)
+        self.environment["TICKET_CLAIMS"] = str(self.claims)
 
     def tearDown(self):
         self.temporary.cleanup()
 
-    def ticket(self, *arguments: str):
+    def ticket(self, *arguments: str, environment: Optional[dict] = None):
         return run(
             ["python3", str(TICKET_SCRIPT), *arguments],
             cwd=ROOT,
-            env=self.environment,
+            env=environment or self.environment,
         )
 
     def write_session(self, project: str, session_id: str, lines: list[str]) -> Path:
@@ -124,6 +160,25 @@ class TicketTelemetryTests(unittest.TestCase):
         path = directory / f"{session_id}.jsonl"
         path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         return path
+
+    def write_codex_session(self, session_id: str, lines: list[str]) -> Path:
+        directory = self.codex_home / "sessions" / "2026" / "01" / "01"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"rollout-2026-01-01T00-00-00-{session_id}.jsonl"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+    def claim(self, ticket_id: str, session_id: str, agent: str = "claude"):
+        result = self.ticket(
+            "claim", ticket_id, "--session", session_id, "--agent", agent
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout)
+
+    def worked(self, ticket_id: str, project: str, session_id: str, lines: list[str]):
+        """The ordinary case: a session ran the ticket, so it claimed it."""
+        self.write_session(project, session_id, lines)
+        self.claim(ticket_id, session_id)
 
     def telemetry_records(self) -> list[dict]:
         if not self.telemetry.exists():
@@ -134,95 +189,92 @@ class TicketTelemetryTests(unittest.TestCase):
             if line.strip()
         ]
 
-    def test_scan_counts_a_session_the_operator_typed_the_id_into(self):
+    def test_claim_records_the_running_session_without_being_told_which(self):
+        environment = self.environment.copy()
+        environment["CLAUDE_CODE_SESSION_ID"] = "session-1"
+
+        result = self.ticket("claim", "TICKET-1", environment=environment)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["session_id"], "session-1")
+        self.assertEqual(payload["agent"], "claude")
+        self.assertFalse(payload["already_claimed"])
+
+    def test_claiming_the_same_session_twice_records_it_once(self):
+        self.claim("TICKET-2", "session-1")
+
+        second = self.ticket("claim", "TICKET-2", "--session", "session-1", "--agent", "claude")
+
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertTrue(json.loads(second.stdout)["already_claimed"])
+        lines = self.claims.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len([line for line in lines if line.strip()]), 1)
+
+    def test_claim_without_a_session_id_anywhere_says_how_to_supply_one(self):
+        result = self.ticket("claim", "TICKET-3")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CLAUDE_CODE_SESSION_ID", result.stderr)
+        self.assertIn("CODEX_SESSION_ID", result.stderr)
+        self.assertFalse(self.claims.exists())
+
+    def test_a_session_that_never_claimed_the_ticket_is_not_counted(self):
+        # The whole point of claiming: prose is no longer evidence. This session
+        # names the ticket in operator prose and still does not count.
         self.write_session(
             "proj-a",
             "session-1",
-            [
-                user_line("please pick up TICKET-1 today"),
-                assistant_line(125_000),
-            ],
+            [user_line("TICKET-4 is the one I mean"), assistant_line(300_000)],
         )
+        self.worked("TICKET-4", "proj-a", "session-2", [assistant_line(90_000)])
 
-        result = self.ticket("scan", "TICKET-1")
+        result = self.ticket("scan", "TICKET-4")
 
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["session_count"], 1)
-        self.assertEqual(payload["sessions"][0]["peak_context"], 125_000)
+        self.assertEqual(payload["peak_context"], 90_000)
+        self.assertEqual(payload["sessions"][0]["session_id"], "session-2")
 
-    def test_scan_excludes_a_tool_result_only_mention(self):
-        self.write_session(
-            "proj-a",
-            "session-1",
+    def test_a_codex_session_is_resolved_from_its_rollout_file(self):
+        self.write_codex_session(
+            "codex-1",
             [
-                tool_result_line("issue TICKET-2 was returned by the tracker search"),
-                assistant_line(200_000),
+                codex_meta_line("codex-1"),
+                codex_token_line(40_000, 10_000),
+                codex_token_line(120_000, 90_000),
             ],
         )
+        self.claim("TICKET-5", "codex-1", agent="codex")
 
-        result = self.ticket("scan", "TICKET-2")
+        result = self.ticket("scan", "TICKET-5")
 
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
-        self.assertEqual(payload["session_count"], 0)
-        self.assertEqual(payload["sessions"], [])
+        self.assertEqual(payload["session_count"], 1)
+        session = payload["sessions"][0]
+        self.assertEqual(session["agent"], "codex")
+        # Codex counts its cached input inside input_tokens; adding it back
+        # would report 210,000 for a turn that cost 120,000.
+        self.assertEqual(session["peak_context"], 120_000)
 
-    def test_scan_excludes_digits_that_only_appear_inside_something_else(self):
-        self.write_session(
-            "proj-a",
-            "session-1",
-            [
-                user_line("Claude Opus 4.6 far ahead (62.67% vs GPT-5.4 nano 32%)"),
-                user_line("task aa95d8d7bd0fc625d finished"),
-                user_line("changes on the branch at commit 624dbe9"),
-                user_line("domain-modeling/SKILL.md:8, 62-64 assume CONTEXT.md"),
-                user_line("landed https://github.com/ConnorGriffin/dotfiles/pull/62"),
-                assistant_line(296_000),
-            ],
-        )
+    def test_a_claim_whose_transcript_is_missing_is_reported_not_dropped(self):
+        self.claim("TICKET-6", "session-gone")
 
-        result = self.ticket("scan", "62")
+        result = self.ticket("scan", "TICKET-6")
 
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
+        self.assertEqual(payload["claim_count"], 1)
         self.assertEqual(payload["session_count"], 0)
-        self.assertEqual(payload["sessions"], [])
-
-    def test_scan_counts_the_ordinary_ways_an_operator_writes_a_ticket_id(self):
-        for index, prose in enumerate(
-            (
-                "let's take a look at #62",
-                "/ticket start 62",
-                "that was settled back in 62.",
-            )
-        ):
-            with self.subTest(prose=prose):
-                session = f"session-{index}"
-                self.write_session(
-                    "proj-a", session, [user_line(prose), assistant_line(125_000)]
-                )
-
-                result = self.ticket("scan", "62", "--project", "proj-a")
-
-                self.assertEqual(result.returncode, 0, result.stderr)
-                payload = json.loads(result.stdout)
-                self.assertIn(
-                    session, [entry["session_id"] for entry in payload["sessions"]]
-                )
+        self.assertEqual(payload["unreadable"], ["session-gone"])
 
     def test_record_flat_order_above_degradation_band_is_under_sliced(self):
-        self.write_session(
-            "proj-a",
-            "session-1",
-            [
-                user_line("start TICKET-3"),
-                assistant_line(200_000),
-            ],
-        )
+        self.worked("TICKET-7", "proj-a", "session-1", [assistant_line(200_000)])
 
         result = self.ticket(
-            "record", "TICKET-3", "--verb", "start", "--trait", "large-diff", "--depth", "deep"
+            "record", "TICKET-7", "--verb", "start", "--trait", "large-diff", "--depth", "deep"
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -232,7 +284,7 @@ class TicketTelemetryTests(unittest.TestCase):
         records = self.telemetry_records()
         self.assertEqual(len(records), 1)
         record = records[0]
-        self.assertEqual(record["ticket_id"], "TICKET-3")
+        self.assertEqual(record["ticket_id"], "TICKET-7")
         self.assertEqual(record["verbs"], ["start"])
         self.assertEqual(record["traits"], ["large-diff"])
         self.assertEqual(record["depth"], "deep")
@@ -243,85 +295,51 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertIn("recorded_at", record)
 
     def test_record_flat_order_below_band_is_ok(self):
-        self.write_session(
-            "proj-a",
-            "session-1",
-            [
-                user_line("start TICKET-4"),
-                assistant_line(50_000),
-            ],
-        )
+        self.worked("TICKET-8", "proj-a", "session-1", [assistant_line(50_000)])
 
         result = self.ticket(
-            "record", "TICKET-4", "--verb", "start", "--trait", "small-diff", "--depth", "light"
+            "record", "TICKET-8", "--verb", "start", "--trait", "small-diff", "--depth", "light"
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        payload = json.loads(result.stdout)
-        self.assertEqual(payload["verdict"], "ok")
+        self.assertEqual(json.loads(result.stdout)["verdict"], "ok")
         self.assertEqual(self.telemetry_records()[0]["verdict"], "ok")
 
     def test_record_chunked_order_still_degraded_when_a_chunk_peaks_high(self):
-        self.write_session(
+        self.worked(
+            "TICKET-9",
             "proj-a",
             "session-1",
-            [
-                user_line("start TICKET-5"),
-                assistant_line(30_000),
-                assistant_line(190_000, subagent=True),
-            ],
+            [assistant_line(30_000), assistant_line(190_000, subagent=True)],
         )
 
         result = self.ticket(
-            "record",
-            "TICKET-5",
-            "--verb",
-            "start",
-            "--trait",
-            "wide-scope",
-            "--depth",
-            "deep",
-            "--chunked",
-            "--chunks",
-            "3",
+            "record", "TICKET-9", "--verb", "start", "--trait", "wide-scope",
+            "--depth", "deep", "--chunked", "--chunks", "3",
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        payload = json.loads(result.stdout)
-        self.assertEqual(payload["verdict"], "still-degraded")
+        self.assertEqual(json.loads(result.stdout)["verdict"], "still-degraded")
 
     def test_record_chunked_order_over_sliced_when_every_chunk_is_small(self):
-        self.write_session(
+        self.worked(
+            "TICKET-10",
             "proj-a",
             "session-1",
-            [
-                user_line("start TICKET-6"),
-                assistant_line(40_000),
-                assistant_line(50_000, subagent=True),
-            ],
+            [assistant_line(40_000), assistant_line(50_000, subagent=True)],
         )
 
         result = self.ticket(
-            "record",
-            "TICKET-6",
-            "--verb",
-            "start",
-            "--trait",
-            "narrow-scope",
-            "--depth",
-            "light",
-            "--chunked",
-            "--chunks",
-            "3",
+            "record", "TICKET-10", "--verb", "start", "--trait", "narrow-scope",
+            "--depth", "light", "--chunked", "--chunks", "3",
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        payload = json.loads(result.stdout)
-        self.assertEqual(payload["verdict"], "over-sliced")
+        self.assertEqual(json.loads(result.stdout)["verdict"], "over-sliced")
 
-    def test_record_with_no_matching_transcript_is_no_data_and_writes_nothing(self):
+    def test_record_with_no_claim_is_no_data_and_writes_nothing(self):
         result = self.ticket(
-            "record", "TICKET-7", "--verb", "start", "--trait", "any", "--depth", "light"
+            "record", "TICKET-11", "--verb", "start", "--trait", "any", "--depth", "light"
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -331,57 +349,32 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertFalse(self.telemetry.exists())
 
     def test_subagent_peak_is_counted_separately_from_the_main_session_peak(self):
-        self.write_session(
+        self.worked(
+            "TICKET-12",
             "proj-a",
             "session-1",
-            [
-                user_line("start TICKET-8"),
-                assistant_line(60_000),
-                assistant_line(140_000, subagent=True),
-            ],
+            [assistant_line(60_000), assistant_line(140_000, subagent=True)],
         )
 
-        result = self.ticket("scan", "TICKET-8")
+        result = self.ticket("scan", "TICKET-12")
 
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["sessions"][0]["peak_context"], 60_000)
         self.assertEqual(payload["sessions"][0]["subagent_peak"], 140_000)
 
-    def test_project_narrowing_excludes_an_unrelated_project_directory(self):
-        self.write_session(
-            "included-project",
-            "session-1",
-            [user_line("start TICKET-9"), assistant_line(10_000)],
-        )
-        self.write_session(
-            "other-project",
-            "session-2",
-            [user_line("start TICKET-9"), assistant_line(10_000)],
-        )
-
-        result = self.ticket("scan", "TICKET-9", "--project", "included")
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        payload = json.loads(result.stdout)
-        self.assertEqual(payload["session_count"], 1)
-        self.assertEqual(payload["sessions"][0]["project"], "included-project")
-
     def test_malformed_line_is_skipped_and_the_rest_of_the_session_still_scans(self):
         # A malformed line is external input (a local file this process did not
         # write): the scan skips it and keeps reading the rest of the file
         # rather than failing the whole session.
-        self.write_session(
+        self.worked(
+            "TICKET-13",
             "proj-a",
             "session-1",
-            [
-                user_line("start TICKET-10"),
-                "not valid json",
-                assistant_line(70_000),
-            ],
+            ["not valid json", assistant_line(70_000)],
         )
 
-        result = self.ticket("scan", "TICKET-10")
+        result = self.ticket("scan", "TICKET-13")
 
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
@@ -389,7 +382,7 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(payload["sessions"][0]["peak_context"], 70_000)
 
     def test_empty_and_whitespace_ids_are_rejected_and_write_nothing(self):
-        for bad_id in ("", "TICKET 11", " "):
+        for bad_id in ("", "TICKET 14", " "):
             with self.subTest(bad_id=bad_id):
                 result = self.ticket(
                     "record", bad_id, "--verb", "start", "--trait", "any", "--depth", "light"
@@ -399,15 +392,13 @@ class TicketTelemetryTests(unittest.TestCase):
                 self.assertEqual(self.telemetry_records(), [])
 
     def test_telemetry_parent_directory_is_created_when_absent(self):
-        self.assertFalse(self.telemetry.parent.exists())
-        self.write_session(
-            "proj-a",
-            "session-1",
-            [user_line("start TICKET-12"), assistant_line(10_000)],
-        )
+        # The claim already created the shared parent, so this asserts the
+        # record path creates what it needs from a clean directory.
+        self.worked("TICKET-15", "proj-a", "session-1", [assistant_line(10_000)])
+        self.assertFalse(self.telemetry.exists())
 
         result = self.ticket(
-            "record", "TICKET-12", "--verb", "start", "--trait", "any", "--depth", "light"
+            "record", "TICKET-15", "--verb", "start", "--trait", "any", "--depth", "light"
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -416,41 +407,21 @@ class TicketTelemetryTests(unittest.TestCase):
 
     def test_appended_record_carries_no_prose_from_the_session(self):
         secret_prose = "quietly worried this deadline is unrealistic and stressful"
-        self.write_session(
+        self.worked(
+            "TICKET-16",
             "proj-a",
             "session-1",
-            [
-                user_line(f"start TICKET-13, {secret_prose}"),
-                assistant_line(10_000),
-            ],
+            [user_line(secret_prose), assistant_line(10_000)],
         )
 
         result = self.ticket(
-            "record", "TICKET-13", "--verb", "start", "--trait", "any", "--depth", "light"
+            "record", "TICKET-16", "--verb", "start", "--trait", "any", "--depth", "light"
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        record = self.telemetry_records()[0]
-        serialized = json.dumps(record)
-        self.assertNotIn(secret_prose, serialized)
-        self.assertEqual(
-            set(record),
-            {
-                "ticket_id",
-                "verbs",
-                "traits",
-                "depth",
-                "chunked",
-                "chunks",
-                "session_count",
-                "peak_context",
-                "subagent_peak",
-                "session_peaks",
-                "verdict",
-                "reason",
-                "recorded_at",
-            },
-        )
+        written = self.telemetry.read_text(encoding="utf-8")
+        self.assertNotIn("unrealistic", written)
+        self.assertNotIn(secret_prose, written)
 
 
 if __name__ == "__main__":

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -302,6 +302,19 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(chosen.returncode, 0, chosen.stderr)
         self.assertEqual(json.loads(chosen.stdout)["agent"], "codex")
 
+    def test_a_session_id_carrying_glob_syntax_is_refused(self):
+        # The id reaches a filesystem glob, so "*" would resolve to every
+        # transcript on the machine and report their maximum as one session.
+        self.write_session("proj-a", "session-1", [assistant_line(200_000)])
+
+        for bad in ("*", "ses?ion-1", "../escape", "a[bc]"):
+            with self.subTest(bad=bad):
+                result = self.ticket("claim", "TICKET-19", "--session", bad, "--agent", "claude")
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("session id", result.stderr)
+        self.assertFalse(self.claims.exists())
+
     def test_a_resumed_session_is_measured_across_every_file_it_wrote(self):
         directory = self.codex_home / "sessions" / "2026" / "01" / "01"
         directory.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The ticket telemetry worked out which sessions worked a ticket by searching local transcripts for the ticket's number in what the operator typed. The verbs now record it as they work, and the searching is deleted.

Searching got it wrong in both directions within a day. Ticket 62 was recorded at a peak taken from a session sixteen days older than the ticket, because the number also appears in percentages, commit hashes, line ranges and another repository's pull requests. Tightening the match fixed those and then reported nothing at all for two tickets an agent had filed, because the operator never typed either number. The peak feeds the rubric that decides whether future work is split across several agents.

* Each verb claims its own session at the start, naming the session, which agent is running it, and the working directory. Reading a ticket's cost means reading those claims.
* Claims carry the agent because the two agents record context differently. One sums three usage fields per turn; the other reports a single input total that already contains its cached part, so adding that part back would report a turn at 282,000 tokens inside a 258,400 token window.
* A session that never claimed a ticket does not count toward it, whatever its prose says.
* A claim whose transcript has been deleted is reported as unreadable, kept out of the peaks, and named in the verdict, rather than counted as a session that cost nothing.
* A session that resumed wrote more than one transcript, and all of them are measured.
* Two agent sessions visible at once is a refusal, not a preference. A worker launched from another agent's session inherits that session's identity, and choosing between them would measure the coordinator instead of the worker.
* A session id reaches a filesystem pattern, so ids carrying pattern or path characters are refused. One such id matched every transcript on the machine.
* The option that narrowed a ticket's count to one repository is removed along with the searching: with claims there is no unrelated session left to filter out.
* A ticket worked before this lands has no claims and reads as no data. Existing records and the rubric's calibration rows are unchanged.

The reasoning is recorded as an architecture decision alongside the change.

```
validated 25 skills and 249 files
Ran 234 tests in 40.446s

OK (skipped=23)
```

Closes #70

> Written by an AI agent. Verify before relying on it.
