### PR TITLE
Ship Codebase Memory discovery activation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,7 @@ jobs:
           tests.test_pr_body_gate
           tests.test_pr_body_bench
           tests.test_ticket
+          tests.test_codebase_memory_install
       - name: Check DCO
         if: github.event_name == 'pull_request'
         run: >-
@@ -40,6 +41,7 @@ jobs:
           python3 -m py_compile skills/workflows/review/scripts/resolve_route.py
           python3 -m py_compile skills/drivers/ticket/scripts/ticket.py
           python3 -m py_compile skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
+          python3 -m py_compile skills/tools/codebase-memory/scripts/install.py
           node --check skills/tools/drive-local-webapp/scripts/driver.mjs
           node --check skills/tools/drive-local-webapp/scripts/self-check.mjs
           sh -n skills/tools/cbm-onboard/scripts/cbm-onboard.sh
@@ -52,9 +54,14 @@ jobs:
       - name: Verify installed skills
         run: |
           for skill in drive-local-webapp cbm-onboard spin-worktree research \
-            implement tdd review prototype scope wayfinder plan-review \
+            codebase-memory implement tdd review prototype scope wayfinder plan-review \
             ui-craft orchestrate; do
             test -f ".agents/skills/$skill/SKILL.md"
+          done
+          for file in scripts/install.py config/claude-settings.json reminder.md \
+            hooks/cbm-code-discovery-gate hooks/cbm-session-reminder; do
+            cmp "skills/tools/codebase-memory/$file" \
+              ".agents/skills/codebase-memory/$file"
           done
       - name: Install pinned browser driver dependencies
         working-directory: skills/tools/drive-local-webapp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,9 @@ ui-surfaces: none
   driver installs its own deps under `skills/tools/drive-local-webapp` (`npm ci`
   plus `npx playwright install chromium`).
 - Test: `python3 scripts/validate.py && python3 -m unittest tests.test_behavior
-  tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench`
+  tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench
+  tests.test_ticket tests.test_codebase_memory_install && python3 -m py_compile
+  skills/tools/codebase-memory/scripts/install.py`
 - Dev: no app to run. To exercise a skill, install the pack into a scratch
   directory with `npx skills add . --skill '<name>' --copy --yes`.
 - Source: `skills/<category>/<name>/` (SKILL.md plus its own `references/`,

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 | Skill | Purpose | Extra requirement |
 | --- | --- | --- |
 | [`cbm-onboard`](skills/tools/cbm-onboard/SKILL.md) | Keep a maintained checkout indexed, or onboard and tear down a hookless ephemeral worktree | `codebase-memory-mcp` on `PATH`; v0.10.8+ for ephemeral lifecycle |
+| [`codebase-memory`](skills/tools/codebase-memory/SKILL.md) | Explore indexed code through the graph and activate portable Claude Code discovery hooks | `codebase-memory-mcp` for graph queries; activation fails open without it |
 | [`ci-design`](skills/tools/ci-design/SKILL.md) | Vocabulary and principles for well-designed CI | — |
 | [`code-review`](skills/tools/code-review/SKILL.md) | Review changes since a fixed point on two axes, Standards and Spec, each returning a verdict per enumerated item so a round terminates | Parallel-agent support recommended; GitHub CLI to fetch an originating issue; see [docs/review-round-mining.md](docs/review-round-mining.md) for the mined evidence behind the fix protocol and the round cap |
 | [`codebase-design`](skills/tools/codebase-design/SKILL.md) | Shared vocabulary for designing deep modules | — |
@@ -67,6 +68,17 @@ Install another skill by itself:
 npx skills add ConnorGriffin/skills --skill spin-worktree
 ```
 
+Install and activate the code-discovery bundle:
+
+```sh
+npx skills add ConnorGriffin/skills --skill codebase-memory
+python3 ~/.claude/skills/codebase-memory/scripts/install.py
+```
+
+The activation command merges the skill-owned hook registrations into existing
+Claude Code settings without replacing unrelated hooks. It does not install the
+external `codebase-memory-mcp` executable/server or index a repository.
+
 Install every skill:
 
 ```sh
@@ -82,8 +94,10 @@ hooks.
 
 Optional integrations are enhancements, not hidden runtime requirements:
 
-- **Codebase Memory:** accelerates structural exploration. Without it, use
-  ordinary repository search and file reads.
+- **`codebase-memory-mcp`:** the external executable/server used by the included
+  `codebase-memory` skill for graph queries. Without the server, the discovery
+  augmentation hook fails open and ordinary repository search and file reads remain
+  available; installing or activating the skill does not install the server.
 - **`codebase-design`:** referenced by `tdd`; helps shape non-trivial module
   interfaces. Without it, keep the shipping module shape and preserve locality.
 - **`domain-modeling`:** referenced by `scope`'s interview mode and `wayfinder`; maintains a

--- a/docs/adr/adr-65-code-discovery-bundle.md
+++ b/docs/adr/adr-65-code-discovery-bundle.md
@@ -1,0 +1,3 @@
+# ADR 65 — The code-discovery skill owns activation
+
+The public `codebase-memory` skill is the canonical source for its discovery hooks, settings registrations, standing instruction, and one installer command that activates them without clobbering existing configuration. Keeping the installer beside the skill gives every consumer one small interface and one implementation; machine repositories may invoke it, but must not reimplement its merge behavior or own divergent copies.

--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -22,8 +22,9 @@ step, so deleting a line removes the link on the next run.
 3. Third-party packs, read only. One machine links 13 skills from an internal pack
    published by its employer, and 2 from `github.com/mattpocock/skills`. Cloned, pinned
    to `main`, linked by allowlist, never edited in place.
-4. The machine's dotfiles: private. The `CLAUDE.md` overlay, `settings.json`, hooks,
-   `.mcp.json`, and the allowlists. It holds no skills at all.
+4. The machine's dotfiles: private. The `CLAUDE.md` overlay, machine-only
+   `settings.json` entries and hooks, `.mcp.json`, and the allowlists. It holds no
+   skills and does not own portable skill behavior.
 
 ### Where a new skill goes
 
@@ -31,7 +32,9 @@ step, so deleting a line removes the link on the next run.
    work? It goes in the private per-machine repo.
 2. Does someone else maintain it? It stays in their pack, linked read only.
 3. Otherwise it goes here, where every machine can link it.
-4. Configuration is not a skill. Hooks, settings and allowlists go in dotfiles.
+4. Portable skill-owned hooks and registration templates live with their skill and
+   are activated through that skill's installer. Machine-only configuration and
+   allowlists stay in dotfiles.
 
 ## Precedence
 
@@ -101,6 +104,11 @@ A skill carrying always-on rules ships a `reminder.md` digest next to its `SKILL
 Those rules decay over a long session, so a `UserPromptSubmit` hook re-injects the
 digest at prompt time. There is no second copy to drift.
 
