### PR TITLE
feat(ticket): opt-in hardening profile for /ticket

### DIFF
--- a/docs/scope/ticket-hardening-profile.md
+++ b/docs/scope/ticket-hardening-profile.md
@@ -1,0 +1,36 @@
+# Scope: /ticket hardening profile (issue 103)
+
+Opt-in `/ticket` profile that replaces agent review rounds with a deterministic
+hardening command plus a human QA script.
+
+## Decisions
+
+_(appended as each settles)_
+
+## Open questions
+
+- Q1 sequencing against `/clean` (issue 102)
+- Q2 profile selection mechanism
+- Q3 target repo with no `Harden:` declaration
+- Q4 stop condition for the hardening loop
+- Q5 QA script: every order or profile-only
+- Q6 disposition of open siblings 89, 92, 94, 95
+
+## Grounding (verified this session)
+
+- No profile mechanism exists in `skills/drivers/ticket/` today; `Review depth:`
+  and `Surface lifecycle:` are the only per-order switches.
+- `/clean` does not exist in the pack; issue 102 is open and unbuilt.
+- This repo declares no `Harden:` line; it is a markdown pack with a Python
+  validator and unittest suite.
+- `profile:` and `ui-surfaces:` in `AGENTS.md` are declared but consumed by no
+  code in this repo, so a repo-facts declaration line has precedent.
+- ADR 97 keeps the current `/ticket` workflow authoritative and defers adapters
+  until a compatibility spike; issue 103 stays inside that boundary by using a
+  raw command line instead of adapters.
+- Issues 87, 88, 91, 93, 96 are already closed; 89, 92, 94, 95 are open and
+  overlap issue 103's substance.
+
+## Spawned tasks
+
+_(none yet)_

--- a/docs/scope/ticket-hardening-profile.md
+++ b/docs/scope/ticket-hardening-profile.md
@@ -45,7 +45,7 @@ _(none)_
 
 - No profile mechanism exists in `skills/drivers/ticket/` today; `Review depth:`
   and `Surface lifecycle:` are the only per-order switches.
