### PR TITLE
Preserve dirty checkouts when spinning worktrees

### DIFF
--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -93,13 +93,14 @@ substitutes a lighter check for the depth the order stamped.
    cuts the branch and worktree through `spin-worktree`; `start` and `revise`
    reuse them; `finalize` tears them down. The first repository action after the
    summary-and-claim opening, before grounding or any repo read, is to cut or
-   reuse the ticket's worktree, which is refused if the control checkout is dirty.
-   Grounding, scope ledgers, and change records all happen and get committed
-   there. The control checkout may be stale
-   or on another branch: its working tree is never read or written, and it never
-   switches branches. It holds the ticket's branch ref, which is what the worktree
-   is cut from. Before its first write, every verb confirms that its working
-   directory is the path the worktree helper reported; a mismatch stops the verb.
+   reuse the ticket's worktree. Grounding, scope ledgers, and change records all
+   happen and get committed there. The control checkout may be dirty, stale, or
+   on another branch: its working tree is never read or written, and it never
+   switches branches. Never commit, stash, move, or clean its files, and never
+   substitute another task's worktree as the control checkout. It holds the
+   ticket's branch ref, which is what the worktree is cut from. Before its first
+   write, every verb confirms that its working directory is the path the worktree
+   helper reported; a mismatch stops the verb.
    A chunked order is the one exception and does not loosen the rule: chunk agents
    work in per-chunk worktrees cut from the ticket branch and torn down as each
    chunk merges back into it, so the ticket still ends with one branch and one

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -45,8 +45,10 @@ scope and spec documents committed in that worktree.
    ticket's branch (`git -C <worktree> branch --show-current`) and reuse it rather
    than respinning.
 
-   e. The helper refuses on a dirty control checkout or an existing target path.
-   Surface that refusal to the user; do not force past it.
+   e. A dirty control checkout is valid: leave its files untouched and spin from
+   it directly. Never search the existing task worktrees for a clean substitute.
+   The helper still refuses an existing target path; surface that refusal to the
+   user rather than forcing past it.
 
 3. **Identify the repo or repos.** From the ticket text, its parent, and its links.
    If the target repo does not exist yet, stop: repo scaffolding happens outside

--- a/skills/tools/spin-worktree/SKILL.md
+++ b/skills/tools/spin-worktree/SKILL.md
@@ -6,7 +6,9 @@ description: Create an isolated Git worktree for issue, pull-request, branch, or
 # Spin an isolated worktree
 
 Keep the ordinary checkout as the control checkout and create one worktree per
-task. The bundled helper refuses to update a dirty control checkout.
+task. Dirty files in the control checkout are preserved and do not block the
+helper: it updates Git refs and shared worktree metadata, creates the destination,
+and never switches, stashes, or edits files in the control checkout.
 
 By default worktrees live under `${AGENT_WORKTREE_ROOT:-~/worktrees}`:
 
@@ -16,7 +18,10 @@ By default worktrees live under `${AGENT_WORKTREE_ROOT:-~/worktrees}`:
 
 ## Workflow
 
-1. Resolve the control repository and pass it explicitly with `--repo`.
+1. Resolve the ordinary checkout and pass it explicitly with `--repo`. Never
+   substitute another task's linked worktree just because it is clean. If a
+   linked worktree is passed accidentally, the helper resolves Git's primary
+   worktree before deriving `<repository>` or running commands.
 2. Resolve this installed skill's directory.
 3. Run one of the commands below.
 4. Report the exact path and use it as the working directory.

--- a/skills/tools/spin-worktree/scripts/spin-worktree.py
+++ b/skills/tools/spin-worktree/scripts/spin-worktree.py
@@ -86,11 +86,12 @@ def repository_root(path: Path) -> Path:
     return Path(value).resolve()
 
 
-def require_clean(repo: Path, *, dry_run: bool) -> None:
-    if dry_run:
-        return
-    if git(repo, "status", "--short", capture=True):
-        raise SpinError(f"control checkout is dirty: {repo}")
+def primary_worktree(repo: Path) -> Path:
+    value = git(repo, "worktree", "list", "--porcelain", capture=True)
+    first_line = value.splitlines()[0] if value else ""
+    if not first_line.startswith("worktree "):
+        raise SpinError(f"cannot determine the primary worktree for {repo}")
+    return Path(first_line.removeprefix("worktree ")).resolve()
 
 
 def local_branch_exists(repo: Path, branch: str) -> bool:
