### PR TITLE
Add hookless Codebase Memory worktree lifecycle

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,10 +39,12 @@ jobs:
           python3 -m py_compile skills/tools/spin-worktree/scripts/spin-worktree.py
           python3 -m py_compile skills/workflows/review/scripts/resolve_route.py
           python3 -m py_compile skills/drivers/ticket/scripts/ticket.py
+          python3 -m py_compile skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
           node --check skills/tools/drive-local-webapp/scripts/driver.mjs
           node --check skills/tools/drive-local-webapp/scripts/self-check.mjs
           sh -n skills/tools/cbm-onboard/scripts/cbm-onboard.sh
           sh -n skills/tools/cbm-onboard/scripts/cbm-reindex.sh
+          sh -n skills/tools/cbm-onboard/scripts/cbm-teardown.sh
       - name: Fresh-install through the standard skills CLI
         run: >-
           npx --yes skills@1.5.20 add . --skill '*'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 
 | Skill | Purpose | Extra requirement |
 | --- | --- | --- |
-| [`cbm-onboard`](skills/tools/cbm-onboard/SKILL.md) | Index a repository with codebase-memory-mcp and keep it current | `codebase-memory-mcp` on `PATH` |
+| [`cbm-onboard`](skills/tools/cbm-onboard/SKILL.md) | Keep a maintained checkout indexed, or onboard and tear down a hookless ephemeral worktree | `codebase-memory-mcp` on `PATH`; v0.10.8+ for ephemeral lifecycle |
 | [`ci-design`](skills/tools/ci-design/SKILL.md) | Vocabulary and principles for well-designed CI | — |
 | [`code-review`](skills/tools/code-review/SKILL.md) | Review changes since a fixed point on two axes, Standards and Spec, each returning a verdict per enumerated item so a round terminates | Parallel-agent support recommended; GitHub CLI to fetch an originating issue; see [docs/review-round-mining.md](docs/review-round-mining.md) for the mined evidence behind the fix protocol and the round cap |
 | [`codebase-design`](skills/tools/codebase-design/SKILL.md) | Shared vocabulary for designing deep modules | — |

--- a/docs/scope/cbm-worktree-lifecycle.md
+++ b/docs/scope/cbm-worktree-lifecycle.md
@@ -29,21 +29,50 @@ Issue: ConnorGriffin/skills#66
   Why: teardown deletes graph state, and selecting the wrong Codebase Memory project
   would cross the ticket's destructive boundary even though the graph is rebuildable.
   Disposition: inline.
+- Require Codebase Memory MCP v0.10.8 or newer for the ephemeral lifecycle and
+  assign its project name explicitly during onboarding.
+  Why: v0.10.8 supports `index_repository.name`; an explicit versioned SHA-256
+  identity derived from the canonical physical checkout path lets teardown delete
+  directly by name without an unreliable registry lookup or a list/delete race.
+  Disposition: inline.
+- Keep default maintained-checkout onboarding on its existing derived-name behavior;
+  the explicit identity contract belongs to hookless ephemeral onboarding and its
+  paired teardown command.
+  Why: renaming existing maintained-checkout projects would create duplicate stale
+  graphs and is outside issue 66.
+  Disposition: inline.
+- Reject `CBM_SKIP_INDEX=1` in hookless mode before repository mutation, while
+  preserving it for default maintained-checkout onboarding.
+  Why: teardown can exist only after hookless onboarding establishes the named graph;
+  silently skipping that operation would make the lifecycle contract fictitious.
+  Disposition: inline.
+- Accept only a stable three-part `codebase-memory-mcp MAJOR.MINOR.PATCH` banner and
+  compare its numeric tuple with `(0, 10, 8)`.
+  Why: numeric components handle later patches/minors/majors without lexicographic
+  errors; rejecting prefixes, suffixes, and prereleases avoids inventing compatibility.
+  Disposition: inline.
+- Support spaces in canonical checkout paths but reject newline-bearing paths before
+  mutation or deletion.
+  Why: Git reports the top level through a line-oriented interface whose terminating
+  newline is ambiguous with path bytes under POSIX command substitution; fail-closed
+  rejection is honest, while pretending to hash the original bytes is not.
+  Disposition: inline.
 
 ### Risk contract
 
-- **Must prevent:** deleting a project without an identity established by the matching
-  successful index operation; writing Git hooks in hookless mode; modifying repository
-  files or Git hooks during teardown; silent success after malformed or failed external
-  tool responses; loss of authoritative repository data.
+- **Must prevent:** deleting a project without the deterministic identity used by the
+  matching hookless index operation; writing Git hooks in hookless mode; modifying
+  repository files or Git hooks during teardown; silent success after malformed or
+  failed external tool responses; loss of authoritative repository data.
 - **Must recover:** none automatically. External tool failures stop nonzero and leave
   manual retry to the caller.
 - **Accepted failure:** hookless onboarding may reconcile the target `.cbmignore`
   before a failed initial index, matching the existing operation order. A race that
   replaces rebuildable graph data under the same already-established project identity
   is recoverable by reindexing and is not promised atomic recovery.
-- **Unsupported:** non-Git targets, malformed external responses, and teardown of a
-  project whose identity was not established by the matching onboarding operation.
+- **Unsupported:** Codebase Memory versions older than v0.10.8, non-Git targets,
+  malformed external responses, and teardown of a project whose identity was not
+  established by the matching hookless onboarding operation.
 - **Evidence owed:** public-interface tests for exact worktree indexing, zero hook
   writes, strict argument rejection before mutation, identity handoff, exact-name
   deletion, idempotent repeat teardown, fail-closed response parsing, repository
@@ -56,14 +85,7 @@ Disposition: inline in the eventual work order after the identity interface sett
 
 ## Open questions
 
