### PR TITLE
feat(ticket): bind each worktree to its exact Codebase Memory project

### DIFF
--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -146,6 +146,38 @@ step is a slot:
   credentials, no access, no runnable suite), say so, open the pull request as a
   draft, and name the missing evidence.
 
+## The graph identity
+
+Before a verb reads code structurally, it binds its current checkout to exactly one
+Codebase Memory project, from that checkout's own path:
+
+```sh
+python3 <cbm-onboard-skill-directory>/scripts/cbm-lifecycle.py ensure <worktree path>
+```
+
+It prints one object, and the verb reports it verbatim:
+
+```json
+{"root_path": "<canonical physical checkout>", "project": "cbm-onboard-v1-<sha256>", "status": "ready"}
+```
+
+* `ready` or `indexed`: query the graph as exactly that `project`. Never choose one
+  by basename, branch, recency, list order, or because it was the only result.
+* `unavailable` (exit 2): no usable Codebase Memory here, so say so in one line and
+  use ordinary discovery for the rest of the session.
+* Any other failure (exit 1): stop at that boundary rather than reading a different
+  repository's graph.
+
+Every session recomputes this from the checkout it just verified, never from chat
+memory or a remembered earlier run. It names one machine's paths, so it never goes
+into a work order or any other tracker comment; a chunk agent is handed its own in
+its prompt.
+
+Before Git removes a worktree this skill authored, the same directory's
+`cbm-teardown.sh` deletes that checkout's project, while the checkout still exists
+for the identity to be derived from. A teardown failure is reported in one line and
+does not hold up the removal.
+
 ## Standing decisions
 
 A project may point this skill at a knowledge base of standing decisions and

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -166,9 +166,10 @@ It prints one object, and the verb reports it verbatim:
   it was the only result.
 * `unavailable` (exit 2): no usable Codebase Memory here, so say so in one line and
   use ordinary discovery for the rest of the session.
-* Any other failure (exit 1): stop the verb and report what `ensure` said. The tool
-  is installed and answered wrongly, which is the one case where continuing risks
-  reading another repository's graph.
+* Any other failure (exit 1): stop the verb and report what `ensure` printed on
+  stderr, which names the cause — a path that is not a checkout, or an installed
+  tool answering for the wrong project or root. Neither is a case where guessing a
+  graph is safe.
 
 Every session recomputes this from the checkout it just verified, never from chat
 memory or a remembered earlier run. It names one machine's paths, so it never goes

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -161,12 +161,14 @@ It prints one object, and the verb reports it verbatim:
 {"root_path": "<canonical physical checkout>", "project": "cbm-onboard-v1-<sha256>", "status": "ready"}
 ```
 
-* `ready` or `indexed`: query the graph as exactly that `project`. Never choose one
-  by basename, branch, recency, list order, or because it was the only result.
+* `ready` or `indexed`: query the graph as exactly that `project`. Never pick the
+  graph by project name, branch-like label, list order, apparent recency, or because
+  it was the only result.
 * `unavailable` (exit 2): no usable Codebase Memory here, so say so in one line and
   use ordinary discovery for the rest of the session.
-* Any other failure (exit 1): stop at that boundary rather than reading a different
-  repository's graph.
+* Any other failure (exit 1): stop the verb and report what `ensure` said. The tool
+  is installed and answered wrongly, which is the one case where continuing risks
+  reading another repository's graph.
 
 Every session recomputes this from the checkout it just verified, never from chat
 memory or a remembered earlier run. It names one machine's paths, so it never goes
@@ -175,8 +177,9 @@ its prompt.
 
 Before Git removes a worktree this skill authored, the same directory's
 `cbm-teardown.sh` deletes that checkout's project, while the checkout still exists
-for the identity to be derived from. A teardown failure is reported in one line and
-does not hold up the removal.
+for the identity to be derived from. Teardown fails loudly on a machine with no
+Codebase Memory installed, which is expected: report it in one line and carry on
+with the removal. It never holds up the removal, and it is never retried.
 
 ## Standing decisions
 

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -31,10 +31,14 @@ What follows is what this skill adds on top. It replaces `start` steps 8 through
    the ticket branch, because a serial chunk cut early misses the work it depends on.
 
 3. **Dispatch one agent per chunk** at the tier its `Agent:` line names, with the
-   working directory set to that chunk's worktree. The prompt is the sub-order fence
-   verbatim, plus the worktree path and the branch name. Nothing else: a sub-order
-   that needs coordinator commentary to be executable is a triage defect, and the fix
-   is to say so, not to patch it in the prompt.
+   working directory set to that chunk's worktree. Bind that chunk worktree's own
+   graph identity first, per the skill page's graph-identity rule. The prompt is the
+   sub-order fence verbatim, plus the worktree path, the branch name, and that
+   chunk's `root_path` and `project`, which the worker uses as given rather than
+   resolving its own. Nothing else: a sub-order that needs coordinator commentary to
+   be executable is a triage defect, and the fix is to say so, not to patch it in the
+   prompt. A chunk never receives the ticket worktree's identity or a sibling's, and
+   an `unavailable` result is passed on as such.
 
    `Surface lifecycle:` is part of that executable interface. Before dispatch,
    confirm every UI-affecting sub-order says `build` or `revise` and names the lock
@@ -74,8 +78,9 @@ What follows is what this skill adds on top. It replaces `start` steps 8 through
    with `--no-ff`. A conflict between two chunks that declared disjoint ownership
    means the slice was wrong: resolve it yourself only when it is mechanical, and say
    so in the report; anything else goes back to the user as a slicing defect. After a
-   chunk merges, remove its worktree and delete its branch
-   (`git -C <control checkout> worktree remove <path>` then
+   chunk merges, remove its worktree and delete its branch (run
+   `<cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <path>` while that checkout
+   still exists, then `git -C <control checkout> worktree remove <path>` and
    `git -C <control checkout> branch -D <chunk branch>`). Chunk branches are never
    pushed, so there is no remote branch to delete.
 

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -29,6 +29,7 @@ the code host back to the tracker; this verb is that sync.
    f. Tear the worktree and branch down:
 
    ```sh
