### PR TITLE
fix(ticket): claim execution sessions at start

### DIFF
--- a/docs/adr/adr-70-claimed-session-attribution.md
+++ b/docs/adr/adr-70-claimed-session-attribution.md
@@ -37,10 +37,12 @@ its session as an early step. `scan` and `record` read those claims and resolve
 each session's transcript by exact id.
 
 The matching machinery is deleted rather than kept as a fallback: the reference
-regex, the operator-typed text extractor, the substring prefilter, and the
-`--project` flag. A fallback would reintroduce the failure mode on exactly the
-tickets where claims are absent, and silently, which is how the first bad record
-was written.
+regex, the operator-typed text extractor, the substring prefilter, and the old
+`scan`/`record --project` filter. Claim's `--project` metadata remains: it records
+the actual working directory of the claimed session, including a dispatched
+worker's chunk worktree. A fallback would reintroduce the failure mode on exactly
+the tickets where claims are absent, and silently, which is how the first bad
+record was written.
 
 A session id comes from the agent's own environment (`CLAUDE_CODE_SESSION_ID`,
 `CODEX_SESSION_ID`) or from `--session` with `--agent`, so a coordinator can

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -91,10 +91,11 @@ substitutes a lighter check for the depth the order stamped.
 
 5. **One worktree, one branch, per ticket, for the whole lifecycle.** `triage`
    cuts the branch and worktree through `spin-worktree`; `start` and `revise`
-   reuse them; `finalize` tears them down. The first action of any verb, before
-   grounding or any repo read, is to cut or reuse the ticket's worktree, which is
-   refused if the control checkout is dirty. Grounding, scope ledgers, and change
-   records all happen and get committed there. The control checkout may be stale
+   reuse them; `finalize` tears them down. The first repository action after the
+   summary-and-claim opening, before grounding or any repo read, is to cut or
+   reuse the ticket's worktree, which is refused if the control checkout is dirty.
+   Grounding, scope ledgers, and change records all happen and get committed
+   there. The control checkout may be stale
    or on another branch: its working tree is never read or written, and it never
    switches branches. It holds the ticket's branch ref, which is what the worktree
    is cut from. Before its first write, every verb confirms that its working

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -1,14 +1,14 @@
 # Coordinator mode
 
-Reached from `start` step 5, on a chunked order only. `/orchestrate`'s rules bind:
+Reached from `start` step 6, on a chunked order only. `/orchestrate`'s rules bind:
 delegate the work, verify every result, never write the implementation yourself.
 Its carve-out binds too, and this flow leans on it twice: small mechanical glue
 stays with the coordinator, so a mechanical merge conflict (step 5) and a finding
 whose chunk agent is already gone (step 8) are fixed in place and mentioned in the
 report. Anything larger than mechanical goes back to a delegate.
 
-What follows is what this skill adds on top. It replaces `start` steps 7 through
-10, and rejoins that verb at step 11 when the last chunk has merged.
+What follows is what this skill adds on top. It replaces `start` steps 8 through
+11, and rejoins that verb at step 12 when the last chunk has merged.
 
 1. **One branch, one pull request, still.** The ticket branch from `start` step 4 is
    the trunk. Each chunk gets its own branch cut from it and merges back. Nothing
@@ -36,6 +36,15 @@ What follows is what this skill adds on top. It replaces `start` steps 7 through
    that needs coordinator commentary to be executable is a triage defect, and the fix
    is to say so, not to patch it in the prompt.
 
+   Once the dispatcher exposes a stable transcript id, claim each unique
+   implementation-worker session through the shared claim rule, passing
+   `--session <id>`, `--agent <agent>`, and `--project <chunk-worktree>`. The agent
+   and project name the worker that did the work and its actual working directory,
+   not the coordinator's. Keep identifiers in coordinator bookkeeping; they never
+   enter sub-order prompts or published comments. If the dispatcher exposes no
+   stable transcript id, report the omitted claim in one line and continue. Claim
+   failures use the shared visible, non-blocking rule.
+
 4. **Review each chunk as it lands**, at that sub-order's stamped depth, before
    merging it. Two things happen, in order, and neither substitutes for the other:
 
@@ -48,7 +57,11 @@ What follows is what this skill adds on top. It replaces `start` steps 7 through
    b. Verify the result yourself, as `/orchestrate` requires of every delegated
    result: read the diff, run the verification command, check the chunk's Done when
    clause. A failed verification retries once in the chunk's agent with the specific