-- How does onboarding hand the exact Codebase Memory project identity to teardown?
-  The installed v0.8.1 CLI cannot safely rediscover it from a path: its
-  `list_projects` response currently contains 1,009 records and every `root_path` is
-  empty. The upstream v0.10.8 interface can accept an explicit project name at index
-  time, but relying on it establishes a new minimum-version contract. Candidate
-  interfaces are: require v0.10.8+ and assign a stable name; persist the successful
-  index response's name in worktree-private Git metadata; or make the harness pass the
-  returned name explicitly to teardown.
+- None.
 
 ## Generated facts
 
@@ -76,12 +98,21 @@ Disposition: inline in the eventual work order after the identity interface sett
 - GitHub's official latest-release API on 2026-08-20 → `v0.10.8`, published
   2026-08-19. Its upstream tool schema adds an optional explicit `name` to
   `index_repository`; deletion remains name-based.
+- The local executable was upgraded to v0.10.8. With stdout/stderr captured
+  separately, a disposable explicit-name cycle returned `indexed`/`isError=false`
+  at exit 0, then `deleted`/`isError=false` at exit 0; repeat deletion returned
+  `not_found`/`isError=true` at exit 1. Graph commands wrote allocator info to stderr.
 - Disposable linked-worktree reproduction with current `cbm-onboard.sh
   --this-checkout` → `.cbmignore` created in the linked worktree and all three managed
   hooks installed in the control checkout's shared `.git/hooks`.
 - `python3 --version` → `Python 3.9.6`; the repository validator passes, while the
   documented full unittest command fails before issue-66 work because existing tests
   require `TemporaryDirectory(ignore_cleanup_errors=True)`. CI selects Python 3.12.
+- `uv python list --only-installed` → managed Python 3.12.13 is available locally;
+  `uv run --python 3.12 python ...` ran the validator plus 212 tests successfully
+  with 23 expected skips, matching CI's Python version line.
+- `.github/workflows/validate.yml` additionally runs `tests.test_ticket`; the work
+  order's local gate includes it rather than deferring that coverage to GitHub.
 
 ## Review rounds
 
@@ -96,6 +127,15 @@ Disposition: inline in the eventual work order after the identity interface sett
     environment.
   - A generic secret-exposure promise was also removed as an unearned control; this
     was fixed without expanding the build.
+- Round 2: four blocking authoring gaps, zero injected defects.
+  - Added exact stdout/stderr/exit evidence for the v0.10.8 lifecycle.
+  - Settled `CBM_SKIP_INDEX`: preserved for default mode, rejected pre-mutation for
+    hookless mode.
+  - Fixed a strict stable-version grammar and numeric comparison cases.
+  - Added physical alias and spaces identity evidence, plus pre-mutation rejection for
+    newline-bearing paths that cannot cross Git's line-oriented shell interface safely.
+- Round 3: countersigned with no remaining blocking objections after attaching the
+  exact v0.10.8 command/output/exit-code appendix.
 
 ## Spawned tasks
 

--- a/docs/scope/cbm-worktree-lifecycle.md
+++ b/docs/scope/cbm-worktree-lifecycle.md
@@ -1,0 +1,103 @@
+# Scope: Codebase Memory worktree lifecycle
+
+Issue: ConnorGriffin/skills#66
+
+## Decisions
+
+- Classify the ticket as `code`: it lands as one pull request in this repository.
+  Why: the deliverables are public shell interfaces, their tests, and documentation.
+  Disposition: inline.
+- Keep the order flat rather than chunked.
+  Why: one repository and one trust boundary are involved; multiple related artifacts
+  fire only one slicing trait, closest to the flat anchor.
+  Disposition: inline.
+- Preserve default onboarding for maintained checkouts; add a hookless mode for
+  ephemeral worktrees.
+  Why: PR #12 established the long-lived hook behavior, while the issue-66
+  reproduction proved that linked worktrees share the control checkout's hooks.
+  Disposition: inline.
+- Both lifecycle scripts must reject unknown options and excess positional arguments
+  before any repository or graph mutation.
+  Why: the current onboarding parser treats a misspelled safety flag as a path and can
+  silently fall through to default hook installation.
+  Disposition: inline.
+- Do not promise a generic secret-exposure control for this change.
+  Why: no secret-bearing input is part of the interface; exact-target deletion,
+  repository non-mutation, and fail-closed external responses are the concrete risks.
+  Disposition: inline.
+- Review depth is Full.
+  Why: teardown deletes graph state, and selecting the wrong Codebase Memory project
+  would cross the ticket's destructive boundary even though the graph is rebuildable.
+  Disposition: inline.
+
+### Risk contract
+
+- **Must prevent:** deleting a project without an identity established by the matching
+  successful index operation; writing Git hooks in hookless mode; modifying repository
+  files or Git hooks during teardown; silent success after malformed or failed external
+  tool responses; loss of authoritative repository data.
+- **Must recover:** none automatically. External tool failures stop nonzero and leave
+  manual retry to the caller.
+- **Accepted failure:** hookless onboarding may reconcile the target `.cbmignore`
+  before a failed initial index, matching the existing operation order. A race that
+  replaces rebuildable graph data under the same already-established project identity
+  is recoverable by reindexing and is not promised atomic recovery.
+- **Unsupported:** non-Git targets, malformed external responses, and teardown of a
+  project whose identity was not established by the matching onboarding operation.
+- **Evidence owed:** public-interface tests for exact worktree indexing, zero hook
+  writes, strict argument rejection before mutation, identity handoff, exact-name
+  deletion, idempotent repeat teardown, fail-closed response parsing, repository
+  non-mutation, and the repository's validation/CI gates.
+
+Why: the graph is derived and rebuildable, but deletion identity and control-checkout
+isolation must be mechanically enforced.
+
+Disposition: inline in the eventual work order after the identity interface settles.
+
+## Open questions
+
+- How does onboarding hand the exact Codebase Memory project identity to teardown?
+  The installed v0.8.1 CLI cannot safely rediscover it from a path: its
+  `list_projects` response currently contains 1,009 records and every `root_path` is
+  empty. The upstream v0.10.8 interface can accept an explicit project name at index
+  time, but relying on it establishes a new minimum-version contract. Candidate
+  interfaces are: require v0.10.8+ and assign a stable name; persist the successful
+  index response's name in worktree-private Git metadata; or make the harness pass the
+  returned name explicitly to teardown.
+
+## Generated facts
+
+- `codebase-memory-mcp --version` → `codebase-memory-mcp 0.8.1`.
+- `codebase-memory-mcp cli list_projects '{}'` parsed through Python → 1,009 records,
+  1,009 empty `root_path` fields, zero nonempty `root_path` fields.
+- `codebase-memory-mcp cli delete_project
+  '{"project":"__issue66_preflight_nonexistent__"}'` →
+  `{"project":"__issue66_preflight_nonexistent__","status":"not_found"}`.
+- GitHub's official latest-release API on 2026-08-20 → `v0.10.8`, published
+  2026-08-19. Its upstream tool schema adds an optional explicit `name` to
+  `index_repository`; deletion remains name-based.
+- Disposable linked-worktree reproduction with current `cbm-onboard.sh
+  --this-checkout` → `.cbmignore` created in the linked worktree and all three managed
+  hooks installed in the control checkout's shared `.git/hooks`.
+- `python3 --version` → `Python 3.9.6`; the repository validator passes, while the
+  documented full unittest command fails before issue-66 work because existing tests
+  require `TemporaryDirectory(ignore_cleanup_errors=True)`. CI selects Python 3.12.
+
+## Review rounds
+
+- Round 1: five blocking authoring defects, zero injected defects.
+  - Path-to-project deletion relied on `root_path` values the installed CLI does not
+    supply.
+  - The deletion response/identity contract was not executable from the draft.
+  - The absolute list-then-delete path invariant was non-atomic across the external
+    process boundary.
+  - Safety-sensitive argument parsing did not require fail-closed rejection.
+  - The local green-before-PR verification gate named no runnable Python 3.12+
+    environment.
+  - A generic secret-exposure promise was also removed as an unearned control; this
+    was fixed without expanding the build.
+
+## Spawned tasks
+
+- None. Cold review agents produced read-only findings; no implementation or follow-up
+  ticket was delegated.