+   <cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <worktree path>
    git -C <control checkout> worktree remove <worktree path>
    git -C <control checkout> branch -D <ticket branch>
    git -C <control checkout> worktree prune

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -15,10 +15,11 @@ long ago and the pull request is one diff.
    `git -C <control checkout> worktree list`), check it is on the pull request's
    head branch: `git -C <worktree> branch --show-current` must equal the pull
    request's `headRefName`. Match: work there. Mismatch: the worktree belongs to a
-   different round or ticket state, so remove it if clean
-   (`git -C <control checkout> worktree remove <path>`, reporting and stopping if
-   `git -C <worktree> status --short` is non-empty, never forcing) and respin fresh.
-   No worktree at all: same respin.
+   different round or ticket state, so remove it if clean (run
+   `<cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <path>` while the checkout
+   still exists, then `git -C <control checkout> worktree remove <path>`, reporting
+   and stopping if `git -C <worktree> status --short` is non-empty, never forcing)
+   and respin fresh. No worktree at all: same respin.
 
    ```sh
    python3 <spin-worktree-skill-directory>/scripts/spin-worktree.py \
@@ -28,6 +29,10 @@ long ago and the pull request is one diff.
    ```
 
    Never fix review comments in the control checkout.
+
+   Bind that worktree's graph identity per the skill page's graph-identity rule
+   before step 4 reads any code, and report what it printed. Each round resolves it
+   afresh, because the worktree it runs against may be the one this step respun.
 
 3. **Read the standing decisions**, per the skill page's standing-decisions slot,
    before actioning the round. Absent, say so in one line and continue. This never

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -34,7 +34,10 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    ([verbs/triage.md](triage.md), step 2). The helper refuses if the control
    checkout is dirty or the target path exists; surface that, and do not force it.
    Use the worktree path the helper printed as the working directory for every step
