### PR TITLE
feat(ticket): route shipped surfaces through revise

### DIFF
--- a/skills/drivers/orchestrate/SKILL.md
+++ b/skills/drivers/orchestrate/SKILL.md
@@ -169,6 +169,13 @@ When coordinator mode runs a ui-craft lifecycle, the delegation split is:
   building to a lock manifest is contract-following, not taste.
 - **Fidelity evidence**: the build agent produces the mock-vs-build screenshots;
   the coordinator walks the ledger as verification.
+- **Shipped-surface revision**: the hermetic-implementation route. The revision
+  agent uses the repo-declared safe fixture, replays the frozen behavior ledger
+  against the base before changing it, and iterates the shipped app in place; it
+  never creates a replacement mock or lock manifest.
+- **Revision evidence**: the revision agent produces same-fixture base-versus-
+  revision before/after renders and raw replay output. The coordinator verifies the
+  behavior-ledger amendment and replay result; there is no fidelity ledger.
 
 Untested seams (benchmark was single-shot mockup generation only): frontend
 build-to-lock with rendered gate assertions, and multi-round mockup iteration.

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -36,6 +36,13 @@ What follows is what this skill adds on top. It replaces `start` steps 8 through
    that needs coordinator commentary to be executable is a triage defect, and the fix
    is to say so, not to patch it in the prompt.
 
+   `Surface lifecycle:` is part of that executable interface. Before dispatch,
+   confirm every UI-affecting sub-order says `build` or `revise` and names the lock
+   manifest or shipped behavior ledger/replay that mode consumes. On a rendered-
+   surface chunk, `none`, a missing legacy field, or a missing contract is a triage
+   defect. The worker loads the named UI Craft mode before implementing its `Do`
+   section; non-UI chunks keep `none`.
+
    Once the dispatcher exposes a stable transcript id, claim each unique
    implementation-worker session through the shared claim rule, passing
    `--session <id>`, `--agent <agent>`, and `--project <chunk-worktree>`. The agent

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -21,6 +21,14 @@ one header fence plus one fence per sub-order, all in the same comment. Every or
 of either shape carries a `Review depth:` line
 ([references/review-depth.md](../references/review-depth.md)).
 
