### PR TITLE
fix: say-less re-statement, pr-body gold standard, cbm-onboard hook paths

### DIFF
--- a/bench/pr_body_bench.py
+++ b/bench/pr_body_bench.py
@@ -136,29 +136,37 @@ def _section_body(text: str, heading_title: str) -> str:
 
 
 def _example_slice(text: str) -> str:
-    """The worked example: the fenced ```markdown block, plus the paragraph that
-    immediately follows it (the "No headings. No reason..." sentence group)."""
-    match = FENCED_MARKDOWN_RE.search(text)
-    if match is None:
+    """"The gold standard" section: the framing paragraphs and the fenced
+    ```markdown body they introduce."""
+    headings = [
+        line_end for _, line_end, title in _headings(text)
+        if title.lower() == "the gold standard"
+    ]
+    if not headings:
+        raise SkillExtractionError(
+            f"heading 'The gold standard' not found in {SKILL_MD}; extraction target moved"
+        )
+    # The example body carries its own markdown headings, so the section cannot be
+    # bounded by the next heading the way a prose section can.
+    fence = FENCED_MARKDOWN_RE.search(text, headings[0])
+    if fence is None:
         raise SkillExtractionError(
             f"no fenced ```markdown example block found in {SKILL_MD}; extraction target moved"
         )
-    fence = match.group(0)
-    rest = text[match.end():]
-    paragraph_match = re.match(r"[ \t]*\n+([^\n].*?)(?:\n[ \t]*\n|\Z)", rest, re.DOTALL)
-    if paragraph_match is None:
+    intro = text[headings[0]:fence.start()].strip()
+    if not intro:
         raise SkillExtractionError(
-            f"no paragraph follows the fenced example block in {SKILL_MD}; extraction target moved"
+            f"no framing paragraph precedes the fenced example block in {SKILL_MD}; "
+            "extraction target moved"
         )
-    sentence = paragraph_match.group(1).strip()
-    return f"{fence}\n\n{sentence}"
+    return f"{intro}\n\n{fence.group(0)}"
 
 
 def _rules_slice(text: str) -> str:
-    """"The shape" numbered list plus the "Textures to cut" list, nothing else."""
-    shape = _section_body(text, "The shape")
-    cuts = _section_body(text, "Textures to cut")
-    return f"{shape}\n\n{cuts}"
+    """"What that body does" numbered list plus the "Never" list, nothing else."""
+    principles = _section_body(text, "What that body does")
+    cuts = _section_body(text, "Never")
+    return f"{principles}\n\n{cuts}"
 
 
 def build_skill_slices(skill_text: str | None = None) -> dict[str, str]:

--- a/skills/tools/cbm-onboard/SKILL.md
+++ b/skills/tools/cbm-onboard/SKILL.md
@@ -31,9 +31,12 @@ directory containing several repositories.
    a managed reindex block to Git's configured `post-commit`, `post-merge`, and
    `post-checkout` hooks without deleting an existing shell hook. The
    `post-checkout` block carries a `[ "$3" = "1" ] || exit 0` guard so it only
-   fires on branch checkouts, not per-file checkouts. It refuses symlink
-   targets. A non-shell foreign hook is left unchanged with a warning because
-   composing it would be unsafe.
+   fires on branch checkouts, not per-file checkouts. A symlinked hook is
+   followed to the file it resolves to, which is what a dotfiles-managed hooks
+   directory needs, and the write lands in whatever repo owns that file. A
+   symlink with no regular-file target is refused, and a `.cbmignore` symlink
+   is refused outright. A non-shell foreign hook is left unchanged with a
+   warning because composing it would be unsafe.
 
    Linked worktrees share the control checkout's Git hooks; they cannot have
    independent hooks. Pass `--this-checkout` only to select the supplied

--- a/skills/tools/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/tools/cbm-onboard/scripts/cbm-onboard.sh
@@ -157,6 +157,13 @@ esac
 # to the repo-local, worktree-safe hooks dir when unset.
 HOOKS_PATH="$(git -C "$ROOT" config --get core.hooksPath 2>/dev/null || true)"
 if [ -n "$HOOKS_PATH" ]; then