-- `/clean` landed as #104 (skills/tools/clean).
+- `/clean` now exists (#104, `skills/tools/clean`).
 - This repo declares no `Harden:` line; it is a markdown pack with a Python
   validator and unittest suite.
 - `profile:` and `ui-surfaces:` in `AGENTS.md` are declared but consumed by no
@@ -53,7 +53,8 @@ _(none)_
 - ADR 97 keeps the current `/ticket` workflow authoritative and defers adapters
   until a compatibility spike; issue 103 stays inside that boundary by using a
   raw command line instead of adapters.
-- Issues 87, 88, 89, 91, 92, 93, 94, 95, 96 are all closed.
+- Siblings 89, 92, 94, and 95 are closed; issues 87, 88, 91, 93, and 96 are
+  also closed.
 
 ## Review ledger
 

--- a/docs/scope/ticket-hardening-profile.md
+++ b/docs/scope/ticket-hardening-profile.md
@@ -16,6 +16,11 @@ hardening command plus a human QA script.
   the residue named. Why: mirrors the two-review-round cap. inline
 - Q5 QA script: profile orders only. Why: it replaces the review round; the
   default template and its tests stay unchanged. inline
+- Q7 Chunked orders: profile is flat-only; triage stamps `Profile: none` on any
+  sliced order. Why: coordinator-mode has its own review path; no consumer for
+  a hardening branch there yet. inline
+- Q8 Plan-review at triage runs only on Full-depth profile orders (ticket change 3);
+  default-workflow orders keep the unconditional review. inline
 - Q1 Sequencing: `/clean` landed as #104; no dependency remains. inline
 - Q6 Siblings 89, 92, 94, 95 are closed; nothing to dispose. inline
 
@@ -27,7 +32,7 @@ hardening command plus a human QA script.
 - Accepted failure: hardening cap reached → draft PR naming residue, manual follow-up.
 - Unsupported: repos without a `Harden:` line (they get the default workflow).
 - Evidence owed: tests pinning that triage, start, revise, and the template carry
-  the profile contract (`Profile: hardening`, `Harden:`, `QA script:`, cap of 3,
+  the profile contract (`Profile: hardening`, `Harden:`, `QA script` section, cap of 3,
   error-not-pass).
 - Why: documentation-only change in a markdown pack; the failure surface is a
   misread rule, not runtime damage. Disposition: inline.
@@ -40,7 +45,7 @@ _(none)_
 
 - No profile mechanism exists in `skills/drivers/ticket/` today; `Review depth:`
   and `Surface lifecycle:` are the only per-order switches.
-- `/clean` does not exist in the pack; issue 102 is open and unbuilt.
+- `/clean` landed as #104 (skills/tools/clean).
 - This repo declares no `Harden:` line; it is a markdown pack with a Python
   validator and unittest suite.
 - `profile:` and `ui-surfaces:` in `AGENTS.md` are declared but consumed by no
@@ -48,8 +53,12 @@ _(none)_
 - ADR 97 keeps the current `/ticket` workflow authoritative and defers adapters
   until a compatibility spike; issue 103 stays inside that boundary by using a
   raw command line instead of adapters.
-- Issues 87, 88, 91, 93, 96 are already closed; 89, 92, 94, 95 are open and
-  overlap issue 103's substance.
+- Issues 87, 88, 89, 91, 92, 93, 94, 95, 96 are all closed.
+
+## Review ledger
+
+- Panel 1: 3 blockers (plan-review exemption unstated; legacy test not fail-first;
+  chunked Profile: unconsumed), all `authoring`; 3 notes. Fixed in draft.
 
 ## Spawned tasks
 

--- a/docs/scope/ticket-hardening-profile.md
+++ b/docs/scope/ticket-hardening-profile.md
@@ -5,16 +5,36 @@ hardening command plus a human QA script.
 
 ## Decisions
 
-_(appended as each settles)_
+- Q2 Profile selection: a `Profile: hardening` line in the work order fence,
+  stamped by triage. Why: start already parses fence lines; the default workflow
+  stays untouched. inline
+- Q3 No `Harden:` line in the target repo: triage refuses to stamp the profile and
+  posts a default-workflow order, saying so. Why: triage-time fact, cheaper than a
+  draft PR. inline
+- Q4 Hardening loop stop: `Harden:` exits 0 and every survivor is killed or listed
+  as equivalent in the PR body; cap of 3 passes, then the PR opens as draft with
+  the residue named. Why: mirrors the two-review-round cap. inline
+- Q5 QA script: profile orders only. Why: it replaces the review round; the
+  default template and its tests stay unchanged. inline
+- Q1 Sequencing: `/clean` landed as #104; no dependency remains. inline
+- Q6 Siblings 89, 92, 94, 95 are closed; nothing to dispose. inline
+
+### Risk contract
+
+- Must prevent: silent incorrect success (a `Harden:` that cannot run reported as
+  pass); secret exposure; irreversible loss of authoritative data.
+- Must recover: none.
+- Accepted failure: hardening cap reached → draft PR naming residue, manual follow-up.
+- Unsupported: repos without a `Harden:` line (they get the default workflow).
+- Evidence owed: tests pinning that triage, start, revise, and the template carry
+  the profile contract (`Profile: hardening`, `Harden:`, `QA script:`, cap of 3,
+  error-not-pass).
+- Why: documentation-only change in a markdown pack; the failure surface is a
+  misread rule, not runtime damage. Disposition: inline.
 
 ## Open questions
 
-- Q1 sequencing against `/clean` (issue 102)
-- Q2 profile selection mechanism
-- Q3 target repo with no `Harden:` declaration
-- Q4 stop condition for the hardening loop
-- Q5 QA script: every order or profile-only
-- Q6 disposition of open siblings 89, 92, 94, 95
+_(none)_
 
 ## Grounding (verified this session)
 

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -27,7 +27,8 @@ four.
   none, implements it on a branch in an isolated worktree (or, on a sliced order,
   coordinates one agent per chunk), iterates the verification step until the
   result matches the order's expectation, passes an adversarial review at the
-  order's stamped depth ([references/review-depth.md](references/review-depth.md)),
+  order's stamped depth ([references/review-depth.md](references/review-depth.md))
+  unless `Profile: hardening` replaces it below Full depth,
   opens the pull request, and stops. Agents never merge.
 * `revise` actions one review round on the open pull request: reload the ticket
   and the order, fix, re-verify, push.
@@ -52,7 +53,9 @@ directly. A verb that cannot reach the contract stops and names what is missing.
 
 `start` and `revise` reach code review as `/review` on the changed code, which
 routes to `code-review`. Neither verb calls a reviewer any other way, and neither
-substitutes a lighter check for the depth the order stamped.
+substitutes a lighter check for the depth the order stamped. Below Full depth under
+`Profile: hardening`, [start](verbs/start.md) and [revise](verbs/revise.md) use its
+exception instead.
 
 ## Shared rules (every verb)
 
@@ -181,6 +184,14 @@ Before Git removes a worktree this skill authored, the same directory's
 for the identity to be derived from. Teardown fails loudly on a machine with no
 Codebase Memory installed, which is expected: report it in one line and carry on
 with the removal. It never holds up the removal, and it is never retried.
+
+## The hardening profile
+
+The target repo declares `Harden: <command>` beside its test command in repo facts.
+Triage stamps `Profile: hardening` only when that line exists.
+It replaces the review rounds as [start](verbs/start.md) and [revise](verbs/revise.md) specify.
+A hardening command that cannot run is an error, never a pass.
+The profile order's QA script lives in its pull request body.
 
 ## Standing decisions
 

--- a/skills/drivers/ticket/references/review-depth.md
+++ b/skills/drivers/ticket/references/review-depth.md
@@ -49,6 +49,9 @@ contract; reviewer taste is not.
 
 ## Who reviews
 
+Under `Profile: hardening`, Targeted and Focused orders get no reviewer; Full-depth
+orders keep one review round after hardening.
+
 * Reviewer tier matches the chunk's builder tier, with Sonnet as the floor: Haiku
   never reviews, so a Haiku chunk is reviewed by Sonnet.
 * A Full-depth or correctness-critical review escalates per

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -29,6 +29,12 @@ chunks say `none`); each sub-order names its own route so the fence remains
 executable without coordinator commentary. One ticket does not mix `build` and
 `revise`: split those into separate tickets rather than inventing a fourth state.
 
+Every flat and chunked-header fence also carries `Profile:`. Use `hardening` only
+for a flat order whose target repo declares `Harden:`; use `none` otherwise,
+including every chunked order. A `QA script` follows `Done when` in flat and
+sub-order fences only when the profile is `hardening`: numbered Given/When/Then
+steps a human follows in the running app to confirm that clause.
+
 ## Two authoring checks before the draft leaves triage
 
 * **Wiring table.** Every value the order names (an environment variable, an input,
@@ -75,6 +81,7 @@ Repo(s): <org/repo> (branch from the default branch)
 Verification: <the command that verifies this change>
 Expectation: <what that command must report before the pull request opens>
 Review depth: <focused | targeted | full> (<one-line reason>)
+Profile: <none | hardening>
 
 Context
 <2-5 bullets: what exists today, what constrains this change, decisions already made
@@ -86,6 +93,13 @@ Do
 
 Done when
 <observable acceptance: verification output, CI green, specific behavior. Not "works".>
+
+QA script
+<present only when Profile is hardening: a human follows these numbered steps in the
+ running app to confirm Done when.>
+1. Given <starting state and fixture>
+2. When <human action>
+3. Then <observable acceptance>
 
 Boundaries
 * Iterate the verification step locally; open the pull request when it matches the expectation.
@@ -116,6 +130,7 @@ Repo(s): <org/repo> (one ticket branch, one pull request)
 Verification: <the command that verifies the merged branch>
 Expectation: <what that command must report before the pull request opens>
 Review depth (whole diff): <targeted | full> (<one-line reason>)
+Profile: <none | hardening>
 
 Why sliced
 <the rubric traits that fired, one line each, and the anchor row this matches>
@@ -153,6 +168,13 @@ Do
 
 Done when
 <observable acceptance for this chunk alone>
+
+QA script
+<present only when the ticket Profile is hardening: a human follows these numbered
+ steps in the running app to confirm Done when.>
+1. Given <starting state and fixture>
+2. When <human action>
+3. Then <observable acceptance>
 
 Boundaries
 * Touch only <files/targets this chunk owns>. Another chunk owns <the rest>.

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -60,8 +60,11 @@ long ago and the pull request is one diff.
    changes and rebase, same rules as `start`: the output must match the order's
    expectation. Re-read the repo's `AGENTS.md` or `CLAUDE.md` and audit the changes
    you are about to push against it, including any completion checklist it defines.
-   Fix violations, then run `/review` at the order's stamped review depth. Fix
-   confirmed findings and repeat verification if code changed.
+   Fix violations. Under `Profile: hardening`, re-run the repo's `Harden:` command
+   with the same stop rule and three-pass cap as `start`, and run `/review` only
+   when the stamped depth is Full. Under `Profile: none`, run `/review` at the
+   order's stamped review depth. Fix confirmed findings and repeat verification if
+   code changed.
 
 8. **Push and respond.** Push to the same branch. Reply to each addressed comment on
    the pull request, resolving or answering it. Update the repo's change record if

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -79,15 +79,19 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    `/ui-craft revise` against the named shipped behavior ledger and replay through
    the repo-declared safe dev-server entrypoint and fixture source. `Surface
    lifecycle: none` skips UI Craft. A new module or interface loads
-   `/codebase-design` vocabulary before the seam is cut. New behavior with testable
-   acceptance criteria goes test-first through `/tdd`. CI or workflow-file changes
-   read `/ci-design` first.
+   `/codebase-design` vocabulary before the seam is cut. With `Profile: none`, new
+   behavior with testable acceptance criteria goes test-first through `/tdd`. With
+   `Profile: hardening`, write tests through the public interface without `/tdd`.
+   CI or workflow-file changes read `/ci-design` first.
 
 9. **Verification loop.** Run the order's `Verification:` command locally and
    iterate until its output matches the order's `Expectation:` line exactly, per the
    skill page's verification-step rule. Never fabricate the output.
 
-10. **Repo-rules audit and adversarial review, before the pull request.** Re-read the
+10. **Repo-rules audit and adversarial review, before the pull request.** An order
+    with no `Profile:` line is `Profile: none`.
+
+    **Profile: none.** Re-read the
    repo's `AGENTS.md` or `CLAUDE.md`, which has decayed from context by now, and
    audit the full diff against it rule by rule, including any completion checklist
    it defines. Fix violations, then hand off to `/review` on the branch's changes
@@ -100,6 +104,16 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    findings, re-run the verification loop if code changed, then review once more.
    Two rounds maximum; findings still open after round two go into the pull request
    body as known issues, never silently dropped.
+
+    **Profile: hardening.** Run `/clean` on the branch diff, then run the repo's
+    `Harden:` command. Fix uncovered lines, surviving mutants, and high-CRAP
+    functions, re-running until the command exits 0 and every survivor is killed by
+    a public-interface test or listed as equivalent with a one-line reason in the
+    pull request body. Stop after at most three passes and open the pull request as
+    a draft naming the residue. A `Harden:` command that cannot run (tool missing,
+    parse failure, wrong runtime) is an error: open a draft pull request, name the
+    missing evidence, and never a pass. Targeted and Focused orders run no
+    `/review`; Full orders run one `/review` round after hardening.
 
 11. **Fold the change record into the baseline in the order's last pull request.**
     When the pull request being opened is the order's final one (single-pull-request
@@ -120,7 +134,9 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
     template because it seems unsuitable: open the pull request with it filled as
     best as possible, and raise the mismatch to the user. Only when no template
     exists anywhere, write the body free-form. Either way the body carries what
-    changed, the verification output in a fence, and a link to the ticket. When
+    changed, the verification output in a fence, and a link to the ticket. Under
+    `Profile: hardening`, it also carries the `Harden:` output in a fence, the
+    survivor list with dispositions, and the QA script verbatim. When
     `/pr-body` is installed, score the body with it before opening. Then move the
     ticket to pending review and comment on it (attribution first) with the pull
     request link and a one-line status.

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -148,7 +148,14 @@ scope and spec documents committed in that worktree.
    its sensitivity floor first; the floor overrides any judgment about how small
    the change looks.
 
-10. **Draft the work order.** Apply
+10. **Stamp the profile.** Read the target repo's `CLAUDE.md` or `AGENTS.md` repo
+    facts for a `Harden:` line. When the user or ticket asks for the hardening
+    profile and that line exists, stamp `Profile: hardening` and write the QA script
+    from the acceptance criteria. When the line is absent, stamp `Profile: none`,
+    say so in the order's Context, and continue with the default workflow. Stamp
+    `Profile: none` on every chunked order: the profile is flat-only.
+
+11. **Draft the work order.** Apply
     [references/brief-quality.md](../references/brief-quality.md), then fill
     [templates/work-order.md](../templates/work-order.md), the flat shape or the
     chunked shape per step 8, and run that page's two authoring checks before the
@@ -162,13 +169,16 @@ scope and spec documents committed in that worktree.
     or depend on private capability. Check that every fence's `Surface lifecycle:`
     value matches the route and contract artifacts settled in step 7.
 
-11. **Adversarial review, mandatory.** Every draft order gets reviewed before it is
-    shown to the user or posted; there is no unreviewed path to step 12. Run
+12. **Adversarial review, mandatory.** Every draft order gets reviewed before it is
+    shown to the user or posted; there is no unreviewed path to step 13. Run
     `/plan-review` against the draft: it spawns cold reviewer agents with the
     five-axis rubric (grounding, acceptance, interface shape, scope, cost) and
     returns objections and a verdict. Review depth follows that skill's stakes
     tiering: an ordinary order gets one panel, and a load-bearing one ends only
     when a fresh cold pass returns no blocking objections.
+
+    When the stamped profile is hardening, run `/plan-review` only on Full-depth
+    orders. Default-workflow orders keep this review unconditionally.
 
     Triage-specific additions on top of that skill:
 
@@ -210,12 +220,12 @@ scope and spec documents committed in that worktree.
     themselves introduced. Stop earlier when a round yields only wording polish,
     because the executing agent grounds in the same repo and resolves polish itself.
 
-12. **Confirm, then post.** Show the user the draft. On approval, post it as one
+13. **Confirm, then post.** Show the user the draft. On approval, post it as one
     ticket comment through the contract's post operation: attribution quote block
     first, then the human summary, then the fenced order or sub-orders. One comment
     carries the whole order, chunked or not.
 
-13. **Move the status** to triaged. Report a failed move; do not retry.
+14. **Move the status** to triaged. Report a failed move; do not retry.
 
 ## Refusals
 

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -302,6 +302,44 @@ class TicketSkillContractTests(unittest.TestCase):
             1,
         )
 
+    def test_hardening_profile_is_produced_and_consumed_across_ticket_paths(self):
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
+            encoding="utf-8"
+        )
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(
+            encoding="utf-8"
+        )
+        start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(
+            encoding="utf-8"
+        )
+        revise = (TICKET_DIRECTORY / "verbs" / "revise.md").read_text(
+            encoding="utf-8"
+        )
+        shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
+
+        flat_order = template.split("## Flat", 1)[1].split("## Chunked", 1)[0]
+        chunked_header = template.split("## Chunked", 1)[1].split(
+            "SUB-ORDER 1/<n>", 1
+        )[0]
+        sub_order = template.split("SUB-ORDER 1/<n>", 1)[1].split("```", 1)[0]
+        self.assertIn("Profile: <none | hardening>", flat_order)
+        self.assertIn("Profile: <none | hardening>", chunked_header)
+        self.assertIn("QA script", flat_order)
+        self.assertIn("QA script", sub_order)
+        self.assertIn("Stamp the profile", triage)
+        self.assertIn("Harden:", triage)
+        for requirement in (
+            "/clean",
+            "Harden:",
+            "three passes",
+            "never a pass",
+            "no `Profile:` line",
+        ):
+            self.assertIn(requirement, start)
+        self.assertIn("Harden:", revise)
+        self.assertIn("Harden:", shared)
+        self.assertIn("Profile: hardening", shared)
+
     def test_start_opens_with_summary_and_claim_before_fetching_the_order(self):
         shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
         start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