@@ -207,8 +208,8 @@ def main() -> int:
     try:
         if arguments.name is not None:
             safe_leaf(arguments.name)
-        repo = repository_root(Path(arguments.repo).expanduser())
-        require_clean(repo, dry_run=arguments.dry_run)
+        supplied_repo = repository_root(Path(arguments.repo).expanduser())
+        repo = primary_worktree(supplied_repo)
         root = Path(arguments.worktree_root).expanduser().resolve()
 
         if arguments.issue is not None:

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -744,18 +744,32 @@ class SpinWorktreeTests(unittest.TestCase):
         self.temporary.cleanup()
 
     def spin(self, *arguments: str):
+        return self.spin_from(self.repo, *arguments)
+
+    def spin_from(self, repo: Path, *arguments: str):
         return run(
             [
                 "python3",
                 str(SPIN_SCRIPT),
                 "--repo",
-                str(self.repo),
+                str(repo),
                 "--worktree-root",
                 str(self.scratch / "worktrees"),
                 *arguments,
             ],
             cwd=ROOT,
         )
+
+    def configure_origin(self):
+        remote = self.scratch / "origin.git"
+        result = run(
+            ["git", "init", "--bare", "-b", "main", str(remote)],
+            cwd=self.scratch,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        run(["git", "remote", "add", "origin", str(remote)], cwd=self.repo)
+        result = run(["git", "push", "-u", "origin", "main"], cwd=self.repo)
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_rejects_names_that_can_escape_the_task_directory(self):
         for unsafe in ("", ".", "..", "../escape", "nested/name", "nested\\name", "/tmp/x"):
@@ -785,6 +799,52 @@ class SpinWorktreeTests(unittest.TestCase):
         self.assertTrue(
             (self.scratch / "worktrees" / "repo" / "local-topic" / ".git").exists()
         )
+
+    def test_dirty_control_checkout_does_not_block_fresh_issue_work(self):
+        self.configure_origin()
+        untracked = self.repo / "unfinished-notes.md"
+        untracked.write_text("keep me\n", encoding="utf-8")
+
+        result = self.spin(
+            "--issue",
+            "13",
+            "--slug",
+            "isf-safety-predicate",
+            "--name",
+            "13",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        worktree = self.scratch / "worktrees" / "repo" / "13"
+        self.assertTrue((worktree / ".git").exists())
+        branch = run(["git", "branch", "--show-current"], cwd=worktree)
+        self.assertEqual(branch.stdout.strip(), "codex/13-isf-safety-predicate")
+        self.assertEqual(untracked.read_text(encoding="utf-8"), "keep me\n")
+        status = run(["git", "status", "--short"], cwd=self.repo)
+        self.assertEqual(status.stdout, "?? unfinished-notes.md\n")
+
+    def test_linked_worktree_input_uses_primary_repository_identity(self):
+        run(["git", "branch", "task-52"], cwd=self.repo)
+        run(["git", "branch", "local-topic"], cwd=self.repo)
+        linked = self.scratch / "linked" / "52"
+        linked.parent.mkdir()
+        result = run(
+            ["git", "worktree", "add", str(linked), "task-52"],
+            cwd=self.repo,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        result = self.spin_from(
+            linked,
+            "--branch",
+            "local-topic",
+            "--name",
+            "13",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((self.scratch / "worktrees" / "repo" / "13" / ".git").exists())
+        self.assertFalse((self.scratch / "worktrees" / "52").exists())
 
 
 class CodexWorkerTests(unittest.TestCase):


### PR DESCRIPTION
## What changed

Worktree setup can now proceed when the ordinary checkout contains unfinished files. Those files remain untouched, and ticket triage no longer detours through another task worktree to satisfy a cleanliness check.

If a linked worktree is supplied anyway, setup resolves the primary checkout before choosing the repository directory. New work therefore stays under the expected worktrees/repository/task layout.

## Why

The previous cleanliness rule blocked safe ticket setup. Working around that rule with an existing task worktree could misidentify the task number as the repository name and create the new worktree in the wrong directory.

## What to check

- A fresh issue worktree is created while untracked control-checkout files remain unchanged.
- Linked-worktree input still produces the expected repository-level destination.
- Existing target paths continue to be refused.

## Verification

The complete repository gate passed: 269 tests passed, 23 skipped, all 26 skills validated, and the DCO hook passed.