--- a/skills/tools/cbm-onboard/SKILL.md
+++ b/skills/tools/cbm-onboard/SKILL.md
@@ -1,23 +1,26 @@
 ---
 name: cbm-onboard
-description: Register a Git repository with codebase-memory-mcp, create a managed .cbmignore baseline, install non-clobbering post-commit/post-merge/post-checkout reindex hooks, and run the initial index. Use when asked to index, onboard, register, or keep a repository current in Codebase Memory.
+description: Register maintained or ephemeral Git checkouts with codebase-memory-mcp, keep long-lived indexes current through non-clobbering Git hooks, and tear down ephemeral indexes by exact deterministic identity. Use when asked to index, onboard, register, remove, or keep a repository current in Codebase Memory.
 ---
 
 # Onboard a repository to Codebase Memory
 
-Use the bundled script to make one maintained checkout one Codebase Memory
-project. Never index a directory containing several repositories.
+Use the bundled scripts for either a long-lived maintained checkout or a
+short-lived checkout with an explicit onboard/teardown lifecycle. Never index a
+directory containing several repositories.
 
 ## Requirements
 
 - Install `codebase-memory-mcp` and make its executable available on `PATH`, or
   set `CODEBASE_MEMORY_BIN` to the executable path.
+- Ephemeral onboarding and teardown require Codebase Memory MCP v0.10.8 or
+  newer. Maintained-checkout onboarding keeps its existing compatibility.
 - Resolve the installed `cbm-onboard` skill directory.
 
 ## Workflow
 
 1. Resolve the target Git repository. Default to the current repository.