-   finding, then escalates one tier per the routing table.
+   finding, then escalates one tier per the routing table. Same-session retries are
+   not re-claimed; claim every fresh implementation escalation once, using the
+   escalation's stable transcript id, agent, and chunk worktree. Review-only
+   sessions are not claimed in this issue; role-aware review attribution belongs to
+   ticket 77.
 
 5. **Merge into the ticket branch** in the ticket's worktree, one chunk at a time,
    with `--no-ff`. A conflict between two chunks that declared disjoint ownership

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -164,10 +164,12 @@ def transcripts_for(claim: dict, projects_dir: Path) -> list[Path]:
     session_id = claim["session_id"]
     if claim.get("agent") == "codex":
         return sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
-    return sorted(projects_dir.glob(f"*/{session_id}.jsonl"))
+    parent_sessions = projects_dir.glob(f"*/{session_id}.jsonl")
+    native_workers = projects_dir.glob(f"*/*/subagents/agent-{session_id}.jsonl")
+    return sorted([*parent_sessions, *native_workers])
 
 
-def claude_peaks(raw: bytes) -> tuple[Optional[str], int, int]:
+def claude_peaks(raw: bytes, *, claimed_worker: bool = False) -> tuple[Optional[str], int, int]:
     started = None
     peak = 0
     subagent_peak = 0
@@ -183,7 +185,7 @@ def claude_peaks(raw: bytes) -> tuple[Optional[str], int, int]:
         if entry.get("type") != "assistant":
             continue
         size = context_size(entry.get("message", {}).get("usage", {}))
-        if entry.get("isSidechain"):
+        if entry.get("isSidechain") and not claimed_worker:
             subagent_peak = max(subagent_peak, size)
         else:
             peak = max(peak, size)
@@ -218,12 +220,16 @@ def codex_peaks(raw: bytes) -> tuple[Optional[str], int, int]:
 
 def session_cost(claim: dict, projects_dir: Path) -> dict:
     paths = transcripts_for(claim, projects_dir)
-    read = codex_peaks if claim.get("agent") == "codex" else claude_peaks
     started = None
     peak = 0
     subagent_peak = 0
     for path in paths:
-        first, own, sub = read(path.read_bytes())
+        if claim.get("agent") == "codex":
+            first, own, sub = codex_peaks(path.read_bytes())
+        else:
+            first, own, sub = claude_peaks(
+                path.read_bytes(), claimed_worker=path.parent.name == "subagents"
+            )
         started = min(x for x in (started, first) if x) if (started or first) else None
         peak = max(peak, own)
         subagent_peak = max(subagent_peak, sub)

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -4,12 +4,17 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
 
 ## Procedure
 
-1. **Fetch the order.** Use the contract's locate operation. None found: refuse,
+1. **Complete the shared opening.** Complete shared rules 1–2: read and summarize
+   the ticket, then claim the session before locating the work order or reaching
+   any later refusal. Use the shared claim command and its visible, non-blocking
+   failure semantics; do not duplicate them here.
+
+2. **Fetch the order.** Use the contract's locate operation. None found: refuse,
    say "no work order on `<ticket-id>`; run /ticket triage `<ticket-id>`", and stop.
    The comment's `Execution:` line says `single agent` or `chunked`; an order with
    no `Execution:` line is a flat order.
 
-2. **Model-check.** The order's `Open as:` line names a required model and effort. A
+3. **Model-check.** The order's `Open as:` line names a required model and effort. A
    session cannot reliably introspect its own reasoning effort from context, so do
    not guess it, and do not answer from memory of an earlier guess. State the model
    name this session's own system prompt reports, then ask the user in prose to
@@ -21,14 +26,8 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    order is refused. Never run part of it, and never launch an agent smarter than the
    coordinator.
 
-3. **Sufficiency check.** Read the order against the actual repo. If the repo has
-   drifted since triage (files moved, the constraint it names is gone), stop and
-   report the mismatch; the fix is a re-triage, not improvisation. On a chunked
-   order, confirm the chunks' declared file and target ownership is still disjoint;
-   an overlap that drift introduced is a re-triage, not a merge problem to solve
-   later.
-
-4. **Worktree and branch.** Never work in the control checkout. Reuse the worktree
+4. **Worktree and branch.** This is the first repository action after the shared
+   opening. Never work in the control checkout. Reuse the worktree
    and branch triage cut, verifying with
    `git -C <worktree> branch --show-current`. Only cut fresh when triage's worktree
    is gone, with the same command shape triage used