+Every fence also carries `Surface lifecycle:`. Use `none` when no rendered surface
+changes, `build` for a greenfield or accepted-fallback lock, and `revise` for a
+shipped surface whose behavior ledger and replay remain its contract. The chunked
+header carries the one active lifecycle across the whole diff (`none` only when all
+chunks say `none`); each sub-order names its own route so the fence remains
+executable without coordinator commentary. One ticket does not mix `build` and
+`revise`: split those into separate tickets rather than inventing a fourth state.
+
 ## Two authoring checks before the draft leaves triage
 
 * **Wiring table.** Every value the order names (an environment variable, an input,
@@ -62,6 +70,7 @@ Open as: <model> / <effort>.
 Execution: single agent.
 
 Classification: <code | investigation | manual>
+Surface lifecycle: <none | build | revise>
 Repo(s): <org/repo> (branch from the default branch)
 Verification: <the command that verifies this change>
 Expectation: <what that command must report before the pull request opens>
@@ -102,6 +111,7 @@ Launch: open a session at the model above and run `/ticket start <ticket-id>`.
         It loads /orchestrate and coordinates the sub-orders itself.
 
 Classification: <code | investigation | manual>
+Surface lifecycle: <none | build | revise>
 Repo(s): <org/repo> (one ticket branch, one pull request)
 Verification: <the command that verifies the merged branch>
 Expectation: <what that command must report before the pull request opens>
@@ -129,6 +139,7 @@ Boundaries
 SUB-ORDER 1/<n> <ticket-id>: <chunk title>
 Mode: parallel | serial after <n>
 Agent: <haiku | sonnet | opus>
+Surface lifecycle: <none | build | revise>
 Review depth: <focused | targeted | full> (<one-line reason>)
 
 Context

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -43,6 +43,17 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    ownership is still disjoint; an overlap that drift introduced is a re-triage,
    not a merge problem to solve later.
 
+   Resolve the order's `Surface lifecycle:` before implementation. `build` requires
+   the named locked manifest. `revise` requires the named shipped behavior ledger,
+   replay, and repo-declared safe dev-server entrypoint plus fixture source. `none`
+   selects no UI Craft mode. An unknown value or a named contract that is absent is
+   drift and requires re-triage. For a legacy order posted before this slot existed,
+   infer `build` only when it explicitly names a locked manifest; otherwise select
+   no UI Craft mode. A legacy order that still asks to change a rendered surface
+   without either contract is insufficient and requires re-triage. On a chunked
+   order, apply the same check to every sub-order before switching to coordinator
+   mode.
+
 6. **Chunked order: switch to coordinator mode.** If the `Execution:` line says
    `chunked`, load `/orchestrate` now, then follow
    [references/coordinator-mode.md](../references/coordinator-mode.md) instead of
@@ -60,8 +71,11 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    change where the repo already records changes, on the same branch, per the skill
    page's change-record rule.
 
-   **Route by shape of the change.** User-interface work runs as `/ui-craft build`
-   against the locked manifest from triage. A new module or interface loads
+   **Route by shape of the change.** `Surface lifecycle: build` runs `/ui-craft
+   build` against the named locked manifest. `Surface lifecycle: revise` runs
+   `/ui-craft revise` against the named shipped behavior ledger and replay through
+   the repo-declared safe dev-server entrypoint and fixture source. `Surface
+   lifecycle: none` skips UI Craft. A new module or interface loads
    `/codebase-design` vocabulary before the seam is cut. New behavior with testable
    acceptance criteria goes test-first through `/tdd`. CI or workflow-file changes
    read `/ci-design` first.
@@ -108,11 +122,13 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
     ticket to pending review and comment on it (attribution first) with the pull
     request link and a one-line status.
 
-    **User-facing surface changes attach two more things, per the engineering
-    charter:** paired mock-versus-build screenshots (headless, same fixture and
-    viewports as the lock) and a fidelity ledger walking every lock-manifest term to
-    met, re-settle, or blocked. Missing either is a blocking gap on the pull request,
-    not a nit. Do not open it without them when the change touches a locked surface.
+    **Surface evidence follows the lifecycle.** A `build` attaches paired
+    mock-versus-build screenshots (same fixture and viewports as the lock) and a
+    fidelity ledger walking every lock-manifest term to met, re-settle, or blocked.
+    A `revise` attaches base-versus-revision before/after screenshots from the same
+    safe fixture, the amended frozen behavior ledger, and raw replay output against
+    the built revision. Missing lifecycle evidence is a blocking gap, not a nit;
+    `revise` never invents a lock manifest or fidelity ledger after the fact.
 
 13. **Stop.** Report the pull request URL, the verification evidence, review
     findings fixed or carried, and anything from the order left undone and why. On a

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -104,9 +104,25 @@ scope and spec documents committed in that worktree.
    instead. A single missing fact with no judgment attached (a hostname, a version)
    is the only exception. When nothing is genuinely uncertain, scope says so and
    returns without asking anything; that outcome is the pass signal, not a wasted
-   step. Resolved answers go into the order. A ticket needing user-interface
-   judgment hands off to `/ui-craft`'s lock phase first, and the order links the
-   locked spec.
+   step. Resolved answers go into the order.
+
+   **Resolve the surface lifecycle.** Every order and sub-order gets one closed
+   `Surface lifecycle:` value:
+
+   * `none` when it changes no rendered surface.
+   * `build` for a greenfield surface after `/ui-craft lock`, or for UI Craft's
+     explicit shipped-surface fallback. Name the lock manifest; on fallback also
+     name the predecessor behavior ledger and replay.
+   * `revise` for a shipped surface. Run UI Craft's setup/router during triage,
+     confirm its safe-start declaration and manufactured data source, and name the
+     frozen behavior ledger and replay that execution will use. Triage records the
+     route but does not start the app or implement the revision.
+
+   A UI Craft refusal or ambiguous route blocks the order. In a chunked order the
+   header carries the one non-`none` lifecycle active across the whole diff and
+   every sub-order carries its own; an affected sub-order must repeat the contract
+   paths it needs to stand alone. If chunks would mix `build` and `revise`, split
+   them into separate tickets instead of adding another lifecycle value.
 
 8. **Decide the shape: flat or chunked.** Read
    [references/slicing.md](../references/slicing.md) and run its trait rubric
@@ -130,7 +146,9 @@ scope and spec documents committed in that worktree.
     produce the right change. Name files and targets concretely. State what must
     not change. Set the verification command and its expectation. In a chunked
     order, no sub-order may reference another sub-order's content, and every chunk
-    names the files or targets it owns so parallel chunks cannot collide.
+    names the files or targets it owns so parallel chunks cannot collide. Check
+    that every fence's `Surface lifecycle:` value matches the route and contract
+    artifacts settled in step 7.
 
 11. **Adversarial review, mandatory.** Every draft order gets reviewed before it is
     shown to the user or posted; there is no unreviewed path to step 12. Run

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -86,6 +86,33 @@ def assistant_line(
 
 
 class TicketSkillContractTests(unittest.TestCase):
+    def test_surface_lifecycle_is_produced_and_consumed_across_ticket_paths(self):
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
+        start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
+            encoding="utf-8"
+        )
+        coordinator = (
+            TICKET_DIRECTORY / "references" / "coordinator-mode.md"
+        ).read_text(encoding="utf-8")
+        orchestrate = (
+            ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Surface lifecycle: <none | build | revise>", template)
+        self.assertEqual(
+            template.count("Surface lifecycle: <none | build | revise>"), 3
+        )
+        for lifecycle in ("`none`", "`build`", "`revise`"):
+            self.assertIn(lifecycle, triage)
+            self.assertIn(lifecycle, start)
+        self.assertIn("legacy order", start)
+        self.assertIn("locked manifest", start)
+        self.assertIn("behavior ledger", start)
+        self.assertIn("before/after", start)
+        self.assertIn("Surface lifecycle:", coordinator)
+        self.assertIn("Shipped-surface revision", orchestrate)
+
     def test_start_opens_with_summary_and_claim_before_fetching_the_order(self):
         shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
         start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a closed `Surface lifecycle: none | build | revise` slot to every ticket work-order fence
- route flat and chunked shipped-surface work through UI Craft `revise`, including its behavior-ledger/replay contract
- preserve legacy locked orders by inferring `build` only when they explicitly name a lock manifest
- select PR evidence by lifecycle: fidelity evidence for `build`, base/revision behavior evidence for `revise`

This removes the workflow contradiction that prevented a shipped UI ticket from using `/ticket start`. It unblocks triage of `harmonichq/germanium#23` once its parent surface ships.

## Verification

```text
python3.14 scripts/validate.py
python3.14 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install
python3.14 -m py_compile skills/tools/codebase-memory/scripts/install.py

validated 26 skills and 262 files
Ran 262 tests in 68.856s
OK (skipped=23)
```

The default system `python3` is 3.9.6 and cannot execute existing tests that use `TemporaryDirectory(ignore_cleanup_errors=...)`; the full gate above ran with the installed Python 3.14 interpreter, matching CI's supported behavior.
