### PR TITLE
feat: adopt robust-skills guidance in ticket and UI Craft

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,6 +15,13 @@ rewrite of the concepts in Matt Pocock's writing-for-agents skill
 (https://github.com/mattpocock/skills), MIT licensed,
 copyright (c) 2026 Matt Pocock.
 
+The pack's ticket capability ownership and codebase-design hexagonal direction,
+and UI Craft's web-implementation reference absorbing the modern-javascript and
+modern-css concept streams, are pack-native adaptations informed by robust-skills
+contributors (c) 2026, from the MIT-licensed snapshot
+https://github.com/ccheney/robust-skills/tree/0ace9a7f5c20d19cad678b894a717945da2ea8ed.
+They are not represented as verbatim copies.
+
 The ui-craft skill absorbs reference material and the design-antipattern
 detector from Paul Bakaus's Impeccable project
 (https://github.com/pbakaus/impeccable), Apache License 2.0,

--- a/docs/research/robust-skills-audit.md
+++ b/docs/research/robust-skills-audit.md
@@ -1,0 +1,134 @@
+# Robust Skills adoption audit
+
+## Decision
+
+Adopt three narrowly scoped streams in the first implementation pass: ticket
+capability ownership/slicing, codebase-design's hexagonal direction and adapter
+responsibility, and UI Craft web implementation. The web stream is delivered through
+the existing ticket → Surface lifecycle → `/ui-craft` route, not as standalone
+skills; UI Craft progressively discloses the CSS/JavaScript mechanics. This is an
+adaptation plan, not a vendor-skill import.
+
+**Upstream snapshot.** `ccheney/robust-skills` at
+`0ace9a7f5c20d19cad678b894a717945da2ea8ed` (the HEAD of the supplied clone),
+licensed MIT. All upstream links below are immutable blob permalinks at that
+commit.
+
+## Inventory and fit
+
+| Stream | Upstream skills (10 total) | Current maintained coverage | Decision |
+| --- | --- | --- | --- |
+| Architecture | [clean-ddd-hexagonal](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/clean-ddd-hexagonal/SKILL.md) | `skills/tools/codebase-design/` defines modules, seams, and adapters, but not an inward-dependency or port-responsibility rule. | Adapt the narrow gap. |
+| Frontend organization | [feature-slicing](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/feature-slicing/SKILL.md) | `ticket` already slices work orders and assigns disjoint file/target ownership; UI Craft owns rendered-surface lifecycle. | Borrow only ownership language for ticket chunks; defer FSD architecture. |
+| UI web implementation | [modern-javascript](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/modern-javascript/SKILL.md), [modern-css](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/modern-css/SKILL.md) | UI Craft owns the ticket-routed surface lifecycle but lacked a compact web-mechanics reference. | Absorb both concept streams into one progressively disclosed UI Craft reference. |
+| Database | [postgres-drizzle](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/postgres-drizzle/SKILL.md) | No database-specific tool. | Defer. |
+| Diagrams | [mermaid-diagrams](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/mermaid-diagrams/SKILL.md) | Existing documentation can use diagrams; no universal diagram-generation procedure. | Defer. |
+| Slack | [slack-mrkdwn](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/slack-mrkdwn/SKILL.md), [slack-block-kit](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/slack-block-kit/SKILL.md) | No Slack connector, app, or product-facing delivery workflow. | Defer. |
+| Teams | [teams-message-formatting](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/teams-message-formatting/SKILL.md), [teams-adaptive-cards](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/teams-adaptive-cards/SKILL.md) | No Teams connector, app, or delivery workflow. | Defer. |
+
+The overlap is deliberate only in two places. `ticket` already requires slicing,
+fresh-agent-readable sub-orders, serial/parallel modes, and disjoint ownership
+in `skills/drivers/ticket/references/slicing.md`; it must remain the owner rather
+than gaining a second feature-architecture skill. `codebase-design` already owns
+the vocabulary—especially seam and adapter—so a hexagonal addition belongs there,
+not in a DDD/clean-architecture duplicate. The upstream FSD hierarchy would
+conflict with the charter's locality, deletion test, and "second caller" seam
+rule ([profile/CHARTER.md](../../profile/CHARTER.md)).
+
+## First-pass implementation contracts
+
+### 1. Ticket capability ownership and slicing
+
+**Destinations:** `skills/drivers/ticket/references/slicing.md`,
+`skills/drivers/ticket/templates/work-order.md`,
+`skills/drivers/ticket/verbs/triage.md`, and `tests/test_ticket.py`.
+
+**Boundary:** make each chunk own a coherent capability plus its named files or
+targets; name any shared contract and its single owning chunk; prohibit a parallel
+chunk from implementing, revising, or depending on another chunk's internal
+capability. Preserve the existing trait rubric, measured thresholds, tracker
+contract, one ticket branch/PR, and coordinator integration. The upstream source
+supports strict directional ownership and public APIs; use that idea only to make
+ticket sub-orders executable independently, not to impose FSD folders.
+
+**Tests/acceptance:** add static contract tests that the template, triage procedure,
+and slicing reference agree on capability owner, shared-contract owner, and no
+parallel overlap. A chunked work order is accepted only when every capability and
+shared contract has exactly one owner, parallel ownership is disjoint, and each
+sub-order is stand-alone. Do **not** copy FSD's layers, `@x` notation, import rule,
+directory tree, or Steiger setup.
+
+### 2. Hexagonal direction and adapter responsibility
+
+**Destinations:** `skills/tools/codebase-design/SKILL.md`,
+`skills/tools/codebase-design/references/DEEPENING.md`, and
+`tests/test_behavior.py`.
+
+**Boundary:** add a compact decision rule: application/domain code declares the
+needed capability at its seam; adapters translate external protocols, storage,
+clock, and framework details; dependencies point from adapter toward the core;
+composition selects adapters. Tie a seam to the existing two-adapter rule—do not
+manufacture ports for hypothetical substitution. This fills the upstream's
+dependency/placement guidance without replacing the pack's deep-module model.
+
+**Tests/acceptance:** assert the canonical vocabulary and the four responsibility
+rules occur in both entry point and reference. Acceptance is that a reader can
+place a port, adapter, and composition root without allowing core code to import
+infrastructure, while a one-adapter case remains local. Do **not** copy the
+upstream's DDD tactical catalogue, aggregate limits, CQRS/event-sourcing/outbox
+prescription, authorization placement table, or canonical directory layout.
+
+### 3. UI Craft web implementation
+
+**Destinations:** `skills/drivers/ui-craft/reference/web-implementation.md`, its
+single context pointer in `skills/drivers/ui-craft/SKILL.md`, minimal direct-mode
+pointers, and focused assertions in `tests/test_behavior.py`.
+
+**Boundary:** route the concepts through the existing ticket → Surface lifecycle →
+`/ui-craft` path. Establish the project baseline first; distinguish ECMAScript
+standardization, runtime/host support, and transform/polyfill support; preserve the
+small set of JavaScript semantics traps; and make CSS cascade, layout, support, and
+degradation decisions. UI Craft remains the single owner of lifecycle, visual
+contracts, behavior preservation, and rendered verification.
+
+**Tests/acceptance:** behavior tests require the progressive-disclosure pointer,
+baseline-before-decision structure, the three compatibility questions, CSS fallback
+or degradation, lifecycle/evidence binding, and pinned provenance. Do not create
+standalone language skills or copy dated matrices, edition snapshots, proposal
+tables, or exhaustive feature catalogs.
+
+## Deferred work
+
+**Postgres/Drizzle:** defer for both domain specificity and version volatility.
+The upstream begins with incompatible stable `0.x` and `1.0.0-beta/rc` relation
+APIs and says its official documentation tracks v1 syntax; a general portable pack
+cannot safely choose between them without a project-specific version contract.
+
+**Mermaid:** defer because delivery compatibility is the issue, not syntax volume.
+The upstream calls C4/architecture forms experimental or beta and notes that hosts
+bundle different Mermaid versions, requiring a target-platform render check. This
+pack has no Mermaid renderer dependency and explicitly avoids third-party
+dependencies ([AGENTS.md](../../AGENTS.md)); add it only with a concrete rendering
+surface and verification path.
+
+**Slack and Teams:** defer all four skills. Their upstream guidance is explicitly
+vendor-surface/transport-specific: Slack distinguishes multiple markup systems and
+streaming/block payloads, while Teams distinguishes four incompatible markup
+systems and multiple transport wrappers. The Teams sources also encode dated
+connector-retirement guidance. With no Slack/Teams connector or owned delivery
+surface here, these broad proactive triggers would create unsupported, rapidly
+changing product policy rather than reusable pack behavior.
+
+## MIT provenance and authorship
+
+The upstream [MIT license](https://github.com/ccheney/robust-skills/blob/0ace9a7f5c20d19cad678b894a717945da2ea8ed/LICENSE) permits adaptation provided its
+copyright and permission notice accompany copies or substantial portions. Write
+each selected skill as a new, pack-native synthesis; cite this pinned snapshot in a
+short `Provenance` section and state that its rules, examples, structure, and
+wording are adapted by this pack's authors. At implementation, add a
+`robust-skills contributors (c) 2026` attribution and source URL to `NOTICE`, and
+add the same portion attribution to `LICENSE` if any substantial text, table,
+example, or reference file is carried forward. If copying is avoided as bounded
+above, the attribution still makes provenance clear without misrepresenting
+authorship; if it is not avoided, carry the full upstream MIT notice with the
+copied material.

--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -82,6 +82,15 @@ chunk 1".
   that touch the same file are serial, not parallel.
 * **File ownership** is declared per chunk. Every chunk names the files or targets
   it owns, and two parallel chunks' ownership is disjoint, so they cannot collide.
+* **Capability ownership** is declared per chunk. A chunk owns one coherent
+  capability together with its named files or targets; every capability has exactly
+  one owning chunk.
+* **Shared-contract ownership** is explicit. Name every shared contract and give it
+  exactly one owning chunk. Other chunks may rely on the stated shared contract,
+  never on that chunk's private capability.
+* **Parallel isolation** follows from that ownership. A parallel chunk must not
+  implement, revise, or depend on another chunk's private capability; make it
+  serial when that work or dependency is real.
 * **Agent tier** comes from
   [the routing table](../../orchestrate/references/routing-table.md): classify the
   chunk into an area (exploration, hermetic implementation, documentation, review)

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -141,6 +141,8 @@ Mode: parallel | serial after <n>
 Agent: <haiku | sonnet | opus>
 Surface lifecycle: <none | build | revise>
 Review depth: <focused | targeted | full> (<one-line reason>)
+Capability owned: <one coherent capability; exactly one sub-order owns it>
+Shared contracts owned: <none | each named contract this sub-order owns>
 
 Context
 <everything this chunk needs to stand alone in a fresh agent. Never "as established
@@ -154,6 +156,8 @@ Done when
 
 Boundaries
 * Touch only <files/targets this chunk owns>. Another chunk owns <the rest>.
+* A parallel chunk must not implement, revise, or depend on this chunk's private
+  capability. Name any shared contract and its one owning sub-order instead.
 * Do not record the change; the coordinator owns that.
 * Commit on this chunk's branch. Do not open a pull request, do not merge.
 ```

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -127,9 +127,13 @@ scope and spec documents committed in that worktree.
 8. **Decide the shape: flat or chunked.** Read
    [references/slicing.md](../references/slicing.md) and run its trait rubric
    against what grounding found. It decides flat or chunked and, when chunked,
-   sizes the chunks and names each one's mode, file ownership, agent tier, and the
-   orchestrator tier. Record which traits fired and which anchor row the ticket
-   matches; the order carries that reasoning, so a wrong call is visible later.
+   sizes the chunks and names each one's mode, coherent capability ownership, file
+   or target ownership, shared-contract ownership, agent tier, and the orchestrator
+   tier. Every capability and shared contract has exactly one owning chunk. A
+   parallel chunk must not implement, revise, or depend on another chunk's private
+   capability; make that work serial when the dependency is real. Record which
+   traits fired and which anchor row the ticket matches; the order carries that
+   reasoning, so a wrong call is visible later.
 
 9. **Stamp the review depth.** Read
    [references/review-depth.md](../references/review-depth.md) and stamp one depth
@@ -145,10 +149,11 @@ scope and spec documents committed in that worktree.
     session: a competent agent with only the ticket and that one block should
     produce the right change. Name files and targets concretely. State what must
     not change. Set the verification command and its expectation. In a chunked
-    order, no sub-order may reference another sub-order's content, and every chunk
-    names the files or targets it owns so parallel chunks cannot collide. Check
-    that every fence's `Surface lifecycle:` value matches the route and contract
-    artifacts settled in step 7.
+    order, no sub-order may reference another sub-order's content. Every chunk
+    names its coherent capability and its files or targets; every capability and
+    shared contract has exactly one owning chunk, so parallel chunks cannot collide
+    or depend on private capability. Check that every fence's `Surface lifecycle:`
+    value matches the route and contract artifacts settled in step 7.
 
 11. **Adversarial review, mandatory.** Every draft order gets reviewed before it is
     shown to the user or posted; there is no unreviewed path to step 12. Run
@@ -185,9 +190,10 @@ scope and spec documents committed in that worktree.
     sound order is a successful review.
 
     e. Chunked orders get one more axis: does each sub-order stand alone in a fresh
-    agent, are two parallel chunks' file and target ownership disjoint, and does the
-    serial ordering reflect a real dependency rather than habit. A chunk failing any
-    of those is a blocking objection.
+    agent; does every capability and shared contract have exactly one owning chunk;
+    are two parallel chunks' file, target, and capability ownership disjoint; and
+    does the serial ordering reflect a real dependency rather than habit. A chunk
+    failing any of those is a blocking objection.
 
     Hard cap at three review panels regardless of tier. Blocking objections still
     arriving at the cap mean the order has unsettled decisions, not undiscovered

--- a/skills/drivers/ui-craft/SKILL.md
+++ b/skills/drivers/ui-craft/SKILL.md
@@ -120,6 +120,12 @@ General design invocations with no mode match (e.g. "make this less bland",
 greenfield surface → `critique`-then-fix. Use
 [reference/design-rules.md](reference/design-rules.md) for the craft pass.
 
+**Web implementation.** For `build`, `revise`, and general UI implementation that
+changes CSS or JavaScript/TypeScript, read
+[reference/web-implementation.md](reference/web-implementation.md) before changing
+code. It governs web mechanics; UI Craft retains lifecycle, visual-contract,
+behavior-preservation, and rendered-evidence ownership.
+
 ## Design rules (all modes)
 
 [reference/design-rules.md](reference/design-rules.md) carries the shared

--- a/skills/drivers/ui-craft/reference/build.md
+++ b/skills/drivers/ui-craft/reference/build.md
@@ -21,6 +21,10 @@ first. The manifest alone never encodes what the surface *does*.
 
 ## Before writing code
 
+Read [web-implementation.md](web-implementation.md) before changing CSS or
+JavaScript/TypeScript; it governs web mechanics while this mode's lock and evidence
+contract remains binding.
+
 1. Read the manifest, the mock headers, and the mock's **component CSS** —
    not just its layout. Diff the mock's component styling (buttons, chips,
    rows) against the app's shipped equivalents; where they differ, the

--- a/skills/drivers/ui-craft/reference/revise.md
+++ b/skills/drivers/ui-craft/reference/revise.md
@@ -9,6 +9,10 @@ run against the built app. The branch is the visual artifact. Review screenshots
 record what changed, but no lock manifest or fidelity ledger is pinned to an app
 template.
 
+Before changing CSS or JavaScript/TypeScript, read
+[web-implementation.md](web-implementation.md); it governs web mechanics while this
+mode's behavior ledger and rendered evidence remain binding.
+
 This mode is for a shipped embodiment of the surface, including a new view inside
 a shell that already ships. A wholly greenfield surface uses `lock`.
 

--- a/skills/drivers/ui-craft/reference/web-implementation.md
+++ b/skills/drivers/ui-craft/reference/web-implementation.md
@@ -1,0 +1,50 @@
+# Web implementation
+
+Use this reference for CSS or JavaScript/TypeScript changes made through UI Craft's
+`build`, `revise`, or general UI implementation route. It guides mechanics, not
+lifecycle: the lock manifest, where present; the frozen behavior ledger, where
+applicable; and rendered evidence remain the UI Craft contract.
+
+## Establish the baseline
+
+Before selecting syntax, APIs, or CSS features, inspect the project's browser and
+support policy, client and server runtime, TypeScript target and libraries,
+bundler/transforms, and intentional polyfills. Record the implementation decision
+against that baseline.
+
+Keep three questions separate:
+
+1. **ECMAScript standardization:** is the language feature in the standard?
+2. **Runtime or host support:** do the target browsers and runtimes provide it?
+3. **Transform or polyfill support:** does the toolchain transform it, and is any
+   required runtime behavior supplied intentionally?
+
+## Preserve behavior and choose CSS deliberately
+
+Keep async sequencing, concurrency, and cancellation ownership explicit. Preserve
+the difference between mutation and change-by-copy, between nullish and other
+property states, and between ECMAScript features and browser or host APIs.
+
+For CSS, decide cascade/source order and specificity before adding overrides. Use
+Grid for two-dimensional layout and Flexbox for one-dimensional layout; choose
+viewport queries for viewport-wide adaptation and container queries for component
+adaptation. Prefer logical properties where direction can vary, honor reduced motion
+and accessibility needs, and use `@supports` with an explicit fallback or acceptable
+degradation when support varies.
+
+Every choice must preserve the locked visual contract or behavior ledger and be
+proven in the rendered evidence required by the active UI Craft mode. Do not replace
+that contract with a compatibility claim.
+
+## Boundaries and provenance
+
+Do not maintain dated browser or Node matrices, edition snapshots, proposal tables,
+or exhaustive feature catalogs here. Check the project baseline and stable primary
+standards instead: [ECMA-262](https://tc39.es/ecma262/),
+[HTML](https://html.spec.whatwg.org/),
+[CSS Cascade](https://www.w3.org/TR/css-cascade-5/), and
+[CSS Containment](https://www.w3.org/TR/css-contain-3/).
+
+This is a pack-native synthesis informed by robust-skills contributors (c) 2026:
+[modern JavaScript](https://github.com/ccheney/robust-skills/tree/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/modern-javascript)
+and [modern CSS](https://github.com/ccheney/robust-skills/tree/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/modern-css).

--- a/skills/tools/codebase-design/SKILL.md
+++ b/skills/tools/codebase-design/SKILL.md
@@ -47,6 +47,10 @@ behind it. _Avoid_: boundary (overloaded with DDD's bounded context).
 **Adapter** — a concrete thing that satisfies an interface at a seam. Describes
 *role* (what slot it fills), not substance (what's inside).
 
+**Core** — the application or domain code behind a seam. The core offers its
+interface to callers and declares the capability it requires from the outside;
+both interface decisions belong on the core side of the seam.
+
 **Leverage** — what callers get from depth: more capability per unit of
 interface they learn. One implementation pays back across N call sites and M
 tests.
@@ -100,6 +104,11 @@ When designing an interface, ask:
   shape.
 - **One adapter means a hypothetical seam. Two adapters means a real one.**
   Don't introduce a seam unless something actually varies across it.
+- **Hexagonal direction.** Adapters depend toward the core; core code must not
+  import infrastructure, framework, storage, clock, or protocol details. An
+  adapter translates those external details and does not duplicate business rules.
+  Composition selects adapters. Keep a one-adapter case local; a simple module may
+  expose its handler directly.
 
 ## Designing for testability
 
@@ -139,6 +148,9 @@ Good interfaces make testing natural:
 - **Depth** is a property of a **Module**, measured against its **Interface**.
 - A **Seam** is where a **Module**'s **Interface** lives.
 - An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- The **Core** offers an **Interface** and declares the capability it requires at
+  its **Seam**; **Adapters** depend toward that **Core**, and composition selects
+  them.
 - **Depth** produces **Leverage** for callers and **Locality** for maintainers.
 
 ## Rejected framings

--- a/skills/tools/codebase-design/references/DEEPENING.md
+++ b/skills/tools/codebase-design/references/DEEPENING.md
@@ -47,6 +47,13 @@ adapter.
   (private to its implementation, used by its own tests) as well as the
   external seam at its interface. Don't expose internal seams through the
   interface just because tests use them.
+- **Hexagonal direction.** The core offers its interface to callers and declares
+  the capability it requires from the outside; locate both interface decisions on
+  the core side of the seam. Adapters depend toward the core, while core code must
+  not import infrastructure, framework, storage, clock, or protocol details.
+  Adapters translate those external details and do not duplicate business rules;
+  composition selects adapters. Keep a one-adapter case local, and let a simple
+  module expose its handler directly.
 
 ## Testing strategy: replace, don't layer
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -597,6 +597,129 @@ class UiCraftContractTests(unittest.TestCase):
         self.assertRegex(sweep, r"Under `revise`, the\s+ledger amendment")
         self.assertIn("--skill spin-worktree", readme)
 
+    def test_web_implementation_is_disclosed_without_becoming_a_standalone_skill(self):
+        skill = (ROOT / "skills" / "drivers" / "ui-craft" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        build = (ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "build.md").read_text(
+            encoding="utf-8"
+        )
+        revise = (
+            ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "revise.md"
+        ).read_text(encoding="utf-8")
+        web = (
+            ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "web-implementation.md"
+        ).read_text(encoding="utf-8")
+        web_contract = " ".join(web.split())
+
+        pointer = "[reference/web-implementation.md](reference/web-implementation.md)"
+        self.assertIn(pointer, skill)
+        self.assertIn("web-implementation.md", build)
+        self.assertIn("web-implementation.md", revise)
+        self.assertLess(
+            web.index("## Establish the baseline"),
+            web.index("## Preserve behavior and choose CSS deliberately"),
+        )
+        for question in (
+            "ECMAScript standardization",
+            "Runtime or host support",
+            "Transform or polyfill support",
+        ):
+            self.assertIn(question, web)
+        for requirement in (
+            "browser and support policy",
+            "TypeScript target and libraries",
+            "async sequencing, concurrency, and cancellation",
+            "mutation and change-by-copy",
+            "nullish and other property states",
+            "Grid for two-dimensional layout",
+            "Flexbox for one-dimensional layout",
+            "container queries",
+            "logical properties",
+            "reduced motion",
+            "@supports",
+            "fallback or acceptable degradation",
+            "lock manifest",
+            "behavior ledger",
+            "rendered evidence",
+        ):
+            self.assertIn(requirement, web_contract)
+        for forbidden in ("browser or Node matrices", "edition snapshots", "proposal tables"):
+            self.assertIn(forbidden, web)
+        self.assertNotRegex(web, r"(?m)^\s*\|")
+        self.assertNotRegex(web, r"\b(?:Chrome|Firefox|Safari|Edge|Node)\s+(?:v)?\d+\b")
+        self.assertIn(
+            "https://github.com/ccheney/robust-skills/tree/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/modern-javascript",
+            web,
+        )
+        self.assertIn(
+            "https://github.com/ccheney/robust-skills/tree/0ace9a7f5c20d19cad678b894a717945da2ea8ed/skills/modern-css",
+            web,
+        )
+        for name in ("modern-css", "modern-javascript"):
+            self.assertFalse((ROOT / "skills" / "tools" / name).exists())
+
+
+class CodebaseDesignHexagonalContractTests(unittest.TestCase):
+    def test_hexagonal_direction_preserves_seam_discipline(self):
+        skill = (ROOT / "skills" / "tools" / "codebase-design" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        deepening = (
+            ROOT / "skills" / "tools" / "codebase-design" / "references" / "DEEPENING.md"
+        ).read_text(encoding="utf-8")
+        core = skill.split("**Core**", 1)[1].split("**Leverage**", 1)[0]
+        principles = skill.split("## Principles", 1)[1].split(
+            "## Designing for testability", 1
+        )[0]
+        skill_direction = principles.split("**Hexagonal direction.**", 1)[1]
+        seam_discipline = deepening.split("## Seam discipline", 1)[1].split(
+            "## Testing strategy", 1
+        )[0]
+        deepening_direction = seam_discipline.split("**Hexagonal direction.**", 1)[1]
+
+        core_terms = core.lower()
+        for requirement in ("offers", "interface", "requires", "core side"):
+            self.assertIn(requirement, core_terms)
+
+        self.assertLess(
+            principles.index("**One adapter means a hypothetical seam."),
+            principles.index("**Hexagonal direction.**"),
+        )
+        self.assertLess(
+            seam_discipline.index("**One adapter means a hypothetical seam."),
+            seam_discipline.index("**Internal seams vs external seams.**"),
+        )
+        self.assertLess(
+            seam_discipline.index("**Internal seams vs external seams.**"),
+            seam_discipline.index("**Hexagonal direction.**"),
+        )
+
+        for direction in (skill_direction, deepening_direction):
+            normalized = " ".join(direction.lower().split())
+            for requirement in (
+                "adapters depend toward the core",
+                "core code must not import",
+                "translate",
+                "business rules",
+                "composition selects adapters",
+                "one-adapter case local",
+                "handler directly",
+            ):
+                self.assertIn(requirement, normalized)
+            self.assertLess(
+                normalized.index("adapters depend toward the core"),
+                normalized.index("composition selects adapters"),
+            )
+
+        self.assertIn("The deletion test.", principles)
+        self.assertIn("Locality", skill)
+        self.assertIn("core side of the seam", deepening_direction)
+
+        design_contract = "\n".join((skill, deepening)).lower()
+        for forbidden in ("cqrs", "event sourcing", "aggregate limit", "outbox"):
+            self.assertNotIn(forbidden, design_contract)
+
 
 class SpinWorktreeTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -86,6 +86,72 @@ def assistant_line(
 
 
 class TicketSkillContractTests(unittest.TestCase):
+    def test_chunk_contract_owns_capabilities_and_shared_contracts_once(self):
+        slicing = (TICKET_DIRECTORY / "references" / "slicing.md").read_text(
+            encoding="utf-8"
+        )
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
+            encoding="utf-8"
+        )
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(
+            encoding="utf-8"
+        )
+        trait_rubric = slicing.split("## The trait rubric", 1)[1].split(
+            "## Anchor table", 1
+        )[0]
+        chunk_shape = slicing.split("## Chunk shape", 1)[1].split(
+            "## Orchestrator tier", 1
+        )[0]
+        triage_shape = triage.split("8. **Decide the shape", 1)[1].split(
+            "9. **Stamp the review depth", 1
+        )[0]
+        sub_order = template.split("SUB-ORDER 1/<n>", 1)[1].split("```", 1)[0]
+
+        self.assertRegex(
+            trait_rubric,
+            r"Slice when \*\*two or more\*\* of these hold\. One or zero: the order stays flat\.",
+        )
+        for heading in (
+            "**File ownership**",
+            "**Capability ownership**",
+            "**Shared-contract ownership**",
+            "**Parallel isolation**",
+        ):
+            self.assertIn(heading, chunk_shape)
+        self.assertLess(
+            chunk_shape.index("**Capability ownership**"),
+            chunk_shape.index("**Shared-contract ownership**"),
+        )
+        self.assertLess(
+            chunk_shape.index("**Shared-contract ownership**"),
+            chunk_shape.index("**Parallel isolation**"),
+        )
+        self.assertIn("capability ownership", triage_shape)
+        self.assertIn("shared-contract ownership", triage_shape)
+
+        self.assertEqual(template.count("Capability owned:"), 1)
+        self.assertEqual(template.count("Shared contracts owned:"), 1)
+        self.assertLess(
+            sub_order.index("Review depth:"), sub_order.index("Capability owned:")
+        )
+        self.assertLess(
+            sub_order.index("Shared contracts owned:"), sub_order.index("Context")
+        )
+        for heading in ("Context", "Do", "Done when", "Boundaries"):
+            self.assertIn(heading, sub_order)
+
+        parallel_isolation = chunk_shape.split("**Parallel isolation**", 1)[1].split(
+            "**Agent tier**", 1
+        )[0]
+        for contract in (parallel_isolation, triage_shape, sub_order):
+            normalized = " ".join(contract.lower().split())
+            for requirement in ("parallel", "implement", "revise", "depend", "private capability"):
+                self.assertIn(requirement, normalized)
+
+        ticket_contract = "\n".join((slicing, template, triage))
+        for forbidden in ("@x", "Feature-Sliced", "Steiger"):
+            self.assertNotIn(forbidden, ticket_contract)
+
     def test_surface_lifecycle_is_produced_and_consumed_across_ticket_paths(self):
         triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
         start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")
@@ -98,6 +164,9 @@ class TicketSkillContractTests(unittest.TestCase):
         orchestrate = (
             ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md"
         ).read_text(encoding="utf-8")
+        ui_craft = (ROOT / "skills" / "drivers" / "ui-craft" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
 
         self.assertIn("Surface lifecycle: <none | build | revise>", template)
         self.assertEqual(
@@ -112,6 +181,11 @@ class TicketSkillContractTests(unittest.TestCase):
         self.assertIn("before/after", start)
         self.assertIn("Surface lifecycle:", coordinator)
         self.assertIn("Shipped-surface revision", orchestrate)
+        self.assertIn("/ui-craft", " ".join(start.split()))
+        self.assertIn(
+            "[reference/web-implementation.md](reference/web-implementation.md)",
+            ui_craft,
+        )
 
     def test_start_opens_with_summary_and_claim_before_fetching_the_order(self):
         shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

The pack now applies selected robust-skills guidance through its existing ticket, module-design, and UI workflows instead of importing a parallel skill collection.

* Chunked ticket orders name one capability owner and one owner for every shared contract, while retaining the existing two-trait threshold for splitting work.
* Codebase design now states the useful hexagonal direction: adapters depend toward the core, translate external details, and do not justify a speculative seam by themselves.
* Ticket-routed UI work reaches one progressively disclosed web-implementation reference for JavaScript, TypeScript, and CSS mechanics. UI Craft remains responsible for locked terms, behavior preservation, and rendered evidence.
* The committed adoption audit records the pinned upstream snapshot, adapted boundaries, provenance, and the Postgres, Mermaid, Slack, and Teams deferrals.

## Why

The existing workflow already owned ticket slicing, module seams, and rendered surfaces, but it did not carry the upstream capability-ownership, dependency-direction, or web-compatibility guidance at those decision points. Absorbing the narrow gaps keeps each rule with the workflow that enforces it.

## Verification

* Full suite: 267 tests pass, 23 skipped.
* Structural validator: all 26 skills accepted.
* Compile check: exit 0. Pre-push DCO gate: 1 commit accepted.

## Review

Independent review passed after the standalone CSS and JavaScript skill design was replaced with UI Craft progressive disclosure. A cold UI Craft run reached and applied the folded compatibility guidance through its normal entrypoint.

## What to check

* A chunked ticket cannot leave capability or shared-contract ownership implicit.
* Hexagonal direction does not weaken the two-adapter rule or create mandatory ports for simple modules.
* UI build and revision routes load web mechanics without bypassing the visual or behavior contracts.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