@@ -37,17 +36,24 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    Use the worktree path the helper printed as the working directory for every step
    below. Move the ticket to in progress.
 
-5. **Chunked order: switch to coordinator mode.** If the `Execution:` line says
+5. **Sufficiency check.** From the ticket worktree, read the order against the
+   actual repo. If the repo has drifted since triage (files moved, the constraint
+   it names is gone), stop and report the mismatch; the fix is a re-triage, not
+   improvisation. On a chunked order, confirm the chunks' declared file and target
+   ownership is still disjoint; an overlap that drift introduced is a re-triage,
+   not a merge problem to solve later.
+
+6. **Chunked order: switch to coordinator mode.** If the `Execution:` line says
    `chunked`, load `/orchestrate` now, then follow
    [references/coordinator-mode.md](../references/coordinator-mode.md) instead of
-   steps 7 through 10, and rejoin at step 11. Flat orders skip this and continue at
-   step 6.
+   steps 8 through 11, and rejoin at step 12. Flat orders skip this and continue at
+   step 7.
 
-6. **Read the standing decisions**, per the skill page's standing-decisions slot,
+7. **Read the standing decisions**, per the skill page's standing-decisions slot,
    before implementing. Absent, say so in one line and continue. This never refuses
    the order.
 
-7. **Implement.** Read the repo's `AGENTS.md` or `CLAUDE.md` first; its rules bind
+8. **Implement.** Read the repo's `AGENTS.md` or `CLAUDE.md` first; its rules bind
    everything you write on this branch. Never add or edit one yourself; if the repo
    has none, work to the user's global standards. Follow the order's Do section.
    Match the repo's existing idioms, reading neighboring code first. Record the
@@ -60,11 +66,11 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    acceptance criteria goes test-first through `/tdd`. CI or workflow-file changes
    read `/ci-design` first.
 
-8. **Verification loop.** Run the order's `Verification:` command locally and
+9. **Verification loop.** Run the order's `Verification:` command locally and
    iterate until its output matches the order's `Expectation:` line exactly, per the
    skill page's verification-step rule. Never fabricate the output.
 
-9. **Repo-rules audit and adversarial review, before the pull request.** Re-read the
+10. **Repo-rules audit and adversarial review, before the pull request.** Re-read the
    repo's `AGENTS.md` or `CLAUDE.md`, which has decayed from context by now, and
    audit the full diff against it rule by rule, including any completion checklist
    it defines. Fix violations, then hand off to `/review` on the branch's changes
@@ -78,7 +84,7 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    Two rounds maximum; findings still open after round two go into the pull request
    body as known issues, never silently dropped.
 
-10. **Fold the change record into the baseline in the order's last pull request.**
+11. **Fold the change record into the baseline in the order's last pull request.**
     When the pull request being opened is the order's final one (single-pull-request
     orders: the only one), the same diff completes whatever the repo's convention
     asks for at landing time. This lands before the pull request is opened or marked
@@ -87,7 +93,7 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
     request is already approved and this was missed, leave it for a later sweep and
     flag it; do not push it onto the approved pull request.
 
-11. **Open the pull request.** `gh pr create` against the default branch. The body
+12. **Open the pull request.** `gh pr create` against the default branch. The body
     follows an existing template when one exists, in this order: the repo's
     `.github/pull_request_template.md` (or its `PULL_REQUEST_TEMPLATE/` directory),
     then the organization default in the organization's `.github` repo. Keep the
@@ -108,15 +114,15 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
     met, re-settle, or blocked. Missing either is a blocking gap on the pull request,
     not a nit. Do not open it without them when the change touches a locked surface.
 
-12. **Stop.** Report the pull request URL, the verification evidence, review
+13. **Stop.** Report the pull request URL, the verification evidence, review
     findings fixed or carried, and anything from the order left undone and why. On a
     chunked order also report each chunk's outcome and tier. Do not merge, do not
     self-approve, and do not respond to reviews; that is `/ticket revise`.
 
 ## Refusals
 