`/ticket` now has an opt-in hardening profile. On an order stamped `Profile: hardening`, the builder runs `/clean` over the branch diff and then the target repo's own `Harden:` command, and a human follows a Given/When/Then QA script in the running app; the agent review rounds that used to sit there do not run. Every order without the stamp keeps today's workflow byte for byte.

* Triage stamps the profile only when the target repo declares `Harden: <command>` beside its test command in its own repo facts. No such line and the order is stamped `Profile: none` with the reason in its Context, so a repo cannot opt in by accident. The whole repo-side contract is that one line: no adapter, gate script, or result schema, which is what ADR 97 rejected.
* A `Harden:` command that cannot run (tool missing, parse failure, wrong runtime) is an error rather than a pass: the pull request opens as a draft naming the missing evidence. The pull request body carries the command output, survivor dispositions, and QA script; the loop stops after three passes, with every surviving mutant either killed by a public-interface test or listed as equivalent with a reason.
* Review shrinks rather than disappears: Targeted and Focused profile orders get no reviewer, Full-depth orders keep one round after hardening, and at triage `/plan-review` runs only on Full-depth profile orders. `revise` re-runs `Harden:` under the same cap.
* The profile is flat-only. Every sliced order is stamped `Profile: none`, so coordinator mode is untouched.

