### PR TITLE
docs(ticket): fire lockstep trait on any over-encoded fact

### DIFF
--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -15,7 +15,7 @@ Slice when **two or more** of these hold. One or zero: the order stays flat.
 | Multiple deliverable artifacts | More than one shippable thing: a library change plus its consumers, a workflow plus the scripts it calls, code plus a runbook |
 | Live run inside the ticket | Acceptance requires standing up and running the artifact before the pull request — real infrastructure, or a local harness the ticket must build first (a browser driver, a seeded database, an offline server) — so what the run exposes is corrected in the same session |
 | Split-path evidence | Acceptance requires proving the same behavior on more than one code path that a single run cannot both exercise — a platform or feature-flag branch, or a re-implementation in another language held identical by test — so each path costs its own harness |
-| Lockstep copies of one fact | Adding one member to a closed set obliges edits in more than two encodings that no single tool checks together: a source of truth, a hand-maintained transcription, a fixture generator, and the committed fixture it freezes |
+| Lockstep copies of one fact | One fact is obliged to appear in more than two encodings that no single tool checks together: a source of truth, a hand-maintained transcription, a fixture generator and the fixture it freezes, or one rule restated in separately installed artifacts that never see each other at run time |
 | Lifecycle-gated surface revision | A shipped user-facing surface must first lock its visual contract, then implement it and prove it through a browser evidence matrix; the lock, implementation, and evidence each consume the same ticket's context |
 | In-flight scope replacement | A new work order rejects implementation already on the ticket branch and must remove or reconcile it before building the replacement |
 
@@ -27,9 +27,10 @@ whether the ticket also has to operate it, which costs a discovery-and-fix cycle
 per surprise plus whatever the run itself takes. The sixth asks what it costs to
 prove the change: a diff of two lines can owe two harnesses when the paths it
 touches cannot both run at once, and building the second one is the work. The
-seventh asks how many places one fact is written down: a single new member of a
-closed set costs a pass per encoding, and the encodings drift because nothing
-checks them together.
+seventh asks how many places one fact is written down: every encoding of that
+fact costs its own pass, whether they are chained from a single source of truth
+or restated independently of one another, and they drift because nothing checks
+them together.
 
 ## Anchor table
 
@@ -47,6 +48,7 @@ the helper's `scan` command, not estimates.
 | 53 | Replace a rejected application route already on the ticket branch, then build a narrower shared route adapter and update its consumers | multiple artifacts, in-flight scope replacement | slice into two serial chunks: remove and reconcile the rejected implementation, then build and verify the replacement | flat revised order; peaked 245k across 5 sessions |
 | 10 | Proof-bounded I:C history across an analyzer, server projections, generated fixtures, and a lifecycle-gated Diagnose revision | multiple artifacts, live run, lockstep copies, lifecycle-gated surface revision | slice into four serial chunks: analyzer, server contract, generated projections/evidence, then surface lock and browser evidence | 3 chunks; peaked 244k |
 | 90 | One shared behavioural judgment across model view, two server projections, generated fixtures and mirrors, and browser replay | multiple artifacts, live run, lockstep copies | slice into three serial chunks: source judgment, projection contracts, then generated artifacts and live replay | 2 chunks; peaked 231k |
+| 90 (skills) | A shared graph-identity interface, its ticket-workflow consumers, and the separately installed discovery policy, with argv and response shapes discovered by probing a live external CLI | multiple artifacts, lockstep copies | slice into two serial chunks: the ensure interface with its spiked contract tests, then the workflow pages and discovery policy that consume it | flat; peaked 243k in one session |
 
 When a ticket's traits match an anchor row, take that row's shape. When it sits
 between rows, say which two and pick the more conservative one.

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -164,6 +164,50 @@ class TicketSkillContractTests(unittest.TestCase):
         for forbidden in ("@x", "Feature-Sliced", "Steiger"):
             self.assertNotIn(forbidden, ticket_contract)
 
+    def test_trait_explanation_ordinals_still_point_at_their_rows(self):
+        # The paragraph under the trait table explains traits by position ("The
+        # fifth asks..."), so inserting or reordering a row silently re-points
+        # every later ordinal at a trait it does not describe. That is how the
+        # table and its explanation drift apart without either looking wrong.
+        slicing = (TICKET_DIRECTORY / "references" / "slicing.md").read_text(
+            encoding="utf-8"
+        )
+        trait_rubric = slicing.split("## The trait rubric", 1)[1].split(
+            "## Anchor table", 1
+        )[0]
+        rows = [
+            line.split("|")[1].strip()
+            for line in trait_rubric.splitlines()
+            if line.startswith("|") and not line.startswith("|---")
+        ][1:]
+        explanation = " ".join(trait_rubric.split("|\n\n", 1)[1].split())
+
+        ordinals = {
+            "first four": 4,
+            "fifth": 5,
+            "sixth": 6,
+            "seventh": 7,
+        }
+        expected = {
+            5: "Live run inside the ticket",
+            6: "Split-path evidence",
+            7: "Lockstep copies of one fact",
+        }
+        for word, position in ordinals.items():
+            self.assertIn(
+                f"The {word}",
+                explanation,
+                f"the explanation no longer refers to the {word} trait",
+            )
+            self.assertGreaterEqual(len(rows), position)
+            if position in expected:
+                self.assertEqual(
+                    rows[position - 1],
+                    expected[position],
+                    f"the {word} trait row is no longer {expected[position]!r};"
+                    " the explanation's ordinal now describes the wrong trait",
+                )
+
     def test_surface_lifecycle_is_produced_and_consumed_across_ticket_paths(self):
         triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
         start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

The slicing rubric's Lockstep copies of one fact trait now fires whenever one fact is obliged to appear in more than two encodings that nothing checks together. It previously fired only when adding a member to a closed set, which is narrower than the cost it prices.

* The sentence under the trait table described the closed-set framing. It now describes the reworded one, so the table and its explanation state the same trigger.
* The anchor table gains the skills 90 actual as `90 (skills)`, since its existing `90` row is harmonic's ticket 90.
* No threshold moves. The 180,000 degradation band and the 120,000 floor held on both tickets, and the helper's constants are untouched.

## Why

Two finished tickets hit the band with this trait silent, and both misses are the same trait failing to fire.

* skills 90 fired Multiple deliverable artifacts alone, so the one-trait rule kept the order flat. It peaked 243,343 tokens in one session and recorded `under-sliced`. One rule lived in the implementation, the ticket skill page, the separately installed discovery policy, the cbm-onboard page, and two test files, and review round one found those copies already drifted into two wordings pinned by two different keyword lists, each green on its own.
* harmonichq/harmonic 79 carried server schemas through generated fixtures, JavaScript mirrors, behavior ledgers, and browser gates, and recorded `still-degraded`.

The measured write-ups are on issue 99. Refs #99, #90

## What to check

The reworded row and the sentence beneath the table have to admit the same cases, since a rubric whose table and explanation disagree misleads triage more than an unchanged one would.

A new test pins the explanation's positional references, "The fifth" through "The seventh", to the trait rows they describe, so inserting or reordering a row turns red instead of silently re-pointing them. It does not assert that a reworded row and its sentence still mean the same thing. The only mechanical form of that check is a keyword match on words the two already share, which stays green whatever the sentences come to say.

Every `/ticket triage` reads this page, so the reworded trait applies to the next order triaged and nothing already ordered changes.

## Verification

* `scripts/validate.py`: 27 skills and 267 files, exit 0.
* Full unittest gate on Python 3.12: 284 tests, OK, 23 skipped.
* The new test fails when the sixth and seventh trait rows are swapped, and passes on this branch.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
