### PR TITLE
docs(ticket): drop unreachable sub-order QA script section

### DIFF
--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -31,9 +31,9 @@ executable without coordinator commentary. One ticket does not mix `build` and
 
 Every flat and chunked-header fence also carries `Profile:`. Use `hardening` only
 for a flat order whose target repo declares `Harden:`; use `none` otherwise,
-including every chunked order. A `QA script` follows `Done when` in flat and
-sub-order fences only when the profile is `hardening`: numbered Given/When/Then
-steps a human follows in the running app to confirm that clause.
+including every chunked order. A `QA script` follows `Done when` in the flat
+fence only when the profile is `hardening`: numbered Given/When/Then steps a
+human follows in the running app to confirm that clause.
 
 ## Two authoring checks before the draft leaves triage
 
@@ -168,13 +168,6 @@ Do
 
 Done when
 <observable acceptance for this chunk alone>
-
-QA script
-<present only when the ticket Profile is hardening: a human follows these numbered
- steps in the running app to confirm Done when.>
-1. Given <starting state and fixture>
-2. When <human action>
-3. Then <observable acceptance>
 
 Boundaries
 * Touch only <files/targets this chunk owns>. Another chunk owns <the rest>.

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -369,7 +369,9 @@ class TicketSkillContractTests(unittest.TestCase):
         self.assertIn("Profile: <none | hardening>", flat_order)
         self.assertIn("Profile: <none | hardening>", chunked_header)
         self.assertIn("QA script", flat_order)
-        self.assertIn("QA script", sub_order)
+        # Triage stamps Profile: none on every chunked order, so a sub-order
+        # QA script section could never fire.
+        self.assertNotIn("QA script", sub_order)
         self.assertIn("Stamp the profile", triage)
         self.assertIn("Harden:", triage)
         for requirement in (


### PR DESCRIPTION
## What changed

The work-order template's sub-order fence no longer carries a `QA script` section. The flat fence keeps its section, and the prose gating the section now names the flat fence alone.

* Triage stamps `Profile: none` on every chunked order, so a sub-order `QA script` section could never fire; it was scaffolding for a state the workflow makes unreachable.
* The template test now pins the absence: the flat fence must carry `QA script` and the sub-order fence must not.

## Why

The section landed in #109 because the locked order for issue 103 named both fences, and the pull request disclosed the tension rather than resolving it. The scope ledger's settled decision is that the profile is flat-only (chunked orders have their own review path in coordinator mode), so the sub-order section is dead by design, not pending design.

Refs #103

## What to check

The flat fence's `QA script` section is untouched; this removes only the copy no order can reach.

## Verification

* `scripts/validate.py`: 27 skills and 268 files, exit 0.
* Full unittest gate on Python 3.14: 285 tests, OK, 23 skipped.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