This repo declares no `Harden:` line and this change does not add one, so no ticket run against this repo takes the new branch today.

Decisions, the risk contract, and what was salvaged from the closed #85 map are in `docs/scope/ticket-hardening-profile.md`.

Fixes #103

## Why

Agent review rounds are the expensive, least reproducible part of a ticket. Where a repo already owns a deterministic coverage and mutation command, that command plus a human walking the feature is a stronger check than another model reading the diff, and it costs the same every time.

## What to check

The failure this guards against is a hardening command that silently does not run being read as a clean pass. `start` and `revise` both treat that as an error with a draft pull request, and the tests pin the phrase.

The sub-order fence carries a QA script section that no order can reach today, because chunked orders are always stamped `Profile: none`. The work order asked for it in both fences.

## Verification

```text
python3 scripts/validate.py                    validated 27 skills and 268 files
python3 -m unittest <declared suites>          284 tests, OK (skipped=23)
python3 -m py_compile .../install.py           passed
```

Run under Python 3.14; the repo's declared command needs 3.10 or newer, and the shell default here is 3.9.6, which fails 32 unrelated tests on `ignore_cleanup_errors`.

The new test failed first for the right reason (`'Profile: <none | hardening>' not found`) before the skill pages changed.

The evidence is that the contract is written and pinned by substring, not that a ticket has run under the profile: no repo declares a `Harden:` line yet, so the branch is unexercised end to end. The issue calls for dogfooding it on the next few tickets.

> Written by an AI agent. Verify before relying on it.
