### PR TITLE
feat(clean): add diff-scoped cleaner pass before hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ the UI workflow uses the bundled browser driver for rendered evidence.
 | [`cbm-onboard`](skills/tools/cbm-onboard/SKILL.md) | Keep a maintained checkout indexed, or onboard and tear down a hookless ephemeral worktree | `codebase-memory-mcp` on `PATH`; v0.10.8+ for ephemeral lifecycle |
 | [`codebase-memory`](skills/tools/codebase-memory/SKILL.md) | Explore indexed code through the graph and activate portable Claude Code discovery hooks | `codebase-memory-mcp` for graph queries; activation fails open without it |
 | [`ci-design`](skills/tools/ci-design/SKILL.md) | Vocabulary and principles for well-designed CI | — |
+| [`clean`](skills/tools/clean/SKILL.md) | Clean a branch's diff in one pass — naming, dead code, duplication, and the charter's deep-module rules — without changing behavior, ending in a ledger rather than a verdict | `codebase-design` from this pack; `domain-modeling` optional |
 | [`code-review`](skills/tools/code-review/SKILL.md) | Review changes since a fixed point on two axes, Standards and Spec, each returning a verdict per enumerated item so a round terminates | Parallel-agent support recommended; GitHub CLI to fetch an originating issue; see [docs/review-round-mining.md](docs/review-round-mining.md) for the mined evidence behind the fix protocol and the round cap |
 | [`codebase-design`](skills/tools/codebase-design/SKILL.md) | Shared vocabulary for designing deep modules | — |
 | [`domain-modeling`](skills/tools/domain-modeling/SKILL.md) | Build and sharpen a project's domain model | — |

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -26,6 +26,7 @@ EXPECTED = {
     "tools/cbm-onboard",
     "tools/codebase-memory",
     "tools/ci-design",
+    "tools/clean",
     "tools/code-review",
     "tools/codebase-design",
     "tools/domain-modeling",

--- a/skills/tools/clean/SKILL.md
+++ b/skills/tools/clean/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: clean
+description: Clean the current branch's diff without changing behavior — naming, dead code, duplication, and the charter's deep-module rules — in one pass, then stop. Use when the user says "clean this diff", "/clean", "cleanup pass", or wants the branch tidied before review or hardening.
+---
+
+# Clean
+
+One cleanup pass over the code a branch changed. It keeps behavior and the test
+suite exactly as they were, and it ends with a ledger instead of a verdict.
+
+This skill **changes code**. It is not a reviewer: it never scores, never grades,
+and never emits findings for a human to action inside the diff. Anything it
+notices outside the diff becomes a follow-up line, never an edit.
+
+One pass. When the ledger is written, stop — no second sweep.
+
+## Fixed point
+
+The pass is scoped to a diff, so it starts by pinning where that diff begins.
+
+Accept an optional ref argument (`/clean <ref>`). With none, the fixed point is
+the merge-base with the default branch. Resolve it by the rules in
+[`code-review`'s "Pin the fixed point"](../code-review/SKILL.md#1-pin-the-fixed-point) —
+the same SHA, branch, tag, PR, and stale-base handling, cited rather than
+restated. Confirm the diff is non-empty before touching anything.
+
+The **scope** is the files changed since that point. Unchanged files are read
+freely for context — that is how you learn the module that already covers a
+behavior — but they are not edited.
+
+## Preconditions
+
+Discover the repo's test command the way `/ticket` does: read `AGENTS.md` or
+`CLAUDE.md` for a test line first, then the CI workflows, then package scripts.
+An argument naming the command overrides discovery.
+
+Run it before any edit.
+
+* **Green:** proceed, and record the command and result for the ledger.
+* **Red:** stop. Report the failing output and make no edits. A branch that is
+  already broken has no baseline to preserve, and a cleaner cannot tell its own
+  damage from damage that was already there.
+* **No runnable suite:** proceed, say so in the ledger, and limit the pass to
+  changes a compiler, type checker, or linter can verify. Behavior preservation
+  is being asserted rather than demonstrated, and the ledger has to say which.
+
+Generated and vendored code is skipped and named in the ledger.
+
+## Checklist
+
+Load [`codebase-design`](../codebase-design/SKILL.md) for the vocabulary before
+starting — module, interface, depth, seam, adapter, deletion test — and use those
+words exactly. Load [`domain-modeling`](../domain-modeling/SKILL.md) when the repo
+has a `CONTEXT.md`, so renames land on the domain's own terms.
+
+Apply the list once per changed module, in this order. Each item names the
+[charter](../../../profile/CHARTER.md) rule that grounds it; a change with no rule
+behind it is taste, and taste is not in scope.
+
+1. **Naming and locality.** Names say what the thing is in the repo's own idiom;
+   related code sits together. *Rule: match the surrounding code.*
+2. **Dead code.** Unreferenced functions, unreachable branches, commented-out
+   blocks, and leftover scaffolding introduced by the diff go. *Rule: no dead
+   code, no speculative abstraction.*
+3. **Duplication.** Behavior the diff re-implements, where an existing module
+   already reaches it through its public interface at that call site, collapses
+   to the existing module. *Rule: reuse the module that already covers the
+   behavior.*
+4. **Shallow modules.** A module the diff introduced whose interface is about as
+   complex as its implementation is deepened or inlined. Apply the deletion test:
+   if removing it only moves complexity around, it should not exist. *Rule: deep
+   modules; the deletion test.*
+5. **Unearned guards.** A guard for a state that cannot occur is complexity, not
+   safety. Remove one **only** when the ledger names the enforced invariant that
+   makes the state unreachable — code that rejects it, or a pinned test.
+   Otherwise keep it. Guards at a trust boundary, and guards grounded by
+   acceptance criteria, security, or observed behavior, always stay. *Rule: earn
+   every guard.*
+6. **Speculative seams.** A seam with one caller is a hypothetical seam; collapse
+   it and build it again when the second caller is real. *Rule: one adapter is a
+   hypothetical seam, two is a real one.*
+
+## Invariants
+
+These bound every edit. A cleanup that cannot be made without breaking one of
+them is not made — it becomes a follow-up line.
+
+* **No behavior change.** Logic branches, error modes, and outputs are what they
+  were. Renaming a variable is in scope; changing what a condition decides is not.
+* **Nothing outside the diff.** Public interfaces of modules the diff did not
+  touch stay untouched, however tempting.
+* **No new dependencies**, and no scope expansion.
+* **Tests are not rewritten to pass.** A test that fails after a cleanup is the
+  cleanup being wrong. Revert the cleanup, keep the test.
+
+## Post-check
+
+Re-run the same test command.
+
+* **Green:** the pass holds; write the ledger.
+* **Red:** revert the cleaner's own edits — `git checkout` the files this pass
+  touched, never a reset of the branch, which would destroy the work the diff
+  came to clean — and report which change broke it, with the failing output.
+  Then stop.
+
+## Ledger
+
+The ledger is the final message. Nothing is written to the repo except the
+cleaned code itself: no plan file, no scratch directory, no report committed to
+the branch.
+
+It carries three things:
+
+* **Changes made** — per change: the file, what moved, and the charter rule that
+  grounded it. A guard removal names its enforced invariant here or it is not a
+  legitimate removal.
+* **Follow-ups** — what was noticed outside the diff, or inside it but blocked by
+  an invariant, listed for a human to route. Not fixed.
+* **Verification** — the test command, its result before, and its result after.
+  A reduced pass (no runnable suite, skipped generated code) says so here.
+
+## Not this skill
+
+* **Review verdicts** — [`review`](../../workflows/review/SKILL.md) routes those.
+  This skill edits; it does not grade.
+* **Writing tests** — [`tdd`](../tdd/SKILL.md).
+* **Mutation testing, coverage gates, and other deterministic hardening** — the
+  hardening step that runs after this one.

--- a/skills/tools/clean/agents/openai.yaml
+++ b/skills/tools/clean/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Clean"
+  short_description: "Clean a branch's diff in one pass without changing behavior, then report a ledger"


### PR DESCRIPTION
## What changed

The pack now owns a cleaner step. `/clean` makes one pass over a branch's diff, tidying only the code that branch changed while keeping behavior and the test suite exactly as they were. Until now the only cleaner available was the Anthropic-shipped `/simplify`, which Codex sessions cannot invoke.

- The pass is bounded on both ends: it pins a fixed point (merge-base by default, reusing `code-review`'s resolution rules by reference), runs the repo's own test command before and after, and ends in a ledger written to the final message rather than to the repo.
- Its checklist is fixed, and each item names the charter rule behind it: naming, dead code, duplication against a module that already covers the behavior, shallow modules failing the deletion test, unearned guards, and one-caller seams. A guard comes out only when the ledger names the enforced invariant that makes its state unreachable.
- A red post-check reverts the cleaner's own edits, never the branch, and stops with the failing output.

Not here: wiring `/clean` into `/ticket start`, which is #103, and the deterministic hardening tools that run after it.

Fixes #102

## Why

`/clean` is the "cleaner" step between the coder and deterministic hardening. It is the one judgment pass that survives replacing agent review rounds with tools, so the depth rules have to live in it. It changes code and emits no verdicts; that is what separates it from `/review`.

## What to check

The behavior-preservation invariant is the whole contract, because nothing reviews the cleaner before hardening runs. The checklist forbids touching logic branches, error modes, and interfaces outside the diff, and findings outside the diff become follow-up lines rather than edits.

## Verification

```text
python3 scripts/validate.py                    validated 27 skills and 267 files
python3 -m unittest <declared suites>          269 tests, OK (skipped=23)
python3 -m py_compile .../install.py           passed
```

Run under Python 3.14; the repo's declared command needs 3.10 or newer.

### Fixture check

Invoked `/clean` against a throwaway two-commit repo in the scratchpad whose branch introduced a one-line forwarding wrapper and a helper defined twice. The ledger it produced:

```text
Fixed point:  6165f73 (merge-base with main)
Scope:        shop/discounts.py, shop/invoices.py, tests/test_shop.py, .gitignore
Test command: python3 -m unittest discover -s tests   (from CLAUDE.md)

Changes
- shop/discounts.py — removed apply_discount_to_total, a one-line forward to
  apply_discount with a single caller; inlined at that caller.
  Rule: deep modules / the deletion test.
- shop/invoices.py — removed the second definition of round_cents; the call site
  now reaches shop.discounts.round_cents.
  Rule: reuse the module that already covers the behavior.

Follow-ups: none outside the diff.

Verification: 3 tests OK before, 3 tests OK after.
```

Net `2 insertions, 10 deletions`; no test was edited.

Post-merge, outside this repo: add `clean` to `PUBLISHED_SKILLS` in `dotfiles/install.sh`.

> Written by an AI agent. Verify before relying on it.
