### PR TITLE
docs(ticket): slice rejected scope replacements

### DIFF
--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -17,6 +17,7 @@ Slice when **two or more** of these hold. One or zero: the order stays flat.
 | Split-path evidence | Acceptance requires proving the same behavior on more than one code path that a single run cannot both exercise — a platform or feature-flag branch, or a re-implementation in another language held identical by test — so each path costs its own harness |
 | Lockstep copies of one fact | Adding one member to a closed set obliges edits in more than two encodings that no single tool checks together: a source of truth, a hand-maintained transcription, a fixture generator, and the committed fixture it freezes |
 | Lifecycle-gated surface revision | A shipped user-facing surface must first lock its visual contract, then implement it and prove it through a browser evidence matrix; the lock, implementation, and evidence each consume the same ticket's context |
+| In-flight scope replacement | A new work order rejects implementation already on the ticket branch and must remove or reconcile it before building the replacement |
 
 The traits are proxies for context load, not for effort. A long-but-uniform change
 (twenty near-identical grants in one target) fires nothing and stays flat, while a
@@ -43,6 +44,7 @@ the helper's `scan` command, not estimates.
 | D | Port live networking into the repo's own tooling, with imports | multiple targets, import | slice; was not | 574k in one session |
 | E | CI previewing every deployment target | multiple targets, multiple artifacts | slice | 359k plus a 313k resume |
 | F | One new member of a closed behavioural taxonomy, wired through its server projection, a JS mirror, three fixture generators and a browser gate | multiple artifacts, live run, lockstep copies | slice: detector and its tests, then the surface and its fixtures | flat; peaked 503k over 4 sessions |
+| 53 | Replace a rejected application route already on the ticket branch, then build a narrower shared route adapter and update its consumers | multiple artifacts, in-flight scope replacement | slice into two serial chunks: remove and reconcile the rejected implementation, then build and verify the replacement | flat revised order; peaked 245k across 5 sessions |
 | 10 | Proof-bounded I:C history across an analyzer, server projections, generated fixtures, and a lifecycle-gated Diagnose revision | multiple artifacts, live run, lockstep copies, lifecycle-gated surface revision | slice into four serial chunks: analyzer, server contract, generated projections/evidence, then surface lock and browser evidence | 3 chunks; peaked 244k |
 | 90 | One shared behavioural judgment across model view, two server projections, generated fixtures and mirrors, and browser replay | multiple artifacts, live run, lockstep copies | slice into three serial chunks: source judgment, projection contracts, then generated artifacts and live replay | 2 chunks; peaked 231k |
 


### PR DESCRIPTION
## What changed

- Add an `In-flight scope replacement` slicing trait for work orders that must remove or reconcile rejected implementation before building its replacement.
- Add Harmonic ticket 53 as the measured calibration anchor: the flat replacement order peaked at 245k tokens across five sessions, so the recommended shape is two serial chunks.

## Why

The existing rubric treated that replacement as a one-trait, flat order. The measured run exceeded the 180k degradation band by about 65k tokens. This amendment makes the hidden cleanup-and-reconciliation pass visible during work-order shaping without changing the global thresholds.

## What to check

- The new trait remains specific to implementation already present on the ticket branch; ordinary scope edits should not fire it.
- The anchor recommends separating rejected-work reconciliation from replacement implementation.

## Validation

- `python3 -m unittest tests.test_ticket` — 27 passed
- `python3 -m py_compile skills/tools/codebase-memory/scripts/install.py` — passed
- `git diff --check` — passed

Local baseline notes:

- `python3 scripts/validate.py` stops on a forbidden value in reachable commit `35397be`; that commit exists only on unrelated local branch `codex/85-evidence-first-execution-profiles` and is not an ancestor of `origin/main` or present on any remote branch.
- The full declared unit command enters unrelated Codex-worker state/fixture errors locally; the focused ticket contract is green.