+The event belongs to the behavior: `say-less` uses `UserPromptSubmit`, while
+`codebase-memory` installs its byte-identical reminder for `SessionStart` and keeps
+the canonical registrations under `skills/tools/codebase-memory/config/`. In both
+cases `reminder.md` is the only authored policy.
+
 ```json
 {
   "hooks": {
@@ -130,7 +138,8 @@ missing file is non-blocking.
 3. Write one allowlist per source, then run the installer.
 4. Link `output-styles/say-less.md` into `~/.claude/output-styles/` and set
    `"outputStyle": "say-less"` in `~/.claude/settings.json`.
-5. Add the digest hook to that same settings file.
+5. Activate each portable skill-owned hook through that skill's installer; add only
+   machine-owned registrations directly to the settings file.
 6. Re-run the installer after any allowlist edit and after any `git pull`.
 
 ## Rules
@@ -150,5 +159,7 @@ missing file is non-blocking.
   carry it, and reserve instructions for what only the model can decide.
 * Delete what nothing invokes. A skill with no recorded invocation gets deleted, not
   kept in case it is useful later. The local transcripts are the evidence.
-* A skill that carries always-on behavior ships a `reminder.md` digest and documents the
-  pointer line an overlay should add.
+* A skill that carries always-on behavior ships a `reminder.md` digest, owns any
+  portable hook and registration template that enforces it, and documents its
+  activation command and shared-profile pointer. Machine-only hooks remain in
+  dotfiles.

--- a/docs/scope/ship-code-discovery-hooks.md
+++ b/docs/scope/ship-code-discovery-hooks.md
@@ -1,0 +1,38 @@
+# Ship code-discovery hooks
+
+## Decisions
+
+- Classify issue #65 as code work delivered through pull requests. The portable pack and its private dotfiles consumer both require tracked changes. `inline`
+- Treat the public pack as the canonical source for the code-discovery skill, hook executables, settings fragment, and standing instruction. A clean consumer cannot depend on private dotfiles. `→ ADR` discharged by [`docs/adr/adr-65-code-discovery-bundle.md`](../adr/adr-65-code-discovery-bundle.md).
+- Preserve existing hook registrations while installing the discovery hooks. The issue explicitly forbids clobbering consumer configuration. `inline`
+- Limit issue #65 to the canonical public-pack change and file a linked `dotfiles` migration issue. Each repository keeps one ticket, branch, worktree, and pull request while the dependency remains explicit. `→ issue` discharged by [ConnorGriffin/dotfiles#73](https://github.com/ConnorGriffin/dotfiles/issues/73).
+- Expose code-discovery activation as one installer command bundled inside the `codebase-memory` skill. The interface hides hook placement and settings merging so every consumer uses one implementation. `→ ADR` discharged by [`docs/adr/adr-65-code-discovery-bundle.md`](../adr/adr-65-code-discovery-bundle.md).
+- Fail before writing anything when settings are malformed or an existing discovery registration conflicts with the canonical registration. Report the exact conflict and leave manual recovery to the operator. `inline`
+- Treat concurrent mutation of the selected Claude home while installation runs as unsupported. The installer validates the state it observes, but does not add descriptor-anchored race machinery for another process replacing paths mid-run. `inline`
+
+### Risk contract
+
+- **Must prevent:** from the filesystem state observed during pre-write validation, clobbering unrelated hook registrations or nodes; exposing secrets or private machine paths; reporting success after partial, conflicting, or non-executable activation; corrupting an existing settings file or following an already-present managed-path symlink into an external target.
+- **Must recover:** every managed-file and settings update is atomic; an interrupted installation must leave each destination at its complete old or new bytes, ignore unfinished temporary files, keep the original settings valid, and converge on rerun without duplicate registrations.
+- **Accepted failure:** malformed settings; a symlink or other non-regular settings node; a conflicting discovery registration; a hooks path that exists but is not a real, non-symlink directory; or an existing unowned/non-regular node at a managed hook-directory path stops before any write, exits non-zero with the exact conflict, and requires the operator to repair the input before retrying.
+- **Unsupported:** concurrent mutation of the selected Claude home while installation runs; configuration formats other than Claude Code's JSON settings schema; installing or configuring the `codebase-memory-mcp` server itself; migrating a consumer's private configuration within issue #65.
+- **Evidence owed:** public-interface tests prove clean installation; preservation of unrelated existing hooks; idempotent reruns; exact registration deduplication; atomic managed-file and settings replacement; convergence from complete managed files with settings absent and with unfinished temporary files present; no-write malformed-settings, non-regular-settings-node, registration-conflict, symlinked-hooks-directory, unmarked-file, leaf-symlink, broken-symlink, directory, and FIFO failures with external targets unchanged; shell-safe executable registrations for caller-supplied Claude-home paths including whitespace; executable hook installation; and discovery instructions available from the public pack.
+
+Why: the installer writes user configuration at a trust boundary, but failures are locally visible and manually recoverable when the original file is preserved.
+
+Disposition: copy unchanged into the issue #65 work order.
+
+## Open questions
+
+- None.
+
+## Spawned tasks
+
+- [ConnorGriffin/dotfiles#73](https://github.com/ConnorGriffin/dotfiles/issues/73) migrates the private consumer after issue #65 lands.
+
+## Review rounds
+
+- Panel 1: five unique blocking defects, all `authoring` — unnamed migrated behavior/canonical artifacts, contradictory duplicated discovery policy, stale private tool facts, and incomplete managed-node safety. The first fix verification found one remaining `authoring` path-quoting defect and one `injected` risk-ledger drift defect.
+- Panel 1 verification after the clean rewrite: zero blockers; the injected count returned to zero, so the rewrite-clean signal did not fire.
+- Panel 2 fresh pass: two `authoring` blockers — managed files were not atomically recoverable, and a symlinked hooks directory could redirect writes. Same-panel verification after the fix: zero blockers.
+- Panel 3 fresh pass: one `authoring` blocker — preventing a concurrent hooks-directory replacement required descriptor-anchored race machinery. Scope reopened; the user classified concurrent Claude-home mutation during installation as unsupported. Same-panel verification: zero blockers and countersigned.

--- a/profile/base.md
+++ b/profile/base.md
@@ -63,6 +63,10 @@ re-raise it.
 **Register.** The say-less skill in this pack owns response shape and register
 (answer-first, stop when done, terse); follow it wherever it is installed.
 
+**Code discovery.** When
+`~/.claude/skills/codebase-memory/reminder.md` is installed, read and follow that
+skill-owned policy for code discovery.
+
 **The final answer stands alone** — the outcome, what was decided, what changed on
 disk, and anything still blocked, without me scrolling the tool log. Restate a narrated
 finding where the answer needs it, and always repeat the state changes. Omit the

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -24,6 +24,7 @@ EXPECTED = {
     "drivers/orchestrate",
     "drivers/ticket",
     "tools/cbm-onboard",
+    "tools/codebase-memory",
     "tools/ci-design",
     "tools/code-review",
     "tools/codebase-design",

--- a/skills/tools/codebase-memory/SKILL.md
+++ b/skills/tools/codebase-memory/SKILL.md
@@ -5,7 +5,6 @@ description: Use the codebase knowledge graph for structural code queries, trace
 
 # Codebase Memory
 
-Use the graph for structural code discovery when the exact repository is indexed.
 Follow [reminder.md](reminder.md) for the standing discovery policy; it is the one
 authored policy shared by this skill, the profile pointer, and the installed
 SessionStart hook.
@@ -28,18 +27,16 @@ The installer owns three files under the selected Claude home's `hooks/`
 directory and merges the skill's registrations into `settings.json`. It preserves
 unrelated settings and hook registrations. Malformed settings, conflicting
 registrations, symlinks, and unowned managed-path files are no-write failures.
-Activation does not install `codebase-memory-mcp` or index a repository.
+Its scope is the bundled files and registrations.
 
-## Structural discovery workflow
+## Graph-query vocabulary
 
-1. Call `list_projects` and `index_status` before structural queries.
-2. Use `get_architecture` for high-level orientation.
-3. Use `search_graph` to locate symbols by name, label, or qualified-name pattern.
-4. Use `trace_path` for callers, callees, data flow, and cross-service paths.
-5. Use `get_code_snippet` after resolving an exact qualified name.
-6. Use `query_graph` for complex multi-hop graph questions.
-7. Use `detect_changes` to map a Git diff to its structural impact.
-
-Use `search_code` or ordinary repository search for literal text. Use
-`index_repository` only when indexing is explicitly requested or the target
-repository requires it.
+- `list_projects` and `index_status` report indexed-project inventory and health.
+- `get_architecture` summarizes repository structure and architectural relationships.
+- `search_graph` locates symbols by name, label, or qualified-name pattern.
+- `trace_path` follows callers, callees, data flow, and cross-service paths.
+- `get_code_snippet` returns exact source for a resolved symbol.
+- `query_graph` handles complex multi-hop graph questions.
+- `search_code` searches literal source text.
+- `detect_changes` maps a Git diff to its structural impact.
+- `index_repository` creates or refreshes a repository graph.

--- a/skills/tools/codebase-memory/SKILL.md
+++ b/skills/tools/codebase-memory/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: codebase-memory
+description: Use the codebase knowledge graph for structural code queries, trace call paths and dependencies, inspect architecture, assess change impact, or activate the bundled Claude Code discovery hooks.
+---
+
+# Codebase Memory
+
+Use the graph for structural code discovery when the exact repository is indexed.
+Follow [reminder.md](reminder.md) for the standing discovery policy; it is the one
+authored policy shared by this skill, the profile pointer, and the installed
+SessionStart hook.
+
+## Activate discovery guidance in Claude Code
+
+After the standard skills installer copies this directory, run:
+
+```sh
+python3 ~/.claude/skills/codebase-memory/scripts/install.py
+```
+
+For a non-default Claude home:
+
+```sh
+python3 <installed-skill>/scripts/install.py --claude-home PATH
+```
+
+The installer owns three files under the selected Claude home's `hooks/`
+directory and merges the skill's registrations into `settings.json`. It preserves
+unrelated settings and hook registrations. Malformed settings, conflicting
+registrations, symlinks, and unowned managed-path files are no-write failures.
+Activation does not install `codebase-memory-mcp` or index a repository.
+
+## Structural discovery workflow
+
+1. Call `list_projects` and `index_status` before structural queries.
+2. Use `get_architecture` for high-level orientation.
+3. Use `search_graph` to locate symbols by name, label, or qualified-name pattern.
+4. Use `trace_path` for callers, callees, data flow, and cross-service paths.
+5. Use `get_code_snippet` after resolving an exact qualified name.
+6. Use `query_graph` for complex multi-hop graph questions.
+7. Use `detect_changes` to map a Git diff to its structural impact.
+
+Use `search_code` or ordinary repository search for literal text. Use
+`index_repository` only when indexing is explicitly requested or the target
+repository requires it.

--- a/skills/tools/codebase-memory/agents/openai.yaml
+++ b/skills/tools/codebase-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codebase Memory"
+  short_description: "Explore indexed code through its knowledge graph"
+  default_prompt: "Use $codebase-memory to explore this repository through the code graph."

--- a/skills/tools/codebase-memory/config/claude-settings.json
+++ b/skills/tools/codebase-memory/config/claude-settings.json
@@ -1,0 +1,54 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<CLAUDE_HOME>/hooks/cbm-code-discovery-gate",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<CLAUDE_HOME>/hooks/cbm-session-reminder"
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<CLAUDE_HOME>/hooks/cbm-session-reminder"
+          }
+        ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<CLAUDE_HOME>/hooks/cbm-session-reminder"
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<CLAUDE_HOME>/hooks/cbm-session-reminder"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/tools/codebase-memory/hooks/cbm-code-discovery-gate
+++ b/skills/tools/codebase-memory/hooks/cbm-code-discovery-gate
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Managed by codebase-memory skill installer.
+# Augment Grep/Glob discovery when codebase-memory-mcp is available; fail open.
+
+if [ -n "${CODEBASE_MEMORY_BIN:-}" ]; then
+    cbm_bin=$CODEBASE_MEMORY_BIN
+else
+    cbm_bin=$(command -v codebase-memory-mcp 2>/dev/null) || exit 0
+fi
+
+[ -x "$cbm_bin" ] || exit 0
+cbm_output=$(mktemp "${TMPDIR:-/tmp}/cbm-augment.XXXXXX") || exit 0
+trap 'rm -f "$cbm_output"' EXIT HUP INT TERM
+if "$cbm_bin" hook-augment >"$cbm_output" 2>/dev/null; then
+    cat "$cbm_output"
+fi
+exit 0

--- a/skills/tools/codebase-memory/hooks/cbm-session-reminder
+++ b/skills/tools/codebase-memory/hooks/cbm-session-reminder
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Managed by codebase-memory skill installer.
+
+cbm_hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 0
+cat "$cbm_hook_dir/cbm-code-discovery-reminder.md" 2>/dev/null || true

--- a/skills/tools/codebase-memory/reminder.md
+++ b/skills/tools/codebase-memory/reminder.md
@@ -1,0 +1,14 @@
+Managed by codebase-memory skill installer.
+
+# Code discovery policy
+
+Use codebase-memory-mcp graph tools first for structural code exploration only
+when `list_projects` and `index_status` show that the exact project is indexed.
+Use `search_graph` to find symbols, `trace_path` for callers and callees,
+`get_code_snippet` for exact source, `query_graph` for multi-hop questions, and
+`get_architecture` for orientation. Use `search_code` or ordinary search and
+file reads for literal text, configuration, non-code files, and unindexed
+projects.
+
+Activating this skill never indexes a project. Run `index_repository` only when
+indexing is explicitly requested or required by the target repository.

--- a/skills/tools/codebase-memory/scripts/install.py
+++ b/skills/tools/codebase-memory/scripts/install.py
@@ -69,7 +69,7 @@ def command_target(command: object) -> str | None:
         words = shlex.split(command)
     except ValueError:
         return None
-    if len(words) != 1:
+    if not words:
         return None
     return os.path.abspath(os.path.expanduser(words[0]))
 

--- a/skills/tools/codebase-memory/scripts/install.py
+++ b/skills/tools/codebase-memory/scripts/install.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Activate the codebase-memory skill's Claude Code discovery hooks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import stat
+import tempfile
+from pathlib import Path
+
+
+SKILL_DIRECTORY = Path(__file__).resolve().parents[1]
+OWNERSHIP = "Managed by codebase-memory skill installer."
+MANAGED_FILES = {
+    "cbm-code-discovery-gate": (SKILL_DIRECTORY / "hooks" / "cbm-code-discovery-gate", 0o755),
+    "cbm-session-reminder": (SKILL_DIRECTORY / "hooks" / "cbm-session-reminder", 0o755),
+    "cbm-code-discovery-reminder.md": (SKILL_DIRECTORY / "reminder.md", 0o644),
+}
+
+
+def lstat_or_none(path: Path) -> os.stat_result | None:
+    try:
+        return path.lstat()
+    except FileNotFoundError:
+        return None
+
+
+def arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Activate codebase-memory discovery hooks in Claude Code."
+    )
+    parser.add_argument(
+        "--claude-home",
+        type=Path,
+        default=Path.home() / ".claude",
+        help="Claude Code home directory (default: $HOME/.claude)",
+    )
+    return parser.parse_args()
+
+
+def atomic_write(path: Path, content: bytes, mode: int) -> None:
+    if path.exists() and path.read_bytes() == content and stat.S_IMODE(path.stat().st_mode) == mode:
+        return
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".codebase-memory-install-", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def command_target(command: object) -> str | None:
+    if not isinstance(command, str):
+        return None
+    try:
+        words = shlex.split(command)
+    except ValueError:
+        return None
+    if len(words) != 1:
+        return None
+    return os.path.abspath(os.path.expanduser(words[0]))
+
+
+def merge_settings(existing: dict, canonical: dict) -> dict:
+    if not isinstance(existing, dict):
+        raise ValueError("settings root must be an object")
+    hooks = existing.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        raise ValueError("settings hooks must be an object")
+
+    expected_by_target: dict[str, list[tuple[str, dict]]] = {}
+    for event, entries in canonical["hooks"].items():
+        for entry in entries:
+            for hook in entry["hooks"]:
+                target = command_target(hook["command"])
+                if target is None:
+                    raise ValueError("canonical managed hook command is not executable")
+                expected_by_target.setdefault(target, []).append((event, entry))
+
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            raise ValueError(f"settings hooks.{event} must be an array")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError(f"settings hooks.{event} entries must be objects")
+            entry_hooks = entry.get("hooks", [])
+            if not isinstance(entry_hooks, list):
+                raise ValueError(f"settings hooks.{event} entry hooks must be an array")
+            managed_targets = {
+                command_target(hook.get("command"))
+                for hook in entry_hooks
+                if isinstance(hook, dict)
+                and command_target(hook.get("command")) in expected_by_target
+            }
+            for target in managed_targets:
+                if not any(
+                    event == expected_event and entry == expected_entry
+                    for expected_event, expected_entry in expected_by_target[target]
+                ):
+                    raise ValueError(
+                        f"conflicting managed hook registration for {target}"
+                    )
+
+    for event, required_entries in canonical["hooks"].items():
+        current_entries = hooks.setdefault(event, [])
+        for required in required_entries:
+            matches = [index for index, entry in enumerate(current_entries) if entry == required]
+            if not matches:
+                current_entries.append(required)
+                continue
+            for index in reversed(matches[1:]):
+                del current_entries[index]
+    return existing
+
+
+def main() -> int:
+    claude_home = arguments().claude_home.expanduser().absolute()
+    hooks_directory = claude_home / "hooks"
+    settings_path = claude_home / "settings.json"
+    settings_stat = lstat_or_none(settings_path)
+    if settings_stat is not None and not stat.S_ISREG(settings_stat.st_mode):
+        raise SystemExit("settings.json must be a regular non-symlink file")
+    hooks_stat = lstat_or_none(hooks_directory)
+    if hooks_stat is not None and not stat.S_ISDIR(hooks_stat.st_mode):
+        raise SystemExit("hooks must be a real non-symlink directory")
+    planned_files = {}
+    for name, (source, mode) in MANAGED_FILES.items():
+        content = source.read_bytes()
+        if OWNERSHIP.encode() not in content:
+            raise SystemExit(f"source is missing ownership text: {source}")
+        planned_files[name] = (content, mode)
+
+    if hooks_stat is not None:
+        for name in MANAGED_FILES:
+            destination = hooks_directory / name
+            destination_stat = lstat_or_none(destination)
+            if destination_stat is None:
+                continue
+            if not stat.S_ISREG(destination_stat.st_mode):
+                raise SystemExit(
+                    f"managed target must be a regular non-symlink file: {destination}"
+                )
+            if OWNERSHIP.encode() not in destination.read_bytes():
+                raise SystemExit(f"managed target is not owned: {destination}")
+
+    template = json.loads(
+        (SKILL_DIRECTORY / "config" / "claude-settings.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    quoted_home = shlex.quote(str(claude_home))
+    for entries in template["hooks"].values():
+        for entry in entries:
+            for hook in entry["hooks"]:
+                hook["command"] = hook["command"].replace(
+                    "<CLAUDE_HOME>", quoted_home
+                )
+    canonical = template
+    if settings_stat is not None:
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise SystemExit(
+                f"settings.json is not valid JSON: {error.msg}"
+            ) from error
+        settings_mode = stat.S_IMODE(settings_stat.st_mode)
+    else:
+        settings = {}
+        settings_mode = 0o600
+    try:
+        merged = merge_settings(settings, canonical)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    content = (json.dumps(merged, indent=2) + "\n").encode()
+
+    claude_home.mkdir(parents=True, exist_ok=True)
+    hooks_directory.mkdir(exist_ok=True)
+    for name, (planned_content, mode) in planned_files.items():
+        atomic_write(hooks_directory / name, planned_content, mode)
+    atomic_write(settings_path, content, settings_mode)
+    print(f"Activated codebase-memory discovery hooks in {claude_home}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_codebase_memory_install.py
+++ b/tests/test_codebase_memory_install.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "skills" / "tools" / "codebase-memory"
+INSTALLER = SKILL / "scripts" / "install.py"
+OWNERSHIP = "Managed by codebase-memory skill installer."
+
+
+def filesystem_snapshot(root: Path) -> dict[str, tuple[int, str | bytes | None]]:
+    snapshot = {}
+
+    def visit(directory: Path) -> None:
+        for entry in os.scandir(directory):
+            path = Path(entry.path)
+            relative = path.relative_to(root).as_posix()
+            metadata = entry.stat(follow_symlinks=False)
+            kind = metadata.st_mode & 0o170000
+            if entry.is_symlink():
+                payload: str | bytes | None = os.readlink(path)
+            elif entry.is_file(follow_symlinks=False):
+                payload = path.read_bytes()
+            else:
+                payload = None
+            snapshot[relative] = (kind, payload)
+            if entry.is_dir(follow_symlinks=False):
+                visit(path)
+
+    if root.is_dir() and not root.is_symlink():
+        visit(root)
+    return snapshot
+
+
+class CodebaseMemoryInstallTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.scratch = Path(self.temporary.name)
+        self.claude_home = self.scratch / "claude-home"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def install(self, claude_home: Path | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "python3",
+                str(INSTALLER),
+                "--claude-home",
+                str(claude_home or self.claude_home),
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def settings(self, claude_home: Path | None = None) -> dict:
+        path = (claude_home or self.claude_home) / "settings.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_clean_install_activates_the_public_skill(self):
+        result = self.install()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        hooks = self.claude_home / "hooks"
+        gate = hooks / "cbm-code-discovery-gate"
+        session = hooks / "cbm-session-reminder"
+        reminder = hooks / "cbm-code-discovery-reminder.md"
+        for path in (gate, session, reminder):
+            self.assertTrue(path.is_file(), path)
+            self.assertIn(OWNERSHIP, path.read_text(encoding="utf-8"))
+        self.assertTrue(os.access(gate, os.X_OK))
+        self.assertTrue(os.access(session, os.X_OK))
+        self.assertFalse(reminder.stat().st_mode & 0o111)
+
+        settings = self.settings()
+        self.assertEqual(settings["hooks"]["PreToolUse"][0]["matcher"], "Grep|Glob")
+        self.assertEqual(
+            [entry["matcher"] for entry in settings["hooks"]["SessionStart"]],
+            ["startup", "resume", "clear", "compact"],
+        )
+        self.assertEqual(self.claude_home.joinpath("settings.json").stat().st_mode & 0o777, 0o600)
+
+    def test_existing_settings_are_merged_and_reruns_are_byte_stable(self):
+        self.claude_home.mkdir()
+        settings_path = self.claude_home / "settings.json"
+        canonical_gate = {
+            "matcher": "Grep|Glob",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": f"{self.claude_home}/hooks/cbm-code-discovery-gate",
+                    "timeout": 5,
+                }
+            ],
+        }
+        original = {
+            "model": "opus",
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Write|Edit", "hooks": [{"type": "command", "command": "safe-hook"}]},
+                    canonical_gate,
+                    canonical_gate,
+                ],
+                "Stop": [{"hooks": [{"type": "command", "command": "stop-hook"}]}],
+            },
+        }
+        settings_path.write_text(json.dumps(original), encoding="utf-8")
+        settings_path.chmod(0o640)
+
+        first = self.install()
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        merged = self.settings()
+        self.assertEqual(merged["model"], "opus")
+        self.assertEqual(merged["hooks"]["Stop"], original["hooks"]["Stop"])
+        self.assertEqual(merged["hooks"]["PreToolUse"][0], original["hooks"]["PreToolUse"][0])
+        self.assertEqual(merged["hooks"]["PreToolUse"].count(canonical_gate), 1)
+        self.assertEqual(settings_path.stat().st_mode & 0o777, 0o640)
+        first_bytes = {
+            path.name: path.read_bytes()
+            for path in [settings_path, *sorted((self.claude_home / "hooks").iterdir())]
+        }
+
+        second = self.install()
+
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_bytes = {
+            path.name: path.read_bytes()
+            for path in [settings_path, *sorted((self.claude_home / "hooks").iterdir())]
+        }
+        self.assertEqual(second_bytes, first_bytes)
+
+    def test_malformed_settings_fail_before_any_write(self):
+        self.claude_home.mkdir()
+        settings_path = self.claude_home / "settings.json"
+        malformed = b'{"hooks": '
+        settings_path.write_bytes(malformed)
+
+        result = self.install()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("settings.json is not valid JSON", result.stderr)
+        self.assertEqual(settings_path.read_bytes(), malformed)
+        self.assertFalse((self.claude_home / "hooks").exists())
+
+    def test_conflicting_managed_registration_fails_before_any_write(self):
+        self.claude_home.mkdir()
+        settings_path = self.claude_home / "settings.json"
+        conflicting = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Grep|Glob",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": f"{self.claude_home}/hooks/cbm-code-discovery-gate",
+                                "timeout": 10,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        original = (json.dumps(conflicting) + "\n").encode()
+        settings_path.write_bytes(original)
+
+        result = self.install()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("conflicting managed hook registration", result.stderr)
+        self.assertEqual(settings_path.read_bytes(), original)
+        self.assertFalse((self.claude_home / "hooks").exists())
+
+    def test_legacy_tilde_registration_target_is_a_conflict(self):
+        home = self.scratch / "home"
+        claude_home = home / ".claude"
+        claude_home.mkdir(parents=True)
+        settings_path = claude_home / "settings.json"
+        legacy = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Grep|Glob",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "~/.claude/hooks/cbm-code-discovery-gate",
+                                "timeout": 5,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        original = (json.dumps(legacy) + "\n").encode()
+        settings_path.write_bytes(original)
+        environment = os.environ.copy()
+        environment["HOME"] = str(home)
+
+        result = subprocess.run(
+            ["python3", str(INSTALLER), "--claude-home", str(claude_home)],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("conflicting managed hook registration", result.stderr)
+        self.assertEqual(settings_path.read_bytes(), original)
+        self.assertFalse((claude_home / "hooks").exists())
+
+    def test_symlinked_settings_fail_without_following_the_external_target(self):
+        self.claude_home.mkdir()
+        external = self.scratch / "external-settings.json"
+        original = b'{"external": true}\n'
+        external.write_bytes(original)
+        settings_path = self.claude_home / "settings.json"
+        settings_path.symlink_to(external)
+
+        result = self.install()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("settings.json must be a regular non-symlink file", result.stderr)
+        self.assertTrue(settings_path.is_symlink())
+        self.assertEqual(external.read_bytes(), original)
+        self.assertFalse((self.claude_home / "hooks").exists())
+
+    def test_symlinked_hooks_directory_fails_without_writing_through_it(self):
+        self.claude_home.mkdir()
+        external = self.scratch / "external-hooks"
+        external.mkdir()
+        sentinel = external / "sentinel"
+        sentinel.write_text("unchanged", encoding="utf-8")
+        (self.claude_home / "hooks").symlink_to(external, target_is_directory=True)
+
+        result = self.install()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("hooks must be a real non-symlink directory", result.stderr)
+        self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
+        self.assertEqual(sorted(path.name for path in external.iterdir()), ["sentinel"])
+        self.assertFalse((self.claude_home / "settings.json").exists())
+
+    def test_every_non_regular_or_unowned_managed_node_is_a_no_write_failure(self):
+        cases = (
+            ("settings-directory", "settings", "directory"),
+            ("settings-fifo", "settings", "fifo"),
+            ("hooks-file", "hooks", "file"),
+            ("gate-unmarked", "gate", "file"),
+            ("gate-symlink", "gate", "symlink"),
+            ("gate-broken-symlink", "gate", "broken-symlink"),
+            ("gate-directory", "gate", "directory"),
+            ("gate-fifo", "gate", "fifo"),
+        )
+        for name, target, node_kind in cases:
+            with self.subTest(name=name):
+                claude_home = self.scratch / name
+                claude_home.mkdir()
+                external = self.scratch / f"{name}-external"
+                external.write_bytes(b"external unchanged")
+                if target == "settings":
+                    path = claude_home / "settings.json"
+                elif target == "hooks":
+                    path = claude_home / "hooks"
+                else:
+                    hooks = claude_home / "hooks"
+                    hooks.mkdir()
+                    path = hooks / "cbm-code-discovery-gate"
+
+                if node_kind == "directory":
+                    path.mkdir()
+                elif node_kind == "fifo":
+                    os.mkfifo(path)
+                elif node_kind == "symlink":
+                    path.symlink_to(external)
+                elif node_kind == "broken-symlink":
+                    path.symlink_to(self.scratch / "does-not-exist")
+                else:
+                    path.write_text("not managed", encoding="utf-8")
+
+                before = filesystem_snapshot(claude_home)
+                result = self.install(claude_home)
+
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertEqual(filesystem_snapshot(claude_home), before)
+                self.assertEqual(external.read_bytes(), b"external unchanged")
+
+    def test_complete_managed_files_converge_when_settings_are_absent(self):
+        hooks = self.claude_home / "hooks"
+        hooks.mkdir(parents=True)
+        source_by_name = {
+            "cbm-code-discovery-gate": SKILL / "hooks" / "cbm-code-discovery-gate",
+            "cbm-session-reminder": SKILL / "hooks" / "cbm-session-reminder",
+            "cbm-code-discovery-reminder.md": SKILL / "reminder.md",
+        }
+        for name, source in source_by_name.items():
+            shutil.copyfile(source, hooks / name)
+        unfinished = hooks / ".codebase-memory-install-unfinished"
+        unfinished.write_text("ignored", encoding="utf-8")
+
+        result = self.install()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(unfinished.read_text(encoding="utf-8"), "ignored")
+        self.assertIsInstance(self.settings(), dict)
+
+    def test_changed_targets_are_atomically_replaced_with_valid_complete_files(self):
+        hooks = self.claude_home / "hooks"
+        hooks.mkdir(parents=True)
+        targets = [
+            hooks / "cbm-code-discovery-gate",
+            hooks / "cbm-session-reminder",
+            hooks / "cbm-code-discovery-reminder.md",
+        ]
+        for target in targets:
+            target.write_text(f"# {OWNERSHIP}\nstale\n", encoding="utf-8")
+        settings_path = self.claude_home / "settings.json"
+        settings_path.write_text('{"unrelated": true}\n', encoding="utf-8")
+        targets.append(settings_path)
+        old_inodes = {path: path.stat().st_ino for path in targets}
+
+        result = self.install()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(self.settings()["unrelated"])
+        for target in targets:
+            self.assertNotEqual(target.stat().st_ino, old_inodes[target], target)
+        for target in targets[:-1]:
+            content = target.read_bytes()
+            self.assertTrue(content)
+            self.assertIn(OWNERSHIP.encode(), content)
+
+    def test_hooks_delegate_fail_open_and_emit_the_single_reminder_policy(self):
+        self.assertEqual(self.install().returncode, 0)
+        hooks = self.claude_home / "hooks"
+        gate = hooks / "cbm-code-discovery-gate"
+        fake = self.scratch / "fake-codebase-memory"
+        fake.write_text(
+            "#!/bin/sh\n[ \"$1\" = hook-augment ] || exit 2\nsed 's/^/augmented:/'\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        environment = os.environ.copy()
+        environment["CODEBASE_MEMORY_BIN"] = str(fake)
+
+        success = subprocess.run(
+            [str(gate)], input="needle\n", text=True, capture_output=True, env=environment
+        )
+
+        self.assertEqual(success.returncode, 0)
+        self.assertEqual(success.stdout, "augmented:needle\n")
+        fake.write_text("#!/bin/sh\nprintf 'must not leak'\nexit 1\n", encoding="utf-8")
+        failed = subprocess.run([str(gate)], text=True, capture_output=True, env=environment)
+        self.assertEqual((failed.returncode, failed.stdout), (0, ""))
+        environment["CODEBASE_MEMORY_BIN"] = str(self.scratch / "missing")
+        missing = subprocess.run([str(gate)], text=True, capture_output=True, env=environment)
+        self.assertEqual((missing.returncode, missing.stdout), (0, ""))
+
+        reminder = (SKILL / "reminder.md").read_bytes()
+        installed_reminder = hooks / "cbm-code-discovery-reminder.md"
+        self.assertEqual(installed_reminder.read_bytes(), reminder)
+        session = subprocess.run(
+            [str(hooks / "cbm-session-reminder")], capture_output=True, check=False
+        )
+        self.assertEqual((session.returncode, session.stdout), (0, reminder))
+
+    def test_rendered_commands_are_shell_safe_for_caller_supplied_paths(self):
+        claude_home = self.scratch / "claude home;$(touch SHOULD_NOT_EXIST);'quote"
+        result = self.install(claude_home)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        settings = self.settings(claude_home)
+        commands = [
+            hook["command"]
+            for entries in settings["hooks"].values()
+            for entry in entries
+            for hook in entry["hooks"]
+        ]
+        environment = os.environ.copy()
+        environment["CODEBASE_MEMORY_BIN"] = str(self.scratch / "missing")
+        outputs = [
+            subprocess.run(
+                command,
+                shell=True,
+                text=True,
+                capture_output=True,
+                env=environment,
+                cwd=self.scratch,
+            )
+            for command in commands
+        ]
+        self.assertTrue(all(item.returncode == 0 for item in outputs))
+        self.assertEqual(outputs[0].stdout, "")
+        expected_reminder = (SKILL / "reminder.md").read_text(encoding="utf-8")
+        self.assertTrue(all(item.stdout == expected_reminder for item in outputs[1:]))
+        self.assertFalse((self.scratch / "SHOULD_NOT_EXIST").exists())
+
+    def test_copied_skill_uses_home_for_the_default_claude_home(self):
+        home = self.scratch / "home"
+        installed_skill = home / ".claude" / "skills" / "codebase-memory"
+        installed_skill.parent.mkdir(parents=True)
+        shutil.copytree(SKILL, installed_skill)
+        environment = os.environ.copy()
+        environment["HOME"] = str(home)
+
+        result = subprocess.run(
+            ["python3", str(installed_skill / "scripts" / "install.py")],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((home / ".claude" / "settings.json").is_file())
+        for relative in (
+            "SKILL.md",
+            "scripts/install.py",
+            "config/claude-settings.json",
+            "reminder.md",
+            "hooks/cbm-code-discovery-gate",
+            "hooks/cbm-session-reminder",
+        ):
+            self.assertEqual(
+                installed_skill.joinpath(relative).read_bytes(),
+                SKILL.joinpath(relative).read_bytes(),
+            )
+
+    def test_pack_guidance_points_to_the_single_discovery_policy_and_activation(self):
+        reminder = (SKILL / "reminder.md").read_text(encoding="utf-8")
+        skill = (SKILL / "SKILL.md").read_text(encoding="utf-8")
+        profile = (ROOT / "profile" / "base.md").read_text(encoding="utf-8")
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        overlay = (ROOT / "docs" / "overlay.md").read_text(encoding="utf-8")
+        validator = (ROOT / "scripts" / "validate.py").read_text(encoding="utf-8")
+        workflow = (ROOT / ".github" / "workflows" / "validate.yml").read_text(
+            encoding="utf-8"
+        )
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        normalized_reminder = " ".join(reminder.split())
+        for phrase in (
+            "exact project is indexed",
+            "configuration, non-code files, and unindexed projects",
+            "Activating this skill never indexes a project",
+        ):
+            self.assertIn(phrase, normalized_reminder)
+        self.assertIn("[reminder.md](reminder.md)", skill)
+        self.assertIn("~/.claude/skills/codebase-memory/reminder.md", profile)
+        self.assertIn("python3 ~/.claude/skills/codebase-memory/scripts/install.py", readme)
+        self.assertIn("portable skill-owned hooks", overlay.lower())
+        self.assertIn('"tools/codebase-memory"', validator)
+        self.assertIn("tests.test_codebase_memory_install", workflow)
+        self.assertIn("skills/tools/codebase-memory/scripts/install.py", workflow)
+        self.assertIn("tests.test_codebase_memory_install", agents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codebase_memory_install.py
+++ b/tests/test_codebase_memory_install.py
@@ -223,6 +223,30 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
         self.assertEqual(settings_path.read_bytes(), original)
         self.assertFalse((claude_home / "hooks").exists())
 
+    def test_managed_command_with_arguments_is_a_conflict(self):
+        self.claude_home.mkdir()
+        settings_path = self.claude_home / "settings.json"
+        command = f"{self.claude_home}/hooks/cbm-code-discovery-gate --unexpected"
+        conflicting = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Grep|Glob",
+                        "hooks": [{"type": "command", "command": command, "timeout": 5}],
+                    }
+                ]
+            }
+        }
+        original = (json.dumps(conflicting) + "\n").encode()
+        settings_path.write_bytes(original)
+
+        result = self.install()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("conflicting managed hook registration", result.stderr)
+        self.assertEqual(settings_path.read_bytes(), original)
+        self.assertFalse((self.claude_home / "hooks").exists())
+
     def test_symlinked_settings_fail_without_following_the_external_target(self):
         self.claude_home.mkdir()
         external = self.scratch / "external-settings.json"
@@ -256,16 +280,18 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
         self.assertFalse((self.claude_home / "settings.json").exists())
 
     def test_every_non_regular_or_unowned_managed_node_is_a_no_write_failure(self):
-        cases = (
+        cases = [
             ("settings-directory", "settings", "directory"),
             ("settings-fifo", "settings", "fifo"),
             ("hooks-file", "hooks", "file"),
-            ("gate-unmarked", "gate", "file"),
-            ("gate-symlink", "gate", "symlink"),
-            ("gate-broken-symlink", "gate", "broken-symlink"),
-            ("gate-directory", "gate", "directory"),
-            ("gate-fifo", "gate", "fifo"),
-        )
+        ]
+        for managed_name in (
+            "cbm-code-discovery-gate",
+            "cbm-session-reminder",
+            "cbm-code-discovery-reminder.md",
+        ):
+            for node_kind in ("file", "symlink", "broken-symlink", "directory", "fifo"):
+                cases.append((f"{managed_name}-{node_kind}", managed_name, node_kind))
         for name, target, node_kind in cases:
             with self.subTest(name=name):
                 claude_home = self.scratch / name
@@ -279,7 +305,7 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
                 else:
                     hooks = claude_home / "hooks"
                     hooks.mkdir()
-                    path = hooks / "cbm-code-discovery-gate"
+                    path = hooks / target
 
                 if node_kind == "directory":
                     path.mkdir()
@@ -461,6 +487,8 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
         ):
             self.assertIn(phrase, normalized_reminder)
         self.assertIn("[reminder.md](reminder.md)", skill)
+        self.assertNotIn("Use the graph for structural code discovery", skill)
+        self.assertNotIn("Use `index_repository` only", skill)
         self.assertIn("~/.claude/skills/codebase-memory/reminder.md", profile)
         self.assertIn("python3 ~/.claude/skills/codebase-memory/scripts/install.py", readme)
         self.assertIn("portable skill-owned hooks", overlay.lower())


### PR DESCRIPTION
## What changed

The public pack now includes the Codebase Memory discovery skill, its graph-query vocabulary, one standing discovery policy, and an activation command for Claude Code.

Activation installs the discovery augmentation and session reminder hooks, then merges their canonical registrations into existing settings. It preserves unrelated configuration, is byte-stable on rerun, replaces each managed file atomically, and refuses malformed, conflicting, symlinked, non-regular, or unowned destination state before writing.

The pack's shared profile, installation guide, overlay ownership contract, validator, local checks, and CI now describe and verify that same skill-owned activation interface. Installing or activating the bundle does not install the external graph server or index a repository.

## Why

A clean consumer previously received no portable instruction or hook that would use an already-built code graph. Keeping the policy, hooks, registrations, and activation behavior with the skill makes this public pack sufficient to equip an agent without private dotfiles.

## What to check

- Existing Claude Code settings and unrelated hook registrations survive activation unchanged.
- Conflicting discovery registrations and hostile filesystem nodes fail before any managed target changes.
- Paths containing whitespace and shell metacharacters execute the rendered hook commands safely.
- The reminder is the only authored discovery-selection and indexing policy; the skill itself keeps neutral query vocabulary.

## Verification

```text
validated 26 skills and 262 files
Ran 258 tests in 140.672s
OK (skipped=23)
python3 -m py_compile skills/tools/codebase-memory/scripts/install.py  # exit 0
push hook: DCO_OK commits=3
```

Full-depth review converged in two rounds. Round 1 found and fixed argument-bearing managed commands escaping conflict detection and duplicated policy in the skill instructions; round 2 rechecked 14 Standards items and both Spec findings with no remaining violations or unmet criteria.

After review, the branch was rebased over the merged Codebase Memory worktree-lifecycle change. The two additive README/CI conflicts preserve both skills' entries and checks; the complete verification above was rerun on that final base.

Closes #65