-2. Run:
+2. For a long-lived maintained checkout, run:
 
    ```sh
    <cbm-onboard-skill-directory>/scripts/cbm-onboard.sh <repo-path>
@@ -32,17 +35,38 @@ project. Never index a directory containing several repositories.
    targets. A non-shell foreign hook is left unchanged with a warning because
    composing it would be unsafe.
 
-   Pass `--this-checkout` to onboard the current checkout as-is instead of
-   resolving to the main worktree — use this for a linked worktree that wants
-   its own `.cbmignore` and hooks rather than sharing the control checkout's.
+   Linked worktrees share the control checkout's Git hooks; they cannot have
+   independent hooks. Pass `--this-checkout` only to select the supplied
+   checkout's `.cbmignore` and initial index. Hook installation still resolves
+   through Git's shared hooks directory.
 
-3. Verify the project through the available Codebase Memory MCP interface with
+3. For an ephemeral checkout, run the complete lifecycle:
+
+   ```sh
+   <cbm-onboard-skill-directory>/scripts/cbm-onboard.sh \
+     --no-hooks --this-checkout <worktree-path>
+   # Use the worktree, then:
+   <cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <worktree-path>
+   ```
+
+   `--no-hooks` reconciles only the selected checkout's `.cbmignore`, performs a
+   full index under a deterministic name derived from its canonical physical
+   path, and never enters hook resolution or installation. `--this-checkout` is
+   load-bearing for a linked worktree: without it, onboarding deliberately
+   resolves to the main checkout, matching maintained-checkout behavior.
+
+   Teardown recomputes that exact identity and calls `delete_project` directly;
+   it never scans projects, edits repository files or Git configuration, or
+   removes hooks or worktrees. Both a successful deletion and an exact
+   already-missing response are success, so teardown is safe to repeat.
+
+4. Verify the project through the available Codebase Memory MCP interface with
    `index_status` or `list_projects`.
-4. Report node and edge counts when available.
-5. Tell the user that `.cbmignore` is tracked and should be committed. The Git
+5. Report node and edge counts when available.
+6. Tell the user that `.cbmignore` is tracked and should be committed. The Git
    hooks are clone-local, so rerun onboarding after a fresh clone.
 
-The initial index uses full mode. post-commit/post-merge/post-checkout
+The initial index uses full mode. Maintained-checkout post-commit/post-merge/post-checkout
 indexing uses fast mode in a detached process and always exits 0, so a broken
 index never fails a commit, merge, or checkout. Re-running onboarding is
 idempotent.

--- a/skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
+++ b/skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Shared contract checks for ephemeral Codebase Memory lifecycle scripts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+MINIMUM_VERSION = (0, 10, 8)
+VERSION_PATTERN = re.compile(rb"codebase-memory-mcp (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\n?\Z")
+
+
+def fail(message: str) -> "NoReturn":
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def identity(target: str, *, main_checkout: bool = False) -> None:
+    git_arguments = (
+        ["worktree", "list", "--porcelain", "-z"]
+        if main_checkout
+        else ["rev-parse", "--show-toplevel"]
+    )
+    result = subprocess.run(
+        ["git", "-C", target, *git_arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode != 0:
+        fail(f"not a Git repository: {target}")
+    if main_checkout:
+        fields = result.stdout.split(b"\0")
+        reported = next(
+            (field[len(b"worktree ") :] for field in fields if field.startswith(b"worktree ")),
+            b"",
+        )
+    else:
+        if not result.stdout.endswith(b"\n"):
+            fail(f"not a Git repository: {target}")
+        reported = result.stdout[:-1]
+    if not reported:
+        fail(f"not a Git repository: {target}")
+    if b"\n" in reported:
+        fail("checkout paths containing newline bytes are unsupported")
+    root = os.path.realpath(os.fsdecode(reported))
+    root_bytes = os.fsencode(root)
+    if b"\n" in root_bytes:
+        fail("checkout paths containing newline bytes are unsupported")
+    project = "cbm-onboard-v1-" + hashlib.sha256(root_bytes).hexdigest()
+    json.dump({"root": root, "project": project}, sys.stdout)
+    sys.stdout.write("\n")
+
+
+def validate_version(path: str) -> None:
+    banner = Path(path).read_bytes()
+    match = VERSION_PATTERN.fullmatch(banner)
+    if not match:
+        fail("unsupported codebase-memory-mcp version banner")
+    version = tuple(int(component) for component in match.groups())
+    if version < MINIMUM_VERSION:
+        fail("codebase-memory-mcp 0.10.8 or newer is required")
+
+
+def validate_response(project: str, status: str, is_error: str, path: str) -> None:
+    try:
+        envelope = json.loads(Path(path).read_text(encoding="utf-8"))
+        structured = envelope["structuredContent"]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError):
+        fail("invalid Codebase Memory JSON response")
+    expected_error = is_error == "true"
+    if (
+        not isinstance(structured, dict)
+        or structured.get("project") != project
+        or structured.get("status") != status
+        or envelope.get("isError") is not expected_error
+    ):
+        fail("Codebase Memory response did not match the requested project and status")
+
+
+def main() -> None:
+    if len(sys.argv) == 3 and sys.argv[1] == "identity":
+        identity(sys.argv[2])
+        return
+    if len(sys.argv) == 4 and sys.argv[1:3] == ["identity", "--main"]:
+        identity(sys.argv[3], main_checkout=True)
+        return
+    if len(sys.argv) == 3 and sys.argv[1] == "version":
+        validate_version(sys.argv[2])
+        return
+    if len(sys.argv) == 6 and sys.argv[1] == "response":
+        validate_response(*sys.argv[2:])
+        return
+    fail("usage: cbm-lifecycle.py identity [--main] PATH | version FILE | response PROJECT STATUS BOOL FILE")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tools/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/tools/cbm-onboard/scripts/cbm-onboard.sh
@@ -11,17 +11,53 @@ BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 REINDEX="$SCRIPT_DIR/cbm-reindex.sh"
+LIFECYCLE="$SCRIPT_DIR/cbm-lifecycle.py"
 
 THIS_CHECKOUT=0
+NO_HOOKS=0
 TARGET="."
-for arg in "$@"; do
-  case "$arg" in
+TARGET_SET=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
     --this-checkout) THIS_CHECKOUT=1 ;;
-    *) TARGET="$arg" ;;
+    --no-hooks) NO_HOOKS=1 ;;
+    --*)
+      printf 'unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+    *)
+      [ "$TARGET_SET" -eq 0 ] || {
+        printf '%s\n' "expected at most one repository path" >&2
+        exit 1
+      }
+      TARGET="$1"
+      TARGET_SET=1
+      ;;
   esac
+  shift
 done
 
-if [ "$THIS_CHECKOUT" -eq 1 ]; then
+if [ "$NO_HOOKS" -eq 1 ] && [ "${CBM_SKIP_INDEX:-0}" = "1" ]; then
+  printf '%s\n' "CBM_SKIP_INDEX=1 is not supported with --no-hooks" >&2
+  exit 1
+fi
+
+IDENTITY_TMP="$(mktemp)"
+VERSION_TMP="$(mktemp)"
+RESPONSE_TMP="$(mktemp)"
+trap 'rm -f "$IDENTITY_TMP" "$VERSION_TMP" "$RESPONSE_TMP"' EXIT
+
+if [ "$NO_HOOKS" -eq 1 ]; then
+  if [ "$THIS_CHECKOUT" -eq 1 ]; then
+    python3 "$LIFECYCLE" identity "$TARGET" >"$IDENTITY_TMP"
+  else
+    python3 "$LIFECYCLE" identity --main "$TARGET" >"$IDENTITY_TMP"
+  fi
+  ROOT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["root"])' "$IDENTITY_TMP")"
+  PROJECT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["project"])' "$IDENTITY_TMP")"
+  "$BIN" --version >"$VERSION_TMP"
+  python3 "$LIFECYCLE" version "$VERSION_TMP"
+elif [ "$THIS_CHECKOUT" -eq 1 ]; then
   ROOT="$(git -C "$TARGET" rev-parse --show-toplevel 2>/dev/null || true)"
 else
   ROOT="$(git -C "$TARGET" worktree list --porcelain 2>/dev/null |
@@ -46,7 +82,7 @@ END_HOOK="# <<< cbm-onboard managed reindex <<<"
 MANAGED_TMP="$(mktemp)"
 OUTPUT_TMP="$(mktemp)"
 HOOK_TMP="$(mktemp)"
-trap 'rm -f "$MANAGED_TMP" "$OUTPUT_TMP" "$HOOK_TMP"' EXIT
+trap 'rm -f "$IDENTITY_TMP" "$VERSION_TMP" "$RESPONSE_TMP" "$MANAGED_TMP" "$OUTPUT_TMP" "$HOOK_TMP"' EXIT
 
 {
   printf '%s\n' "$BEGIN_IGNORE"
@@ -109,6 +145,7 @@ else
   printf '%s\n' "$IGNORE is already current"
 fi
 
+if [ "$NO_HOOKS" -eq 0 ]; then
 COMMON_DIR="$(git -C "$ROOT" rev-parse --git-common-dir)"
 case "$COMMON_DIR" in
   /*) : ;;
@@ -194,9 +231,20 @@ for HOOK_NAME in post-commit post-merge post-checkout; do
 done
 
 [ "$HOOK_SYMLINK_REFUSED" -eq 0 ] || exit 1
+fi
 
 if [ "${CBM_SKIP_INDEX:-0}" = "1" ]; then
   printf '%s\n' "skipped initial index (CBM_SKIP_INDEX=1): $ROOT"
+elif [ "$NO_HOOKS" -eq 1 ]; then
+  INDEX_EXIT=0
+  "$BIN" cli --json index_repository --repo-path "$ROOT" --mode full --name "$PROJECT" \
+    >"$RESPONSE_TMP" || INDEX_EXIT=$?
+  python3 "$LIFECYCLE" response "$PROJECT" indexed false "$RESPONSE_TMP" || exit 1
+  [ "$INDEX_EXIT" -eq 0 ] || {
+    printf 'Codebase Memory index failed with exit %s\n' "$INDEX_EXIT" >&2
+    exit 1
+  }
+  printf '%s\n' "indexed $ROOT as $PROJECT"
 else
   PAYLOAD="$(python3 -c \
     'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "full"}))' \

--- a/skills/tools/cbm-onboard/scripts/cbm-teardown.sh
+++ b/skills/tools/cbm-onboard/scripts/cbm-teardown.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Remove one ephemeral checkout's deterministic Codebase Memory project.
+
+set -eu
+
+BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true)}"
+[ -n "$BIN" ] && [ -x "$BIN" ] || {
+  printf '%s\n' "codebase-memory-mcp is not executable; install it or set CODEBASE_MEMORY_BIN" >&2
+  exit 1
+}
+
+TARGET="."
+if [ "$#" -gt 1 ]; then
+  printf '%s\n' "expected at most one repository path" >&2
+  exit 1
+fi
+if [ "$#" -eq 1 ]; then
+  case "$1" in
+    --*)
+      printf 'unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+    *) TARGET="$1" ;;
+  esac
+fi
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LIFECYCLE="$SCRIPT_DIR/cbm-lifecycle.py"
+IDENTITY_TMP="$(mktemp)"
+VERSION_TMP="$(mktemp)"
+RESPONSE_TMP="$(mktemp)"
+trap 'rm -f "$IDENTITY_TMP" "$VERSION_TMP" "$RESPONSE_TMP"' EXIT
+
+python3 "$LIFECYCLE" identity "$TARGET" >"$IDENTITY_TMP"
+PROJECT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["project"])' "$IDENTITY_TMP")"
+"$BIN" --version >"$VERSION_TMP"
+python3 "$LIFECYCLE" version "$VERSION_TMP"
+
+DELETE_EXIT=0
+"$BIN" cli --json delete_project --project "$PROJECT" >"$RESPONSE_TMP" || DELETE_EXIT=$?
+case "$DELETE_EXIT" in
+  0)
+    python3 "$LIFECYCLE" response "$PROJECT" deleted false "$RESPONSE_TMP"
+    printf '%s\n' "deleted Codebase Memory project $PROJECT"
+    ;;
+  1)
+    python3 "$LIFECYCLE" response "$PROJECT" not_found true "$RESPONSE_TMP"
+    printf '%s\n' "Codebase Memory project $PROJECT was not found"
+    ;;
+  *)
+    printf 'Codebase Memory delete failed with exit %s\n' "$DELETE_EXIT" >&2
+    exit 1
+    ;;
+esac

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import importlib.util
 import io
 import json
@@ -22,6 +23,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 CBM_SCRIPT = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-onboard.sh"
+CBM_TEARDOWN = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-teardown.sh"
 SPIN_SCRIPT = ROOT / "skills" / "tools" / "spin-worktree" / "scripts" / "spin-worktree.py"
 CODEX_WORKER = ROOT / "skills" / "drivers" / "orchestrate" / "scripts" / "codex-worker.py"
 UI_CRAFT_AUDIT = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "audit.md"
@@ -78,6 +80,351 @@ class CbmOnboardTests(unittest.TestCase):
         )
         self.assertNotIn("must-not-appear", result.stdout + result.stderr)
         return result
+
+    def configure_lifecycle_binary(self):
+        self.requests = self.scratch / "requests.jsonl"
+        self.binary.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+if sys.argv[1:] == ["--version"]:
+    print(os.environ.get("CBM_FAKE_VERSION", "codebase-memory-mcp 0.10.8"))
+    raise SystemExit(0)
+
+with open(os.environ["CBM_FAKE_REQUESTS"], "a", encoding="utf-8") as handle:
+    handle.write(json.dumps(sys.argv[1:]) + "\\n")
+
+if "index_repository" in sys.argv:
+    project = sys.argv[sys.argv.index("--name") + 1] if "--name" in sys.argv else "derived-by-cbm"
+    status = "indexed"
+    is_error = False
+    exit_code = 0
+elif "delete_project" in sys.argv:
+    project = sys.argv[sys.argv.index("--project") + 1]
+    state = os.environ["CBM_FAKE_DELETE_STATE"]
+    if os.path.exists(state):
+        status = "not_found"
+        is_error = True
+        exit_code = 1
+    else:
+        open(state, "w", encoding="utf-8").close()
+        status = "deleted"
+        is_error = False
+        exit_code = 0
+else:
+    raise SystemExit(9)
+project = os.environ.get("CBM_FAKE_PROJECT", project)
+status = os.environ.get("CBM_FAKE_STATUS", status)
+if "CBM_FAKE_IS_ERROR" in os.environ:
+    is_error = os.environ["CBM_FAKE_IS_ERROR"] == "true"
+exit_code = int(os.environ.get("CBM_FAKE_EXIT", exit_code))
+if os.environ.get("CBM_FAKE_MALFORMED") == "1":
+    print("not json")
+    raise SystemExit(exit_code)
+print(json.dumps({
+    "structuredContent": {"project": project, "status": status},
+    "isError": is_error,
+}))
+raise SystemExit(exit_code)
+""",
+            encoding="utf-8",
+        )
+        self.binary.chmod(0o755)
+        self.environment["CBM_FAKE_REQUESTS"] = str(self.requests)
+        self.environment["CBM_FAKE_DELETE_STATE"] = str(self.scratch / "deleted")
+
+    def test_hookless_onboarding_indexes_exact_worktree_without_touching_hooks(self):
+        run(["git", "config", "user.name", "Test User"], cwd=self.repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=self.repo)
+        (self.repo / "README.md").write_text("fixture\n", encoding="utf-8")
+        run(["git", "add", "README.md"], cwd=self.repo)
+        self.assertEqual(run(["git", "commit", "-m", "fixture"], cwd=self.repo).returncode, 0)
+        worktree = self.scratch / "linked worktree"
+        self.assertEqual(
+            run(["git", "worktree", "add", "-b", "fixture-worktree", str(worktree)], cwd=self.repo).returncode,
+            0,
+        )
+        run(["git", "config", "core.hooksPath", ".custom-hooks"], cwd=self.repo)
+        configured_hooks = self.repo / ".custom-hooks"
+        configured_hooks.mkdir()
+        hooks = (
+            self.repo / ".git" / "hooks" / "post-commit",
+            configured_hooks / "post-commit",
+        )
+        for hook in hooks:
+            hook.write_bytes(b"#!/bin/sh\nprintf 'sentinel\\n'\n")
+        before = {hook: hook.read_bytes() for hook in hooks}
+        self.configure_lifecycle_binary()
+
+        result = run(
+            [str(CBM_SCRIPT), "--no-hooks", "--this-checkout", str(worktree)],
+            cwd=ROOT,
+            env=self.environment,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((worktree / ".cbmignore").exists())
+        self.assertFalse((self.repo / ".cbmignore").exists())
+        self.assertEqual({hook: hook.read_bytes() for hook in hooks}, before)
+        request = json.loads(self.requests.read_text(encoding="utf-8"))
+        canonical = str(worktree.resolve())
+        expected_name = "cbm-onboard-v1-" + hashlib.sha256(canonical.encode()).hexdigest()
+        self.assertEqual(
+            request,
+            ["cli", "--json", "index_repository", "--repo-path", canonical, "--mode", "full", "--name", expected_name],
+        )
+
+    def test_teardown_is_exact_idempotent_and_does_not_mutate_repository(self):
+        self.configure_lifecycle_binary()
+        hook = self.repo / ".git" / "hooks" / "post-commit"
+        hook.write_bytes(b"#!/bin/sh\nprintf 'sentinel\\n'\n")
+        onboard = run(
+            [str(CBM_SCRIPT), "--no-hooks", "--this-checkout", str(self.repo)],
+            cwd=ROOT,
+            env=self.environment,
+        )
+        self.assertEqual(onboard.returncode, 0, onboard.stderr)
+        before = {
+            "ignore": (self.repo / ".cbmignore").read_bytes(),
+            "hook": hook.read_bytes(),
+        }
+        before_files = {
+            path.relative_to(self.repo): (path.stat().st_mode, path.read_bytes())
+            for path in self.repo.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        }
+
+        first = run([str(CBM_TEARDOWN), str(self.repo)], cwd=ROOT, env=self.environment)
+        second = run([str(CBM_TEARDOWN), str(self.repo)], cwd=ROOT, env=self.environment)
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertIn("deleted", first.stdout)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertIn("not found", second.stdout)
+        self.assertEqual((self.repo / ".cbmignore").read_bytes(), before["ignore"])
+        self.assertEqual(hook.read_bytes(), before["hook"])
+        after_files = {
+            path.relative_to(self.repo): (path.stat().st_mode, path.read_bytes())
+            for path in self.repo.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        }
+        self.assertEqual(after_files, before_files)
+        canonical = str(self.repo.resolve())
+        project = "cbm-onboard-v1-" + hashlib.sha256(canonical.encode()).hexdigest()
+        requests = [json.loads(line) for line in self.requests.read_text(encoding="utf-8").splitlines()]
+        self.assertEqual(
+            requests[1:],
+            [
+                ["cli", "--json", "delete_project", "--project", project],
+                ["cli", "--json", "delete_project", "--project", project],
+            ],
+        )
+        self.assertTrue(all("list_projects" not in request for request in requests))
+
+    def test_default_onboarding_keeps_skip_hooks_and_derived_name_request(self):
+        self.configure_lifecycle_binary()
+        skipped_environment = self.environment | {"CBM_SKIP_INDEX": "1"}
+
+        skipped = run([str(CBM_SCRIPT), str(self.repo)], cwd=ROOT, env=skipped_environment)
+
+        self.assertEqual(skipped.returncode, 0, skipped.stderr)
+        self.assertIn(BEGIN_HOOK, (self.repo / ".git" / "hooks" / "post-commit").read_text())
+        self.assertFalse(self.requests.exists())
+
+        indexed = run([str(CBM_SCRIPT), str(self.repo)], cwd=ROOT, env=self.environment)
+
+        self.assertEqual(indexed.returncode, 0, indexed.stderr)
+        request = json.loads(self.requests.read_text(encoding="utf-8"))
+        self.assertEqual(request[:2], ["cli", "index_repository"])
+        self.assertEqual(json.loads(request[2]), {"repo_path": str(self.repo.resolve()), "mode": "full"})
+        self.assertNotIn("--name", request)
+
+    def test_hookless_onboarding_enforces_stable_numeric_version_grammar(self):
+        self.configure_lifecycle_binary()
+        cases = (
+            ("codebase-memory-mcp 0.10.7", False),
+            ("codebase-memory-mcp 0.10.8", True),
+            ("codebase-memory-mcp 0.10.10", True),
+            ("codebase-memory-mcp 0.11.0", True),
+            ("codebase-memory-mcp 1.0.0", True),
+            ("codebase-memory-mcp 0.010.8", False),
+            ("codebase-memory-mcp 0.10", False),
+            ("codebase-memory-mcp 0.10.8-beta.1", False),
+            ("prefix codebase-memory-mcp 0.10.8", False),
+            ("codebase-memory-mcp 0.10.8 suffix", False),
+        )
+
+        for banner, supported in cases:
+            with self.subTest(banner=banner):
+                ignore = self.repo / ".cbmignore"
+                if ignore.exists():
+                    ignore.unlink()
+                if self.requests.exists():
+                    self.requests.unlink()
+                environment = self.environment | {"CBM_FAKE_VERSION": banner}
+
+                result = run(
+                    [str(CBM_SCRIPT), "--no-hooks", "--this-checkout", str(self.repo)],
+                    cwd=ROOT,
+                    env=environment,
+                )
+
+                self.assertEqual(result.returncode == 0, supported, result.stderr)
+                self.assertEqual(ignore.exists(), supported)
+                self.assertEqual(self.requests.exists(), supported)
+
+    def test_lifecycle_responses_fail_closed(self):
+        self.configure_lifecycle_binary()
+        index_cases = (
+            {"CBM_FAKE_PROJECT": "wrong-project"},
+            {"CBM_FAKE_STATUS": "deleted"},
+            {"CBM_FAKE_IS_ERROR": "true"},
+            {"CBM_FAKE_EXIT": "1"},
+            {"CBM_FAKE_MALFORMED": "1"},
+        )
+        for update in index_cases:
+            with self.subTest(operation="index", update=update):
+                if self.requests.exists():
+                    self.requests.unlink()
+                result = run(
+                    [str(CBM_SCRIPT), "--no-hooks", "--this-checkout", str(self.repo)],
+                    cwd=ROOT,
+                    env=self.environment | update,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                request = json.loads(self.requests.read_text(encoding="utf-8"))
+                self.assertIn("index_repository", request)
+
+        delete_cases = (
+            {"CBM_FAKE_PROJECT": "wrong-project", "CBM_FAKE_STATUS": "deleted", "CBM_FAKE_IS_ERROR": "false", "CBM_FAKE_EXIT": "0"},
+            {"CBM_FAKE_STATUS": "indexed", "CBM_FAKE_IS_ERROR": "false", "CBM_FAKE_EXIT": "0"},
+            {"CBM_FAKE_STATUS": "deleted", "CBM_FAKE_IS_ERROR": "true", "CBM_FAKE_EXIT": "0"},
+            {"CBM_FAKE_STATUS": "deleted", "CBM_FAKE_IS_ERROR": "false", "CBM_FAKE_EXIT": "1"},
+            {"CBM_FAKE_STATUS": "not_found", "CBM_FAKE_IS_ERROR": "true", "CBM_FAKE_EXIT": "0"},
+            {"CBM_FAKE_STATUS": "deleted", "CBM_FAKE_IS_ERROR": "false", "CBM_FAKE_EXIT": "2"},
+            {"CBM_FAKE_MALFORMED": "1", "CBM_FAKE_EXIT": "0"},
+        )
+        for update in delete_cases:
+            with self.subTest(operation="delete", update=update):
+                if self.requests.exists():
+                    self.requests.unlink()
+                result = run(
+                    [str(CBM_TEARDOWN), str(self.repo)],
+                    cwd=ROOT,
+                    env=self.environment | update,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                request = json.loads(self.requests.read_text(encoding="utf-8"))
+                self.assertEqual(request[2], "delete_project")
+                self.assertNotIn("list_projects", request)
+
+    def test_identity_is_physical_across_relative_and_symlink_spellings(self):
+        self.configure_lifecycle_binary()
+        alias = self.scratch / "repo alias"
+        alias.symlink_to(self.repo, target_is_directory=True)
+        relative = os.path.relpath(self.repo, ROOT)
+
+        onboard = run(
+            [str(CBM_SCRIPT), "--no-hooks", "--this-checkout", str(alias)],
+            cwd=ROOT,
+            env=self.environment,
+        )
+        teardown = run([str(CBM_TEARDOWN), relative], cwd=ROOT, env=self.environment)
+
+        self.assertEqual(onboard.returncode, 0, onboard.stderr)
+        self.assertEqual(teardown.returncode, 0, teardown.stderr)
+        requests = [json.loads(line) for line in self.requests.read_text().splitlines()]
+        indexed_name = requests[0][requests[0].index("--name") + 1]
+        deleted_name = requests[1][requests[1].index("--project") + 1]
+        self.assertEqual(indexed_name, deleted_name)
+        self.assertEqual(
+            indexed_name,
+            "cbm-onboard-v1-" + hashlib.sha256(os.fsencode(self.repo.resolve())).hexdigest(),
+        )
+
+    def test_newline_checkout_paths_fail_before_mutation_or_graph_request(self):
+        self.configure_lifecycle_binary()
+        for name in ("embedded\nname", "trailing\n"):
+            with self.subTest(name=name):
+                checkout = self.scratch / name
+                checkout.mkdir()
+                self.assertEqual(run(["git", "init", "-b", "main"], cwd=checkout).returncode, 0)
+                if self.requests.exists():
+                    self.requests.unlink()
+
+                onboard = run(
+                    [str(CBM_SCRIPT), "--no-hooks", "--this-checkout", str(checkout)],
+                    cwd=ROOT,
+                    env=self.environment,
+                )
+                teardown = run([str(CBM_TEARDOWN), str(checkout)], cwd=ROOT, env=self.environment)
+
+                self.assertNotEqual(onboard.returncode, 0)
+                self.assertNotEqual(teardown.returncode, 0)
+                self.assertFalse((checkout / ".cbmignore").exists())
+                self.assertFalse(self.requests.exists())
+
+    def test_hookless_without_this_checkout_retains_main_checkout_resolution(self):
+        run(["git", "config", "user.name", "Test User"], cwd=self.repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=self.repo)
+        (self.repo / "README.md").write_text("fixture\n", encoding="utf-8")
+        run(["git", "add", "README.md"], cwd=self.repo)
+        self.assertEqual(run(["git", "commit", "-m", "fixture"], cwd=self.repo).returncode, 0)
+        worktree = self.scratch / "linked"
+        self.assertEqual(
+            run(["git", "worktree", "add", "-b", "linked", str(worktree)], cwd=self.repo).returncode,
+            0,
+        )
+        self.configure_lifecycle_binary()
+
+        result = run(
+            [str(CBM_SCRIPT), "--no-hooks", str(worktree)],
+            cwd=ROOT,
+            env=self.environment,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((self.repo / ".cbmignore").exists())
+        self.assertFalse((worktree / ".cbmignore").exists())
+        request = json.loads(self.requests.read_text())
+        self.assertEqual(request[request.index("--repo-path") + 1], str(self.repo.resolve()))
+
+    def test_rejects_invalid_arguments_and_hookless_skip_before_mutation(self):
+        cases = (
+            (["--unknown"], {}),
+            ([str(self.repo), str(self.scratch)], {}),
+            (["--no-hooks", str(self.repo)], {"CBM_SKIP_INDEX": "1"}),
+        )
+
+        for arguments, environment_update in cases:
+            with self.subTest(arguments=arguments):
+                ignore = self.repo / ".cbmignore"
+                if ignore.exists():
+                    ignore.unlink()
+                environment = self.environment | environment_update
+                result = run(
+                    [str(CBM_SCRIPT), *arguments],
+                    cwd=ROOT,
+                    env=environment,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(ignore.exists())
+                self.assertFalse(
+                    (self.repo / ".git" / "hooks" / "post-commit").exists()
+                )
+
+        for arguments in (["--unknown"], [str(self.repo), str(self.scratch)]):
+            with self.subTest(command="teardown", arguments=arguments):
+                result = run(
+                    [str(CBM_TEARDOWN), *arguments],
+                    cwd=ROOT,
+                    env=self.environment,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse((self.repo / ".cbmignore").exists())
 
     def test_refuses_cbmignore_symlink_without_touching_target(self):
         target = self.scratch / "outside-ignore"


### PR DESCRIPTION
## What changed

`cbm-onboard` now supports a complete lifecycle for short-lived worktrees without changing the control checkout:

- `--no-hooks --this-checkout <worktree>` indexes that exact physical checkout under a deterministic project identity while leaving shared Git hooks untouched.
- `cbm-teardown.sh <worktree>` deletes only that exact project and treats an already-missing project as successful, so cleanup is safe to repeat.
- Maintained-checkout onboarding keeps its existing `.cbmignore`, hook installation, skip, and derived-name behavior.
- The skill guidance now explains that linked worktrees share hooks and documents the v0.10.8+ ephemeral lifecycle.
- Public behavior tests cover path identity, strict arguments, version compatibility, hook isolation, exact deletion, idempotency, and fail-closed external responses. CI syntax-checks every lifecycle script.

This lets an external harness enroll a session worktree before launching an agent and remove its derived graph afterward without leaving stale projects or control-checkout hooks behind.

## Verification

```text
$ uv run --python 3.12 python scripts/validate.py && uv run --python 3.12 python -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket
validated 25 skills and 249 files
Ran 237 tests in 78.652s
OK (skipped=23)
```

Full adversarial review converged with no blocking Standards or Spec findings. The pre-push gate also reported `validated 25 skills and 251 files` and `DCO_OK commits=3`.

Closes #66