-   below. Move the ticket to in progress.
+   below. Move the ticket to in progress. Then bind that worktree's graph identity
+   per the skill page's graph-identity rule, before step 5 reads any code, and
+   report what it printed: a fresh session resolves this from the checkout it just
+   verified rather than inheriting triage's.
 
 5. **Sufficiency check.** From the ticket worktree, read the order against the
    actual repo. If the repo has drifted since triage (files moved, the constraint

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -50,6 +50,11 @@ scope and spec documents committed in that worktree.
    The helper still refuses an existing target path; surface that refusal to the
    user rather than forcing past it.
 
+   f. Bind that worktree's graph identity before grounding, per the skill page's
+   graph-identity rule, and report what it printed. A reused worktree gets the same
+   check: the identity is recomputed here every session, never remembered from the
+   run that cut it.
+
 3. **Identify the repo or repos.** From the ticket text, its parent, and its links.
    If the target repo does not exist yet, stop: repo scaffolding happens outside
    this skill. Post nothing, and tell the user which ticket has to land first.

--- a/skills/tools/cbm-onboard/SKILL.md
+++ b/skills/tools/cbm-onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cbm-onboard
-description: Register maintained or ephemeral Git checkouts with codebase-memory-mcp, keep long-lived indexes current through non-clobbering Git hooks, and tear down ephemeral indexes by exact deterministic identity. Use when asked to index, onboard, register, remove, or keep a repository current in Codebase Memory.
+description: Register maintained or ephemeral Git checkouts with codebase-memory-mcp, keep long-lived indexes current through non-clobbering Git hooks, and tear down ephemeral indexes by exact deterministic identity. Use when asked to index, onboard, register, remove, or keep a repository current in Codebase Memory, or to resolve which Codebase Memory project belongs to a checkout and make it ready.
 ---
 
 # Onboard a repository to Codebase Memory

--- a/skills/tools/cbm-onboard/SKILL.md
+++ b/skills/tools/cbm-onboard/SKILL.md
@@ -63,10 +63,31 @@ directory containing several repositories.
    removes hooks or worktrees. Both a successful deletion and an exact
    already-missing response are success, so teardown is safe to repeat.
 
-4. Verify the project through the available Codebase Memory MCP interface with
+4. For an automated workflow that must bind one checkout to its exact project
+   without touching that checkout, run:
+
+   ```sh
+   python3 <cbm-onboard-skill-directory>/scripts/cbm-lifecycle.py ensure <checkout-path>
+   ```
+
+   `ensure` is the machine interface: it resolves the supplied checkout as given,
+   canonicalizes it physically, derives the same deterministic name the rest of the
+   lifecycle uses, and makes exactly that project ready. It asks `index_status` for
+   the computed name only, indexes solely on the exact not-found response, and
+   re-asks `index_status` afterwards because `index_repository` does not echo the
+   root it indexed. It never chooses among `list_projects`, and it writes nothing to
+   the repository, its `.cbmignore`, its Git configuration, or its hooks.
+
+   It prints one object on success, `{"root_path", "project", "status"}`, where
+   status is `ready` for a project that was already indexed and `indexed` for one it
+   just built. A missing or too-old binary prints `{"status": "unavailable"}` and
+   exits 2, which is a visible degraded mode rather than permission to use some
+   other project. Every other failure exits 1 with nothing on stdout.
+
+5. Verify the project through the available Codebase Memory MCP interface with
    `index_status` or `list_projects`.
-5. Report node and edge counts when available.
-6. Tell the user that `.cbmignore` is tracked and should be committed. The Git
+6. Report node and edge counts when available.
+7. Tell the user that `.cbmignore` is tracked and should be committed. The Git
    hooks are clone-local, so rerun onboarding after a fresh clone.
 
 The initial index uses full mode. Maintained-checkout post-commit/post-merge/post-checkout

--- a/skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
+++ b/skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -14,6 +15,9 @@ from pathlib import Path
 
 MINIMUM_VERSION = (0, 10, 8)
 VERSION_PATTERN = re.compile(rb"codebase-memory-mcp (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\n?\Z")
+# The exact response Codebase Memory gives for a project it does not hold. Only
+# this signal permits indexing; anything else is a failure rather than a miss.
+MISSING_PROJECT_ERROR = "project not found or not indexed"
 
 
 def fail(message: str) -> "NoReturn":
@@ -21,7 +25,7 @@ def fail(message: str) -> "NoReturn":
     raise SystemExit(1)
 
 
-def identity(target: str, *, main_checkout: bool = False) -> None:
+def physical_identity(target: str, *, main_checkout: bool = False) -> tuple[str, str]:
     git_arguments = (
         ["worktree", "list", "--porcelain", "-z"]
         if main_checkout
@@ -54,34 +58,136 @@ def identity(target: str, *, main_checkout: bool = False) -> None:
     if b"\n" in root_bytes:
         fail("checkout paths containing newline bytes are unsupported")
     project = "cbm-onboard-v1-" + hashlib.sha256(root_bytes).hexdigest()
+    return root, project
+
+
+def identity(target: str, *, main_checkout: bool = False) -> None:
+    root, project = physical_identity(target, main_checkout=main_checkout)
     json.dump({"root": root, "project": project}, sys.stdout)
     sys.stdout.write("\n")
 
 
-def validate_version(path: str) -> None:
-    banner = Path(path).read_bytes()
+def parsed_version(banner: bytes) -> "tuple[int, ...] | None":
     match = VERSION_PATTERN.fullmatch(banner)
-    if not match:
+    return tuple(int(component) for component in match.groups()) if match else None
+
+
+def validate_version(path: str) -> None:
+    version = parsed_version(Path(path).read_bytes())
+    if version is None:
         fail("unsupported codebase-memory-mcp version banner")
-    version = tuple(int(component) for component in match.groups())
     if version < MINIMUM_VERSION:
         fail("codebase-memory-mcp 0.10.8 or newer is required")
 
 
+def read_envelope(raw: str) -> tuple[dict, object]:
+    """Split one Codebase Memory response into its structured body and error flag."""
+
+    try:
+        envelope = json.loads(raw)
+        structured = envelope["structuredContent"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        fail("invalid Codebase Memory JSON response")
+    if not isinstance(structured, dict):
+        fail("invalid Codebase Memory JSON response")
+    return structured, envelope.get("isError")
+
+
 def validate_response(project: str, status: str, is_error: str, path: str) -> None:
     try:
-        envelope = json.loads(Path(path).read_text(encoding="utf-8"))
-        structured = envelope["structuredContent"]
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError):
+        raw = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
         fail("invalid Codebase Memory JSON response")
-    expected_error = is_error == "true"
+    structured, reported_error = read_envelope(raw)
     if (
-        not isinstance(structured, dict)
-        or structured.get("project") != project
+        structured.get("project") != project
         or structured.get("status") != status
-        or envelope.get("isError") is not expected_error
+        or reported_error is not (is_error == "true")
     ):
         fail("Codebase Memory response did not match the requested project and status")
+
+
+def unavailable() -> "NoReturn":
+    """Report the one visible degraded mode: no usable Codebase Memory binary."""
+
+    json.dump({"status": "unavailable"}, sys.stdout)
+    sys.stdout.write("\n")
+    raise SystemExit(2)
+
+
+def usable_binary() -> str:
+    configured = os.environ.get("CODEBASE_MEMORY_BIN") or shutil.which("codebase-memory-mcp")
+    if not configured or not os.access(configured, os.X_OK):
+        unavailable()
+    banner = subprocess.run(
+        [configured, "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    version = parsed_version(banner.stdout) if banner.returncode == 0 else None
+    if version is None or version < MINIMUM_VERSION:
+        unavailable()
+    return configured
+
+
+def call_tool(binary: str, arguments: list[str]) -> tuple[int, str]:
+    result = subprocess.run(
+        [binary, "cli", "--json", *arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode, result.stdout.decode("utf-8", "replace")
+
+
+def ready_for(structured: dict, reported_error: object, project: str, root: str) -> bool:
+    return (
+        reported_error is False
+        and structured.get("project") == project
+        and structured.get("status") == "ready"
+        and structured.get("root_path") == root
+    )
+
+
+def ensure(target: str) -> None:
+    """Make the exact project for one physical checkout ready, and name it."""
+
+    binary = usable_binary()
+    root, project = physical_identity(target)
+
+    code, raw = call_tool(binary, ["index_status", "--project", project])
+    structured, reported_error = read_envelope(raw)
+    if code == 0:
+        if not ready_for(structured, reported_error, project, root):
+            fail(f"Codebase Memory did not report {project} ready for {root}")
+        json.dump({"root_path": root, "project": project, "status": "ready"}, sys.stdout)
+        sys.stdout.write("\n")
+        return
+    if code != 1 or reported_error is not True or structured.get("error") != MISSING_PROJECT_ERROR:
+        fail(f"Codebase Memory index_status failed for {project}")
+
+    code, raw = call_tool(
+        binary,
+        ["index_repository", "--repo-path", root, "--mode", "full", "--name", project],
+    )
+    structured, reported_error = read_envelope(raw)
+    if (
+        code != 0
+        or reported_error is not False
+        or structured.get("project") != project
+        or structured.get("status") != "indexed"
+    ):
+        fail(f"Codebase Memory failed to index {root} as {project}")
+
+    # index_repository never echoes the root it indexed, so the binding is only
+    # proven by asking for the project's own root afterwards.
+    code, raw = call_tool(binary, ["index_status", "--project", project])
+    structured, reported_error = read_envelope(raw)
+    if code != 0 or not ready_for(structured, reported_error, project, root):
+        fail(f"Codebase Memory did not report {project} ready for {root} after indexing")
+    json.dump({"root_path": root, "project": project, "status": "indexed"}, sys.stdout)
+    sys.stdout.write("\n")
 
 
 def main() -> None:
@@ -91,13 +197,19 @@ def main() -> None:
     if len(sys.argv) == 4 and sys.argv[1:3] == ["identity", "--main"]:
         identity(sys.argv[3], main_checkout=True)
         return
+    if len(sys.argv) == 3 and sys.argv[1] == "ensure":
+        ensure(sys.argv[2])
+        return
     if len(sys.argv) == 3 and sys.argv[1] == "version":
         validate_version(sys.argv[2])
         return
     if len(sys.argv) == 6 and sys.argv[1] == "response":
         validate_response(*sys.argv[2:])
         return
-    fail("usage: cbm-lifecycle.py identity [--main] PATH | version FILE | response PROJECT STATUS BOOL FILE")
+    fail(
+        "usage: cbm-lifecycle.py identity [--main] PATH | ensure PATH"
+        " | version FILE | response PROJECT STATUS BOOL FILE"
+    )
 
 
 if __name__ == "__main__":

--- a/skills/tools/codebase-memory/reminder.md
+++ b/skills/tools/codebase-memory/reminder.md
@@ -2,13 +2,24 @@ Managed by codebase-memory skill installer.
 
 # Code discovery policy
 
-Use codebase-memory-mcp graph tools first for structural code exploration only
-when `list_projects` and `index_status` show that the exact project is indexed.
-Use `search_graph` to find symbols, `trace_path` for callers and callees,
-`get_code_snippet` for exact source, `query_graph` for multi-hop questions, and
-`get_architecture` for orientation. Use `search_code` or ordinary search and
-file reads for literal text, configuration, non-code files, and unindexed
-projects.
+Use codebase-memory-mcp graph tools first for structural code exploration, against
+exactly one project: the one that belongs to the checkout you are working in.
+
+Establish that project before querying. When a workflow supplies a `project` for
+the checkout it verified, use exactly that name as given. Otherwise resolve the
+canonical current checkout through the supported structured interface,
+`python3 <cbm-onboard-skill-directory>/scripts/cbm-lifecycle.py ensure <checkout
+path>`, and use the `project` it prints. Never pick the graph by project name,
+branch-like label, list order, apparent recency, or because it was the only result;
+`list_projects` is an inventory, not a way to choose the current checkout. A
+reported `unavailable`, or no usable interface at all, means ordinary search and
+file reads for the rest of the session.
+
+With that project established, use `search_graph` to find symbols, `trace_path` for
+callers and callees, `get_code_snippet` for exact source, `query_graph` for
+multi-hop questions, and `get_architecture` for orientation. Use `search_code` or
+ordinary search and file reads for literal text, configuration, non-code files, and
+unindexed projects.
 
 Activating this skill never indexes a project. Run `index_repository` only when
 indexing is explicitly requested or required by the target repository.

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -24,6 +24,7 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 CBM_SCRIPT = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-onboard.sh"
 CBM_TEARDOWN = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-teardown.sh"
+CBM_LIFECYCLE = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-lifecycle.py"
 SPIN_SCRIPT = ROOT / "skills" / "tools" / "spin-worktree" / "scripts" / "spin-worktree.py"
 CODEX_WORKER = ROOT / "skills" / "drivers" / "orchestrate" / "scripts" / "codex-worker.py"
 UI_CRAFT_AUDIT = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "audit.md"
@@ -52,6 +53,230 @@ def run(
         stderr=subprocess.PIPE,
         check=False,
     )
+
+
+class CbmEnsureTests(unittest.TestCase):
+    """The machine interface a workflow uses to bind one checkout to one project."""
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.scratch = Path(self.temporary.name)
+        self.repo = self.scratch / "repo"
+        self.repo.mkdir()
+        self.assertEqual(run(["git", "init", "-b", "main"], cwd=self.repo).returncode, 0)
+        (self.repo / "module.py").write_text("def hello():\n    return 1\n", encoding="utf-8")
+        self.requests = self.scratch / "requests.jsonl"
+        self.indexed = self.scratch / "indexed"
+        self.binary = self.scratch / "codebase-memory-mcp"
+        self.binary.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+if sys.argv[1:] == ["--version"]:
+    print(os.environ.get("CBM_FAKE_VERSION", "codebase-memory-mcp 0.10.8"))
+    raise SystemExit(0)
+
+with open(os.environ["CBM_FAKE_REQUESTS"], "a", encoding="utf-8") as handle:
+    handle.write(json.dumps(sys.argv[1:]) + "\\n")
+
+indexed = os.environ["CBM_FAKE_INDEXED"]
+if os.environ.get("CBM_FAKE_MALFORMED") == "1":
+    print("not json")
+    raise SystemExit(0)
+
+if "index_repository" in sys.argv:
+    if os.environ.get("CBM_FAKE_RECHECK_MISSING") != "1":
+        open(indexed, "w", encoding="utf-8").close()
+    print(json.dumps({
+        "structuredContent": {
+            "project": sys.argv[sys.argv.index("--name") + 1],
+            "status": "indexed",
+        },
+        "isError": False,
+    }))
+    raise SystemExit(0)
+
+if "index_status" in sys.argv:
+    project = sys.argv[sys.argv.index("--project") + 1]
+    if not os.path.exists(indexed):
+        print(json.dumps({
+            "structuredContent": {"error": "project not found or not indexed"},
+            "isError": True,
+        }))
+        raise SystemExit(1)
+    print(json.dumps({
+        "structuredContent": {
+            "project": os.environ.get("CBM_FAKE_PROJECT", project),
+            "status": os.environ.get("CBM_FAKE_STATUS", "ready"),
+            "root_path": os.environ.get("CBM_FAKE_ROOT", os.environ["CBM_FAKE_REAL_ROOT"]),
+        },
+        "isError": False,
+    }))
+    raise SystemExit(0)
+
+raise SystemExit(9)
+""",
+            encoding="utf-8",
+        )
+        self.binary.chmod(0o755)
+        self.environment = os.environ.copy()
+        self.environment["CODEBASE_MEMORY_BIN"] = str(self.binary)
+        self.environment["CBM_FAKE_REQUESTS"] = str(self.requests)
+        self.environment["CBM_FAKE_INDEXED"] = str(self.indexed)
+        self.environment["CBM_FAKE_REAL_ROOT"] = str(self.repo.resolve())
+        self.environment["GIT_CONFIG_GLOBAL"] = os.devnull
+        self.environment["GIT_CONFIG_SYSTEM"] = os.devnull
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def ensure(self, target=None):
+        return run(
+            ["python3", str(CBM_LIFECYCLE), "ensure", str(target or self.repo)],
+            cwd=ROOT,
+            env=self.environment,
+        )
+
+    def project_for(self, checkout: Path) -> str:
+        return "cbm-onboard-v1-" + hashlib.sha256(os.fsencode(checkout.resolve())).hexdigest()
+
+    def issued(self) -> list[list[str]]:
+        if not self.requests.exists():
+            return []
+        return [json.loads(line) for line in self.requests.read_text(encoding="utf-8").splitlines()]
+
+    def test_a_missing_project_is_indexed_under_its_own_name_and_rechecked(self):
+        result = self.ensure()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        project = self.project_for(self.repo)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {"root_path": str(self.repo.resolve()), "project": project, "status": "indexed"},
+        )
+        self.assertEqual(
+            self.issued(),
+            [
+                ["cli", "--json", "index_status", "--project", project],
+                [
+                    "cli",
+                    "--json",
+                    "index_repository",
+                    "--repo-path",
+                    str(self.repo.resolve()),
+                    "--mode",
+                    "full",
+                    "--name",
+                    project,
+                ],
+                ["cli", "--json", "index_status", "--project", project],
+            ],
+        )
+
+    def test_an_existing_project_is_reported_ready_without_reindexing(self):
+        self.indexed.touch()
+
+        result = self.ensure()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["status"], "ready")
+        self.assertEqual(
+            self.issued(),
+            [["cli", "--json", "index_status", "--project", self.project_for(self.repo)]],
+        )
+
+    def test_the_checkout_its_git_configuration_and_hooks_are_left_alone(self):
+        hook = self.repo / ".git" / "hooks" / "post-commit"
+        hook.write_bytes(b"#!/bin/sh\nprintf 'sentinel\\n'\n")
+        before = {
+            "tracked": run(["git", "status", "--porcelain"], cwd=self.repo).stdout,
+            "config": (self.repo / ".git" / "config").read_bytes(),
+            "hook": hook.read_bytes(),
+        }
+
+        self.assertEqual(self.ensure().returncode, 0)
+
+        self.assertFalse((self.repo / ".cbmignore").exists())
+        self.assertEqual(run(["git", "status", "--porcelain"], cwd=self.repo).stdout, before["tracked"])
+        self.assertEqual((self.repo / ".git" / "config").read_bytes(), before["config"])
+        self.assertEqual(hook.read_bytes(), before["hook"])
+
+    def test_identity_is_physical_and_per_checkout_never_chosen_from_an_inventory(self):
+        run(["git", "config", "user.name", "Test User"], cwd=self.repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=self.repo)
+        run(["git", "add", "module.py"], cwd=self.repo)
+        self.assertEqual(run(["git", "commit", "-m", "fixture"], cwd=self.repo).returncode, 0)
+        worktree = self.scratch / "linked"
+        self.assertEqual(
+            run(["git", "worktree", "add", "-b", "fixture", str(worktree)], cwd=self.repo).returncode,
+            0,
+        )
+        spelling = self.scratch / "spelled"
+        spelling.symlink_to(self.repo)
+        self.indexed.touch()
+
+        projects = []
+        for target, root in ((self.repo, self.repo), (spelling, self.repo), (worktree, worktree)):
+            self.environment["CBM_FAKE_REAL_ROOT"] = str(root.resolve())
+            result = self.ensure(target)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            projects.append(json.loads(result.stdout)["project"])
+
+        self.assertEqual(projects[0], projects[1])
+        self.assertNotEqual(projects[0], projects[2])
+        self.assertEqual(projects[2], self.project_for(worktree))
+        self.assertNotIn("list_projects", json.dumps(self.issued()))
+
+    def test_a_missing_or_too_old_binary_is_one_visible_unavailable_outcome(self):
+        for label, override in (
+            ("missing", {"CODEBASE_MEMORY_BIN": str(self.scratch / "absent")}),
+            ("too old", {"CBM_FAKE_VERSION": "codebase-memory-mcp 0.10.7"}),
+            ("unparseable", {"CBM_FAKE_VERSION": "some other tool 1.0"}),
+        ):
+            with self.subTest(label):
+                self.environment.update(override)
+                result = self.ensure()
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertEqual(json.loads(result.stdout), {"status": "unavailable"})
+                self.environment["CODEBASE_MEMORY_BIN"] = str(self.binary)
+                self.environment.pop("CBM_FAKE_VERSION", None)
+
+    def test_a_response_for_another_project_root_or_state_stops_the_binding(self):
+        self.indexed.touch()
+        for label, override in (
+            ("another project", {"CBM_FAKE_PROJECT": "cbm-onboard-v1-somebody-else"}),
+            ("another root", {"CBM_FAKE_ROOT": str(self.scratch / "elsewhere")}),
+            ("not ready", {"CBM_FAKE_STATUS": "indexing"}),
+            ("malformed", {"CBM_FAKE_MALFORMED": "1"}),
+        ):
+            with self.subTest(label):
+                self.environment.update(override)
+                result = self.ensure()
+                self.assertEqual(result.returncode, 1, result.stdout)
+                self.assertEqual(result.stdout, "")
+                self.assertNotIn("index_repository", json.dumps(self.issued()))
+                self.assertNotIn("delete_project", json.dumps(self.issued()))
+                for key in override:
+                    self.environment.pop(key)
+
+    def test_an_index_that_cannot_be_confirmed_at_the_requested_root_fails(self):
+        self.environment["CBM_FAKE_RECHECK_MISSING"] = "1"
+
+        result = self.ensure()
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("after indexing", result.stderr)
+        self.assertEqual([request[2] for request in self.issued()], ["index_status", "index_repository", "index_status"])
+
+    def test_a_path_that_is_not_a_checkout_is_refused_before_any_tool_call(self):
+        result = self.ensure(self.scratch / "not-a-repo")
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(self.issued(), [])
 
 
 class CbmOnboardTests(unittest.TestCase):

--- a/tests/test_codebase_memory_install.py
+++ b/tests/test_codebase_memory_install.py
@@ -481,7 +481,7 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
 
         normalized_reminder = " ".join(reminder.split())
         for phrase in (
-            "exact project is indexed",
+            "against exactly one project",
             "configuration, non-code files, and unindexed projects",
             "Activating this skill never indexes a project",
         ):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 import unittest
@@ -186,6 +187,84 @@ class TicketSkillContractTests(unittest.TestCase):
             "[reference/web-implementation.md](reference/web-implementation.md)",
             ui_craft,
         )
+
+    def test_every_verb_binds_its_own_checkout_graph_before_it_reads_code(self):
+        shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
+        start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")
+        revise = (TICKET_DIRECTORY / "verbs" / "revise.md").read_text(encoding="utf-8")
+        rule = shared.split("## The graph identity", 1)[1].split("## Standing decisions", 1)[0]
+
+        self.assertIn("cbm-lifecycle.py ensure", rule)
+        for state in ("`ready`", "`indexed`", "`unavailable`"):
+            self.assertIn(state, rule)
+        normalized = " ".join(rule.lower().split())
+        for guess in ("basename", "branch", "recency", "list order", "only result"):
+            self.assertIn(guess, normalized)
+        self.assertIn("recomputes", normalized)
+        self.assertIn("ordinary discovery", normalized)
+
+        for page, worktree, code in (
+            (triage, "Cut or reuse the worktree", "5. **Ground.**"),
+            (start, "Worktree and branch", "Sufficiency check"),
+            (revise, "2. **Worktree.**", "4. **Collect the round.**"),
+        ):
+            binding = page.index("graph-identity rule")
+            self.assertLess(page.index(worktree), binding)
+            self.assertLess(binding, page.index(code))
+
+    def test_the_graph_identity_never_travels_in_a_tracker_artifact(self):
+        shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("never goes into a work order", " ".join(shared.split()))
+        for machine_local in ("cbm-onboard-v1-", "root_path", "cbm-lifecycle.py"):
+            self.assertNotIn(machine_local, template)
+
+    def test_a_chunk_agent_is_handed_its_own_graph_identity_and_no_other(self):
+        coordinator = (
+            TICKET_DIRECTORY / "references" / "coordinator-mode.md"
+        ).read_text(encoding="utf-8")
+        dispatch = coordinator.split("3. **Dispatch one agent per chunk", 1)[1].split(
+            "\n4. **", 1
+        )[0]
+
+        self.assertIn("graph-identity rule", dispatch)
+        self.assertIn("`root_path`", dispatch)
+        self.assertIn("`project`", dispatch)
+        normalized = " ".join(dispatch.lower().split())
+        self.assertIn("uses as given", normalized)
+        self.assertIn("never receives the ticket worktree's identity or a sibling's", normalized)
+
+    def test_every_ticket_authored_worktree_removal_tears_the_graph_down_first(self):
+        pages = {
+            name: (TICKET_DIRECTORY / relative).read_text(encoding="utf-8")
+            for name, relative in (
+                ("revise", Path("verbs") / "revise.md"),
+                ("finalize", Path("verbs") / "finalize.md"),
+                ("coordinator", Path("references") / "coordinator-mode.md"),
+            )
+        }
+
+        for name, page in pages.items():
+            removals = [match.start() for match in re.finditer(r"worktree remove", page)]
+            self.assertTrue(removals, name)
+            for removal in removals:
+                self.assertIn("cbm-teardown.sh", page[max(0, removal - 400) : removal], name)
+
+    def test_discovery_uses_a_supplied_project_and_otherwise_resolves_the_checkout(self):
+        reminder = (
+            ROOT / "skills" / "tools" / "codebase-memory" / "reminder.md"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(reminder.split())
+
+        self.assertIn("use exactly that name as given", normalized)
+        self.assertIn("cbm-lifecycle.py ensure", normalized)
+        self.assertIn("Activating this skill never indexes a project.", normalized)
+        for guess in ("branch-like label", "list order", "apparent recency", "only result"):
+            self.assertIn(guess, normalized)
 
     def test_start_opens_with_summary_and_claim_before_fetching_the_order(self):
         shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -13,6 +13,17 @@ from typing import Optional
 ROOT = Path(__file__).resolve().parents[1]
 TICKET_SCRIPT = ROOT / "skills" / "drivers" / "ticket" / "scripts" / "ticket.py"
 TICKET_DIRECTORY = ROOT / "skills" / "drivers" / "ticket"
+DISCOVERY_POLICY = ROOT / "skills" / "tools" / "codebase-memory" / "reminder.md"
+# Both installed artifacts state this rule independently, because an agent may hold
+# either one without the other. Pinning one vocabulary is what keeps them from
+# drifting into two different rules.
+GRAPH_SELECTION_TRAPS = (
+    "project name",
+    "branch-like label",
+    "list order",
+    "apparent recency",
+    "only result",
+)
 
 
 def run(command: list[str], *, cwd: Path, env: Optional[dict[str, str]] = None):
@@ -199,8 +210,8 @@ class TicketSkillContractTests(unittest.TestCase):
         for state in ("`ready`", "`indexed`", "`unavailable`"):
             self.assertIn(state, rule)
         normalized = " ".join(rule.lower().split())
-        for guess in ("basename", "branch", "recency", "list order", "only result"):
-            self.assertIn(guess, normalized)
+        for trap in GRAPH_SELECTION_TRAPS:
+            self.assertIn(trap, normalized)
         self.assertIn("recomputes", normalized)
         self.assertIn("ordinary discovery", normalized)
 
@@ -255,16 +266,41 @@ class TicketSkillContractTests(unittest.TestCase):
                 self.assertIn("cbm-teardown.sh", page[max(0, removal - 400) : removal], name)
 
     def test_discovery_uses_a_supplied_project_and_otherwise_resolves_the_checkout(self):
-        reminder = (
-            ROOT / "skills" / "tools" / "codebase-memory" / "reminder.md"
-        ).read_text(encoding="utf-8")
+        reminder = DISCOVERY_POLICY.read_text(encoding="utf-8")
         normalized = " ".join(reminder.split())
 
         self.assertIn("use exactly that name as given", normalized)
         self.assertIn("cbm-lifecycle.py ensure", normalized)
         self.assertIn("Activating this skill never indexes a project.", normalized)
-        for guess in ("branch-like label", "list order", "apparent recency", "only result"):
-            self.assertIn(guess, normalized)
+        for trap in GRAPH_SELECTION_TRAPS:
+            self.assertIn(trap, normalized.lower())
+
+    def test_a_failed_graph_teardown_is_said_once_and_never_stops_the_removal(self):
+        shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
+        rule = " ".join(
+            shared.split("## The graph identity", 1)[1]
+            .split("## Standing decisions", 1)[0]
+            .split()
+        )
+        pages = [
+            (TICKET_DIRECTORY / relative).read_text(encoding="utf-8")
+            for relative in (
+                Path("verbs") / "revise.md",
+                Path("verbs") / "finalize.md",
+                Path("references") / "coordinator-mode.md",
+            )
+        ]
+
+        self.assertIn("report it in one line and carry on with the removal", rule)
+        self.assertIn("never holds up the removal", rule)
+        self.assertIn("never retried", rule)
+        self.assertIn("no Codebase Memory installed", rule)
+        # One authority for the disposition; the call sites carry only the command,
+        # so a teardown that fails cannot be handled two ways in one lifecycle.
+        self.assertEqual(
+            sum(page.count("holds up the removal") for page in pages) + rule.count("holds up the removal"),
+            1,
+        )
 
     def test_start_opens_with_summary_and_claim_before_fetching_the_order(self):
         shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

Every `/ticket` session now establishes one deterministic Codebase Memory identity for the checkout it just verified, and queries that project alone. Until now no ticket page established a graph at all, so an agent picked from whatever `list_projects` happened to return: the maintained checkout, a stale worktree project, or no match.

* `cbm-onboard` gains `ensure`, a machine interface that derives the project name from a checkout's canonical physical path, asks for that name alone, indexes only on the exact not-found response, and re-asks afterwards because `index_repository` never echoes the root it indexed. It writes nothing to the checkout, its `.cbmignore`, its Git configuration, or its hooks.
* Triage, start, and revise each bind their own worktree before reading code, and a chunk agent is handed its own `root_path` and `project` rather than the ticket worktree's. The identity names one machine's paths, so it stays out of work orders and every other tracker comment.
* Every worktree removal this skill authors now runs the existing `cbm-teardown.sh` first, while the checkout still exists to derive the name from. Teardown exits nonzero on a machine with no Codebase Memory installed, which is said once before the removal proceeds.
* No usable binary yields one `unavailable` outcome and ordinary discovery for the rest of the session.

The argv and response shapes `ensure` depends on came from spiking the installed 0.10.8 CLI, and are pinned in the tests rather than in a fixture system.

Fixes #90

## Why

The scope, its boundaries, and what was deliberately cut from it are in the work order comment on the issue.

## What to check

The identity is derived, never chosen. Two installed artifacts state the anti-guessing rule (the ticket skill's graph-identity section and the discovery policy the codebase-memory installer ships), and they now carry one vocabulary pinned by a single list in the tests, so rewording either copy fails a test.

The work order forbids `docs/adr/adr-90-*.md`, so this change is recorded in its commit messages and here rather than as a decision record.

## Verification

```text
python3 scripts/validate.py               validated 27 skills and 267 files
python3 -m unittest <declared suites>     283 tests, OK (skipped=23)
python3 -m py_compile <declared files>    passed
```

Run under Python 3.14; the repo's declared command needs 3.10 or newer. The branch is rebased on `main` rather than merged, because the DCO gate walks every commit in the range and a GitHub `Update branch` merge commit carries no sign-off.

Against the installed 0.10.8 CLI, on throwaway repos in a scratchpad: the first `ensure` returned `indexed`, repeats returned `ready`, a symlinked spelling returned the same project, the checkout gained no `.cbmignore` and no hooks, and a missing binary returned `{"status": "unavailable"}` at exit 2. Those projects were deleted afterwards.

That live check covers `ensure` only. No ticket verb has run against a live worktree through the amended pages; those changes are prose pinned by contract tests, not executed.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