+  # git expands a leading tilde in a path-valued config; a global hooksPath is
+  # commonly written that way, and joining it to the repo would create a literal
+  # "~" directory inside the checkout.
+  case "$HOOKS_PATH" in
+    "~") HOOKS_PATH="$HOME" ;;
+    "~/"*) HOOKS_PATH="$HOME/${HOOKS_PATH#\~/}" ;;
+  esac
   case "$HOOKS_PATH" in
     /*) HOOKS_DIR="$HOOKS_PATH" ;;
     *) HOOKS_DIR="$ROOT/$HOOKS_PATH" ;;
@@ -168,22 +175,30 @@ fi
 HOOK_SYMLINK_REFUSED=0
 for HOOK_NAME in post-commit post-merge post-checkout; do
   HOOK="$HOOKS_DIR/$HOOK_NAME"
+  HOOK_FILE="$HOOK"
 
+  # A dotfiles-managed hooks dir is usually a farm of symlinks into the dotfiles
+  # checkout. Edit the file the link resolves to: shadowing the link would be
+  # clobbered by the next dotfiles run, and refusing leaves no hook at all.
   if [ -L "$HOOK" ]; then
-    printf 'refusing symlink target: %s\n' "$HOOK" >&2
-    HOOK_SYMLINK_REFUSED=1
-    continue
+    HOOK_FILE="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$HOOK")"
+    if [ ! -f "$HOOK_FILE" ]; then
+      printf 'refusing symlink without a regular-file target: %s\n' "$HOOK" >&2
+      HOOK_SYMLINK_REFUSED=1
+      continue
+    fi
+    printf 'following symlink %s to %s\n' "$HOOK" "$HOOK_FILE"
   fi
 
   : >"$HOOK_TMP"
-  mkdir -p "$(dirname "$HOOK")"
+  mkdir -p "$(dirname "$HOOK_FILE")"
   INSTALL_HOOK=1
-  if [ -e "$HOOK" ]; then
-    FIRST_LINE="$(sed -n '1p' "$HOOK")"
+  if [ -e "$HOOK_FILE" ]; then
+    FIRST_LINE="$(sed -n '1p' "$HOOK_FILE")"
     if ! printf '%s\n' "$FIRST_LINE" |
       grep -Eq '^#!.*[/[:space:]](ba|da|k|z)?sh([[:space:]]|$)'; then
       printf 'SKIP hook installation: existing hook is not a shell script; left unchanged: %s\n' \
-        "$HOOK" >&2
+        "$HOOK_FILE" >&2
       INSTALL_HOOK=0
     fi
   else
@@ -192,7 +207,7 @@ for HOOK_NAME in post-commit post-merge post-checkout; do
 
   [ "$INSTALL_HOOK" -eq 1 ] || continue
 
-  if [ -e "$HOOK" ]; then
+  if [ -e "$HOOK_FILE" ]; then
     awk -v begin="$BEGIN_HOOK" -v end="$END_HOOK" '
       { lines[++n] = $0 }
       END {
@@ -215,7 +230,7 @@ for HOOK_NAME in post-commit post-merge post-checkout; do
         }
         for (i = 1; i <= out_n; i++) print output[i]
       }
-    ' "$HOOK" >"$HOOK_TMP"
+    ' "$HOOK_FILE" >"$HOOK_TMP"
   fi
   {
     printf '\n%s\n' "$BEGIN_HOOK"
@@ -225,9 +240,9 @@ for HOOK_NAME in post-commit post-merge post-checkout; do
     printf '"%s"\n' "$REINDEX"
     printf '%s\n' "$END_HOOK"
   } >>"$HOOK_TMP"
-  cp "$HOOK_TMP" "$HOOK"
-  chmod +x "$HOOK"
-  printf '%s\n' "installed managed reindex command in $HOOK"
+  cp "$HOOK_TMP" "$HOOK_FILE"
+  chmod +x "$HOOK_FILE"
+  printf '%s\n' "installed managed reindex command in $HOOK_FILE"
 done
 
 [ "$HOOK_SYMLINK_REFUSED" -eq 0 ] || exit 1

--- a/skills/tools/pr-body/SKILL.md
+++ b/skills/tools/pr-body/SKILL.md
@@ -8,187 +8,154 @@ description: Write a pull-request body and score it before the PR is opened, or 
 The body is for whoever merges the change. It carries facts about the change in
 the system's own terms. The diff already carries the files.
 
-Start from a real one. A Pulumi PR that grows a GHES appliance data volume:
+## The gold standard
+
+This is the target. Copy its shape, not its subject.
+
+The whole thing is what you would say to the team in one sentence, plus the
+handful of facts a merger cannot get from the title. The decisions, the
+alternatives, and the operator log are in the diff and the spec, and the body
+says where they are rather than repeating them.
 
 ```markdown
-Grows the appliance data volume from 2 TB to 4 TB. It has been
-running near capacity.
+## Motivation and Context
 
-* Volume size 2000 to 4000 GiB.
-* Resources: 1 to update.
+ghes-config now sets the memory ceilings and rate-limit posture that production already runs: 17 keys per ring for prd and stg, read off the production primary, rate limiting off. Staging had sandbox-sized ceilings on production-sized hardware.
 
-EBS expands online. The filesystem grows on the next boot.
+* The 14 rate-limit keys are new to the reconciler's allowlist, on the `ghe-config` transport. dev.yaml is unchanged.
+* Staging's primary was brought to those values by hand. Three of the four keys written did not exist there before, so the comparison below shows staging carrying production's values, not the appliance honouring the new ceilings.
+* No reconciler instance exists in any ring, so nothing reads these files today.
+
+Decisions and the operator log are in the change folder under `openspec/changes/archive/`.
+
+Fixes PROJ-7351
+
+## How Has This Been Tested?
+
+* Production primary against staging primary after the apply: 17 lines per side, diff exit 0. Replication in sync on both replicas.
+* `parity_test.sh` 37 checks pass, `python3 -m unittest discover -s scripts` 36 OK.
+* `pulumi preview` against `origin/main`: this branch moves no resource.
+
+## Checklist before requesting a review
+
+- [x] I have performed a self-review of my code.
+- [x] I have stepped through the README as though I was a new user to ensure clarity.
+- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
+- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
+- [x] I have removed commented code from PRs to `main`.
+- [x] I have followed conventional-commits standards when making this PR.
 
 > Written by an AI agent operating for <operator>. Verify before relying on it.
 ```
 
-No headings. No reason the author does not actually know. No advice for the
-reviewer. Nothing that rates the change. Everything below is that example,
-generalized.
+## What that body does
 
-## The shape
+1. **Sections come from the team, never from you.** Fill
+   `.github/pull_request_template.md` when the repo ships one, then the
+   organization default in the organization's `.github` repo. When neither
+   exists, read the last two merged pull requests written by someone else and
+   use their headings; a team convention lives in the pull requests even when it
+   lives in no file. Only a repo with no template and no history gets a body
+   with no headings.
+2. **The opening states what the system now does**, present tense, then the
+   state it replaced. One sentence each. It is the line you would say to the
+   team, and a reader who stops there has the change.
+3. **Three or four bullets, not twelve.** A bullet earns its place by carrying a
+   fact the opening does not imply. Never a bullet per file, and two bullets
+   that restate each other are one bullet.
+4. **Point at the spec and the diff instead of summarizing them.** Why this
+   value, what else was considered, which command ran in what order: one line
+   saying where that lives. A reader who wants the decision opens the spec, and
+   a body that retells it goes stale against it.
+5. **Evidence is the raw number.** "17 lines per side, diff exit 0", "37 checks
+   pass", "moves no resource". Not the method, not the command line, not a
+   sentence about having been careful.
+6. **The caveat states what the evidence does not show.** "The comparison shows
+   staging carrying production's values, not the appliance honouring the new
+   ceilings." That clause is the most valuable one in the body, and it is the
+   first one a weaker author drops. Fold the deviation that caused it into the
+   same bullet.
+7. **Blast radius as mechanism.** "No reconciler instance exists in any ring, so
+   nothing reads these files today." Never a rating of the risk.
+8. **`Fixes <KEY>` on its own line**, and the ticket appears nowhere else.
+9. **Tick only what is true.** An unticked box for a check that does not apply
+   is correct, and it is more credible than a body where every box is ticked.
+10. **Length follows the facts, and most facts are not the body's job.** The
+    gold standard is about 1.5 KB. An earlier draft of the same change ran 2.4
+    KB by carrying decisions the spec already held, and prose ran 5.8 KB and
+    said no more.
 
-1. **Open with the action, and put the situation behind it.** "Grows the volume
-   from 2 TB to 4 TB. It has been running near capacity." The situation is
-   support for the action, not a runway to it.
-2. **Never invent the motivation.** Write only what you know. "Before the next
-   release cycle" is an assumption dressed as a fact, and a reviewer who knows
-   the schedule will spot it. If nobody told you why, the body says what
-   changed and stops.
-3. **Flat bullets, at the level of behavior.** No `Summary` / `Changes` /
-   `Testing` scaffolding you invented. If the repo ships a PR template, fill its
-   sections; if it does not, the body has no headings.
-4. **One bullet per genuinely distinct fact.** Three bullets that restate each
-   other are one fact and two lines of padding. Never a bullet per file.
-5. **Evidence is the raw number, not the method.** `Resources: 1 to update`
-   beats a sentence about running preview against dev and prd. The reader wants
-   the result; the method is the author's business.
-6. **Risk is the one place prose belongs, and only the mechanism half.** "EBS
-   expands online, no downtime." State how the system behaves. Do not rate the
-   change.
-7. **Say nothing to the reviewer.** No "worth checking", no "please review the
-   IAM change". Telling a reviewer where to look is telling them where not to.
-8. **Length follows the facts.** One line when there is no risk and no context
-   worth stating. Longer when a change carries three genuine risks. There is no
-   target and no ceiling. A body is as long as the true statements about the
-   change and no longer.
+## Never
 
-## Textures to cut
-
-* **Verdict clauses.** "This is a low-risk change", "no downtime is expected",
-  "improves maintainability", "should have no impact". These rate the change
-  instead of describing it, and every one of them is a claim the reader cannot
-  check. Banned as a class, not as a wordlist.
-* **Parenthetical asides.** One per body at most. Past that they read as an
-  author arguing with themselves.
-* **Inline code spans and symbol names.** Name the behavior. A function name in
-  prose sends the reader to the diff to find out what the sentence meant.
-* **Paragraphs where bullets serve.** If it is a list of facts, make it a list.
-* **Prose volume with no action behind it.** Three paragraphs on a two-line
-  change is the most common failure in the labeled set.
-* **Pretentious or juvenile phrasing.** Write the plain sentence.
-* **An em dash** (use parens or two sentences), **emoji**, `-` bullets, and
-  capitalized host or resource names.
-
-## Before and after
-
-Invented motivation, and the action buried:
-
-> As part of our ongoing capacity work ahead of the Q3 release, and because the
-> appliance has been under pressure for some time, this PR increases the data
-> volume.
-
-Becomes:
-
-> Grows the appliance data volume from 2 TB to 4 TB. It has been running near
-> capacity.
-
-Invented scaffolding, and a bullet per file:
-
-> ## Summary
-> ## Changes
-> * `pulumi/volumes.go`: change size
-> * `pulumi/Pulumi.prd.yaml`: bump config
-> ## Testing
-> Ran preview.
-
-Becomes:
-
-> Grows the appliance data volume from 2 TB to 4 TB.
->
-> * Resources: 1 to update.
-
-Verdict and method narration, replaced by mechanism and number:
-
-> This is a low-risk change and should have no impact. I verified it with
-> pulumi preview against dev and prd.
-
-Becomes:
-
-> EBS expands online. The filesystem grows on the next boot.
->
-> * Resources: 1 to update.
+* Motivation nobody told you. "Ahead of the next release cycle" is a guess
+  wearing a fact's clothes.
+* A clause that rates the change: "low risk", "no impact expected", "improves
+  maintainability", "lands cleanly". The reader can check a mechanism and cannot
+  check a rating.
+* Anything addressed to the reviewer: "worth checking", "please look at the IAM
+  change". Telling a reviewer where to look tells them where not to.
+* Method narration: "I ran preview against dev and prd", "verified with".
+* A retelling of the spec or the diff: the reasoning behind a value, the
+  alternatives weighed, the order the commands ran in. Name where it lives.
+* An empty template section. Cut the heading only if the template does not ship
+  it; otherwise fill it.
+* An em dash (use parens or two sentences), emoji, `-` bullets, capitalized host
+  or account names, and a bare file path outside code formatting.
+* Three parentheses in a sentence. One in a body is fine.
 
 ## Verbs
 
 ### write
 
-Score a body file, run the judge, and write a receipt on pass. This is the path
-the hook requires.
-
-1. Write the body to a file. The hook only reads `--body-file`, so the file has
-   to exist anyway.
-2. Run the scorer against it, with the target repo so it can read the repo's PR
-   template:
+1. Write the body to a file. The gate only reads `--body-file`, so the file has
+   to exist anyway. Pass an absolute path with no `~`: the gate reads the
+   command text, and it cannot resolve a tilde or a path that does not exist
+   yet. Create the file in one call and run `gh` in the next, or the gate sees a
+   file that is not there.
+2. Score it, with the target repo so the scorer can read the repo's template:
 
    ```sh
    python3 <pr-body-skill-directory>/scripts/pr_body_lint.py \
      --body-file <path> --repo <repo-root> --json
    ```
 
-3. Fix every blocking finding. Each one carries fix text written as an
-   instruction; apply it to the body, do not argue with it. A warning is a
-   judgment call the author owns.
-4. Run the voice judge over the fixed body: [references/judge.md](references/judge.md).
-   Give it the body and the diff (`git diff <base>...HEAD`), which the judge
-   needs to see a fact the change makes load-bearing that the body never
-   mentions. The judge returns a verdict plus line-level rewrites, some of them
-   lines to add. Apply the rewrites you accept, then re-run the scorer, because
-   a rewrite can reintroduce a rule finding.
-5. On a clean scorer pass and a judge pass, write the receipt: the sha256 of the
-   body file's exact bytes, at
-   `~/.local/state/pr-body/receipts/<sha256>.json`. Then open the PR with
-   `--body-file` pointing at the same file.
+3. Fix every blocking finding. Each carries fix text written as an instruction;
+   apply it rather than arguing with it. A warning is a judgment call you own.
+4. Run the voice judge: [references/judge.md](references/judge.md). Give it the
+   body and `git diff <base>...HEAD`. The judge exists for one thing the scorer
+   cannot see: a fact the diff makes load-bearing that the body never mentions.
+   Apply the rewrites you accept, then re-score, because a rewrite can
+   reintroduce a rule finding.
+5. Record the receipt, then open or edit the pull request with `--body-file`
+   pointing at the same file:
+
+   ```sh
+   python3 <pr-body-skill-directory>/scripts/pr_body_receipt.py write <path>
+   ```
 
 Editing the file after step 5 changes its hash and voids the receipt. Run the
 write verb again.
 
 ### audit
 
-Score an existing PR's body and report. Never modify it.
+Score an existing body and report. Never modify it.
 
-1. Pull the body to a file: `gh pr view <pr> --json body -q .body`.
-2. Run the scorer against it, with `--repo` pointed at a checkout of the target
-   repo.
+1. `gh pr view <pr> --json body -q .body > <path>`.
+2. Score it with `--repo` pointed at a checkout of the target repo.
 3. Run the judge over the same body, with `gh pr diff <pr>` as the diff.
 4. Report the scorer findings by rule with their line numbers, then the judge's
-   rewrites. No receipt is written, because the audit did not author the body.
+   rewrites. No receipt: the audit did not author the body.
 
 ## The gate
 
 A PreToolUse hook on `Bash` matches `gh pr create` and `gh pr edit`, hashes the
-`--body-file` it was handed, and hard-denies when no receipt matches that hash.
-It also denies the invocation forms it cannot read (inline `--body`, heredocs),
-which is what forces `--body-file` in the first place.
+`--body-file` it was handed, and denies when no receipt matches that hash. It
+also denies the forms it cannot read: inline `--body`, heredocs, a tilde path, a
+file that does not exist yet.
 
-**There is no bypass.** No environment variable, no marker line, no flag. An
-agent that reaches the deny has one move: fix the body and run the write verb.
-The escape that does exist is uninstalling the hook from `~/.claude/hooks/`,
-which a human can do and an agent must not.
-
-The hook fails closed. An internal error, a malformed payload, or an unreadable
-body file all deny. The asymmetry that justifies it: a human can uninstall the
-hook, an agent cannot, so a broken gate costs a human one edit and costs an
-agent nothing it should have had.
-
-## What the gate cannot see
-
-The deterministic scorer catches roughly a third of what the operator rejects.
-On the hand-labeled set of 25 real bodies it caught 4 of the 12 rejected ones,
-and all 4 were empty or near-empty. Every miss was a voice judgment:
-pretentious phrasing, too much prose for not enough action, too many
-parentheses, too many code references.
-
-That is the whole reason the judge exists, and the reason a receipt (rather than
-a lint exit code) is what the hook checks. A body that passes the linter has
-been checked for countable defects only. Do not read a pass as a verdict that
-the body is good.
-
-A denial is not a setback. Measured over 256 runs, a body that fails the linter
-passes after one round of fixing, and an author given no guidance at all
-converges as fast as one given the whole of this file. Fix the findings and move
-on; do not rewrite from scratch. Measurements:
-[docs/pr-body-measurement.md](../../../docs/pr-body-measurement.md).
+There is no bypass, and the hook fails closed. The escape that exists is
+uninstalling the hook from `~/.claude/hooks/`, which a human can do and an agent
+must not.
 
 ## Rules the scorer implements
 
@@ -212,10 +179,10 @@ there is decorative. Grounds and fix text for each:
 | `bullet-per-file` | most bullets in a list of 3 or more lead with a filename | blocks |
 | `symbol-in-prose` | an identifier or function name outside code formatting | warns |
 
-Two behaviors of the scorer are worth knowing before arguing with a finding.
-Lines matching the repo's `.github/pull_request_template.md`, and the AI
-disclosure blockquote, are treated as scaffolding and exempt from the prose
-rules.
-Below 40 characters of prose the density rules (em dash, emoji, paths,
-narration, verdicts, reviewer asks, bullet-per-file, symbols) do not run at all;
-the structural rules run at every length.
+Lines matching the repo's template, and the AI disclosure blockquote, are
+scaffolding and exempt from the prose rules. Below 40 characters of prose the
+density rules do not run at all; the structural rules run at every length.
+
+A scorer pass means the countable defects are absent. On the labeled set it
+caught 4 of 12 rejected bodies, and all 4 were empty or near-empty. Everything
+else was voice, which is what the judge and the gold standard above are for.

--- a/skills/tools/say-less/SKILL.md
+++ b/skills/tools/say-less/SKILL.md
@@ -20,9 +20,17 @@ They do not lapse when the topic changes. Turn them off only when the reader say
 "stop say-less" or "normal mode"; confirm in one line, then return to default style.
 
 Invoked mid-conversation with no arguments, first re-state the previous assistant
-message under these rules, then stay active for the rest of the session. The
-re-statement keeps every decision the reader still owes and every fact they need
-to make it; it drops the process narration.
+message under these rules, then stay active for the rest of the session.
+
+The re-statement is a contraction. It is one sentence: the fact that answers the
+reader's last question, in the words they used. A second sentence is allowed only
+for the one decision that blocks their next action. Nothing else survives, whatever
+it cost to produce: process narration, tradeoffs already stated, remaining loose
+ends, shorthand the reader never used. A re-statement longer than the message it
+re-states has failed, and is the most common way this rule is broken.
+
+The dropped material is not lost, it is unasked for. Raise a dropped loose end when
+the reader reaches it, or when acting without it would be unsafe.
 
 A machine can also wire the digest ([reminder.md](reminder.md)) into a
 user-prompt-submit hook so the core rules re-inject on every prompt without invoking

--- a/skills/tools/say-less/SKILL.md
+++ b/skills/tools/say-less/SKILL.md
@@ -22,12 +22,25 @@ They do not lapse when the topic changes. Turn them off only when the reader say
 Invoked mid-conversation with no arguments, first re-state the previous assistant
 message under these rules, then stay active for the rest of the session.
 
-The re-statement is a contraction. It is one sentence: the fact that answers the
-reader's last question, in the words they used. A second sentence is allowed only
-for the one decision that blocks their next action. Nothing else survives, whatever
-it cost to produce: process narration, tradeoffs already stated, remaining loose
-ends, shorthand the reader never used. A re-statement longer than the message it
-re-states has failed, and is the most common way this rule is broken.
+The re-statement is a contraction, written for a reader who has not read the message
+it replaces. It is as short as it can be while still letting them decide, which is a
+cap on content, not a sentence count. Material kept in a semicolon, a subordinate
+clause, or a parenthesis has been re-typeset, not dropped. One clause per sentence,
+in the reader's own words.
+
+Three things survive the cut:
+
+1. **The answer, first.** The recommendation or the fact the reader asked for.
+2. **Each option, and what it costs.** When the message asks the reader to choose,
+   naming only the winner makes the choice unreviewable. Name every option in a
+   phrase, with the one cost that separates it, then the recommendation.
+3. **Any consequence that lands on a decision the reader already made.** A cost that
+   is the price of an earlier answer is the reason this choice exists. It is the last
+   thing to cut, not the first.
+
+Everything else goes, whatever it cost to produce: process narration, the evidence
+trail, spike and telemetry shorthand, ticket identifiers the reader did not use,
+tradeoffs that do not separate the options, remaining loose ends.
 
 The dropped material is not lost, it is unasked for. Raise a dropped loose end when
 the reader reaches it, or when acting without it would be unsafe.

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -68,6 +68,10 @@ class CbmOnboardTests(unittest.TestCase):
         self.environment = os.environ.copy()
         self.environment["CODEBASE_MEMORY_BIN"] = str(self.binary)
         self.environment["PRIVATE_SENTINEL"] = "must-not-appear"
+        # A developer's own global core.hooksPath would otherwise decide where the
+        # script installs, and the run would write outside the fixture.
+        self.environment["GIT_CONFIG_GLOBAL"] = os.devnull
+        self.environment["GIT_CONFIG_SYSTEM"] = os.devnull
 
     def tearDown(self):
         self.temporary.cleanup()
@@ -240,6 +244,22 @@ raise SystemExit(exit_code)
         self.assertEqual(request[:2], ["cli", "index_repository"])
         self.assertEqual(json.loads(request[2]), {"repo_path": str(self.repo.resolve()), "mode": "full"})
         self.assertNotIn("--name", request)
+
+    def test_tilde_hooks_path_installs_under_home_not_inside_the_checkout(self):
+        self.configure_lifecycle_binary()
+        home = self.scratch / "home"
+        (home / "hooks").mkdir(parents=True)
+        run(["git", "config", "core.hooksPath", "~/hooks"], cwd=self.repo)
+
+        result = run(
+            [str(CBM_SCRIPT), str(self.repo)],
+            cwd=ROOT,
+            env=self.environment | {"HOME": str(home), "CBM_SKIP_INDEX": "1"},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(BEGIN_HOOK, (home / "hooks" / "post-commit").read_text())
+        self.assertFalse((self.repo / "~").exists())
 
     def test_hookless_onboarding_enforces_stable_numeric_version_grammar(self):
         self.configure_lifecycle_binary()
@@ -437,7 +457,7 @@ raise SystemExit(exit_code)
         self.assertIn("refusing symlink target", result.stderr)
         self.assertEqual(target.read_text(encoding="utf-8"), "sentinel\n")
 
-    def test_refuses_hook_symlink_and_honors_core_hooks_path(self):
+    def test_follows_hook_symlink_to_its_target_and_honors_core_hooks_path(self):
         run(
             ["git", "config", "core.hooksPath", ".custom-hooks"],
             cwd=self.repo,
@@ -445,18 +465,43 @@ raise SystemExit(exit_code)
         hooks = self.repo / ".custom-hooks"
         hooks.mkdir()
         target = self.scratch / "outside-hook"
-        target.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-        (hooks / "post-commit").symlink_to(target)
+        target.write_text("#!/bin/sh\nprintf 'dispatcher\\n'\n", encoding="utf-8")
+        link = hooks / "post-commit"
+        link.symlink_to(target)
+
+        result = self.onboard()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        physical_link = Path(os.path.realpath(link.parent)) / link.name
+        self.assertIn(
+            f"following symlink {physical_link} to {Path(os.path.realpath(target))}",
+            result.stdout,
+        )
+        contents = target.read_text(encoding="utf-8")
+        self.assertIn("printf 'dispatcher\\n'", contents)
+        self.assertIn(BEGIN_HOOK, contents)
+        self.assertTrue(link.is_symlink())
+        self.assertFalse((self.repo / ".git" / "hooks" / "post-commit").exists())
+
+        again = self.onboard()
+
+        self.assertEqual(again.returncode, 0, again.stderr)
+        self.assertEqual(target.read_text(encoding="utf-8"), contents)
+
+    def test_refuses_hook_symlink_with_no_regular_file_target(self):
+        run(
+            ["git", "config", "core.hooksPath", ".custom-hooks"],
+            cwd=self.repo,
+        )
+        hooks = self.repo / ".custom-hooks"
+        hooks.mkdir()
+        (hooks / "post-commit").symlink_to(self.scratch / "does-not-exist")
 
         result = self.onboard()
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("refusing symlink target", result.stderr)
-        self.assertEqual(
-            target.read_text(encoding="utf-8"),
-            "#!/bin/sh\nexit 0\n",
-        )
-        self.assertFalse((self.repo / ".git" / "hooks" / "post-commit").exists())
+        self.assertIn("refusing symlink without a regular-file target", result.stderr)
+        self.assertFalse((self.scratch / "does-not-exist").exists())
     def test_preserves_unmatched_markers_foreign_hook_and_is_idempotent(self):
         run(
             ["git", "config", "core.hooksPath", ".custom-hooks"],

--- a/tests/test_pr_body_bench.py
+++ b/tests/test_pr_body_bench.py
@@ -41,12 +41,12 @@ class SkillSliceExtractionTests(unittest.TestCase):
         slices = BENCH.build_skill_slices()
         self.assertIn("```markdown", slices["example"])
         self.assertIn(DISCLOSURE, slices["example"])
-        self.assertIn("No headings", slices["example"])
+        self.assertIn("Copy its shape", slices["example"])
 
-    def test_rules_slice_contains_the_shape_and_textures_to_cut_only(self):
+    def test_rules_slice_contains_the_principles_and_never_list_only(self):
         slices = BENCH.build_skill_slices()
-        self.assertIn("Open with the action", slices["rules"])
-        self.assertIn("Verdict clauses", slices["rules"])
+        self.assertIn("Point at the spec", slices["rules"])
+        self.assertIn("Method narration", slices["rules"])
         # Content unique to other sections must not leak in.
         self.assertNotIn("gh pr create --body-file", slices["rules"])
         self.assertNotIn("PreToolUse hook", slices["rules"])
@@ -62,16 +62,16 @@ class SkillSliceExtractionTests(unittest.TestCase):
         self.assertLess(sizes["example"], sizes["full"])
         self.assertLess(sizes["rules"], sizes["full"])
 
-    def test_moved_shape_heading_raises_instead_of_shipping_empty_slice(self):
+    def test_moved_principles_heading_raises_instead_of_shipping_empty_slice(self):
         text = BENCH.SKILL_MD.read_text(encoding="utf-8").replace(
-            "## The shape", "## The Shapeee"
+            "## What that body does", "## What the body doess"
         )
         with self.assertRaises(BENCH.SkillExtractionError):
             BENCH.build_skill_slices(text)
 
-    def test_moved_textures_heading_raises(self):
+    def test_moved_never_heading_raises(self):
         text = BENCH.SKILL_MD.read_text(encoding="utf-8").replace(
-            "## Textures to cut", "## Stuff to trim"
+            "## Never", "## Stuff to trim"
         )
         with self.assertRaises(BENCH.SkillExtractionError):
             BENCH.build_skill_slices(text)
@@ -84,7 +84,10 @@ class SkillSliceExtractionTests(unittest.TestCase):
             BENCH.build_skill_slices(text)
 
     def test_heading_present_but_body_empty_raises(self):
-        text = "# PR body\n\n## The shape\n\n## Textures to cut\n\nsomething\n"
+        text = (
+            "# PR body\n\n## The gold standard\n\n```markdown\nbody\n```\n\n"
+            "## What that body does\n\n## Never\n\nsomething\n"
+        )
         with self.assertRaises(BENCH.SkillExtractionError):
             BENCH.build_skill_slices(text)
 


### PR DESCRIPTION
Three fixes to the pack, none of which touch each other.

* say-less now produces a re-statement short enough to replace the message it stands in for, with every option and the one cost that separates it kept, and process narration dropped.
* pr-body's gold standard is now the sentence you would say to the team plus the three facts a merger cannot infer, and it names where the decisions live instead of retelling them. About 1.7 KB, down from 2.4.
* cbm-onboard resolves hook paths the way git does. A `core.hooksPath` written with a leading tilde was joined to the repo, so hooks landed in a literal `~` directory inside the checkout and never in the real path; a symlinked hook was refused, which on a dotfiles-managed hooks directory meant no reindex hook at all, and it is now followed to the file it resolves to.
* Following a symlink means the managed block is written into whatever repo owns that file, a dotfiles checkout included. A symlink with no regular-file target is still refused.
* The cbm fixtures run with global and system git config at `/dev/null`, so a developer's own `core.hooksPath` cannot decide where the script writes during a test. That inheritance is how the tilde bug reached a passing suite.
* The bench that scores pr-body extracts its prompt slices from SKILL.md by heading, so the renamed sections moved with it.

The branch is rebased on main. The merge commit it used to carry had no sign-off and was failing the DCO check.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