-* No work order (step 1), model mismatch (step 2), repo drift or overlapping chunk
-  ownership (step 3).
+* No work order (step 2), model mismatch (step 3), repo drift or overlapping chunk
+  ownership (step 5).
 * The order's classification is `manual`: nothing to execute, so say so.
 * Verification cannot be run at all (no credentials, no access, no runnable suite):
   stop after implementation, open the pull request as a draft, and say which

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -86,6 +86,36 @@ def assistant_line(
 
 
 class TicketSkillContractTests(unittest.TestCase):
+    def test_start_opens_with_summary_and_claim_before_fetching_the_order(self):
+        shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
+        start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")
+
+        self.assertLess(shared.index("Open with the ticket summary"), shared.index("Claim the session"))
+        opening = start.index("Complete shared rules 1–2")
+        fetch = start.index("Fetch the order")
+        self.assertLess(opening, fetch)
+        self.assertLess(start.index("Worktree and branch"), start.index("Sufficiency check"))
+        self.assertIn("never blocks the verb", shared)
+
+    def test_coordinator_claims_unique_implementation_workers_not_reviewers(self):
+        coordinator = (TICKET_DIRECTORY / "references" / "coordinator-mode.md").read_text(
+            encoding="utf-8"
+        )
+        contract = " ".join(coordinator.split())
+
+        for requirement in (
+            "each unique implementation-worker session",
+            "`--session <id>`",
+            "`--agent <agent>`",
+            "`--project <chunk-worktree>`",
+            "Same-session retries are not re-claimed",
+            "fresh implementation escalation",
+            "Review-only sessions are not claimed",
+            "stable transcript id",
+            "one line and continue",
+        ):
+            self.assertIn(requirement, contract)
+
     def test_triage_requires_the_brief_quality_checklist(self):
         triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
         checklist = TICKET_DIRECTORY / "references" / "brief-quality.md"
@@ -248,6 +278,41 @@ class TicketTelemetryTests(unittest.TestCase):
         # Codex counts its cached input inside input_tokens; adding it back
         # would report 210,000 for a turn that cost 120,000.
         self.assertEqual(session["peak_context"], 120_000)
+
+    def test_a_claimed_native_claude_worker_is_measured_as_its_own_session(self):
+        worker_id = "worker-synthetic-1"
+        directory = self.projects / "synthetic-project" / "parent-synthetic" / "subagents"
+        directory.mkdir(parents=True)
+        claimed_path = directory / f"agent-{worker_id}.jsonl"
+        claimed_path.write_text(assistant_line(130_000, subagent=True) + "\n", encoding="utf-8")
+        (directory / f"agent-{worker_id}-near-collision.jsonl").write_text(
+            assistant_line(260_000, subagent=True) + "\n", encoding="utf-8"
+        )
+        worker_project = "/tmp/synthetic-chunk-worktree"
+        claim = self.ticket(
+            "claim",
+            "TICKET-20",
+            "--session",
+            worker_id,
+            "--agent",
+            "claude",
+            "--project",
+            worker_project,
+        )
+        self.assertEqual(claim.returncode, 0, claim.stderr)
+
+        result = self.ticket("scan", "TICKET-20")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["session_count"], 1)
+        self.assertEqual(payload["peak_context"], 130_000)
+        self.assertEqual(payload["subagent_peak"], 0)
+        session = payload["sessions"][0]
+        self.assertEqual(session["project"], worker_project)
+        self.assertEqual(session["transcripts"], [str(claimed_path)])
+        self.assertEqual(session["peak_context"], 130_000)
+        self.assertEqual(session["subagent_peak"], 0)
 
     def test_a_claim_whose_transcript_is_missing_is_reported_not_dropped(self):
         self.claim("TICKET-6", "session-gone")


### PR DESCRIPTION
## Summary

- Ticket execution now claims its coordinator session before work-order refusals, model checks, or repository work can exit.
- Sliced execution attributes each implementation worker to its stable session identity and actual chunk worktree while keeping review-only sessions out of this change.
- Claimed native Claude workers now resolve by exact transcript identity and measure their sidechain turns as their own execution peak.

## Why

Ticket execution could finish substantial work while finalize found no attributable session and recorded `no-data`. This fixes attribution at the point work begins, without reconstructing historical telemetry or changing slicing verdicts.

## Verification

```
validated 26 skills and 262 files
Ran 261 tests in 314.513s
OK (skipped=23)
py_compile: exit 0
```

The pre-push guard also reported `DCO_OK commits=1`.

## Review

Full-depth review converged in two rounds:

- Standards: 14 rules checked, 0 violated, 0 unverified.
- Spec: 12 criteria checked, all met; no scope creep or risk-contract violations.

## What to check

- A fresh ticket start attempts its session claim before any later refusal or repository action.
- Sliced implementation workers retain their worker identity and chunk worktree attribution.
- A claimed native worker excludes a higher-peaked near-collision transcript and reports its own peak.

Closes #75
