### PR TITLE
feat(ticket): key telemetry claims and records by repository identity

### DIFF
--- a/docs/adr/adr-107-ticket-telemetry-repo-identity.md
+++ b/docs/adr/adr-107-ticket-telemetry-repo-identity.md
@@ -1,0 +1,91 @@
+# ADR 107 — Ticket telemetry keys claims and records by repository, not just ticket id
+
+Date: 2026-08-23
+Status: accepted
+Issue: https://github.com/ConnorGriffin/skills/issues/107
+
+## Context
+
+ADR 70 made `claim` record its own attribution instead of inferring it, so
+`scan` and `record` measure exactly the sessions that claimed a ticket rather
+than guessing from transcript prose. That fixed *which sessions* count. It did
+not fix *which ticket*: `read_claims` filters only on `ticket_id`, and two
+repositories that both happen to number an issue, say, 42 write claims that
+`scan` cannot tell apart. A claim made against `ConnorGriffin/skills#42`
+would be folded into the peak reported for a different repository's ticket
+42, understating one and overstating the other, and neither number would be
+visibly wrong — the ticket id alone gave no reason to suspect it.
+
+`claim` already resolves a real, checkout-derived value before this change:
+`arguments.project or str(Path.cwd())` is always a filesystem path — either
+the claiming process's own working directory, or a coordinator-supplied
+`--project <chunk-worktree>` naming a dispatched worker's real checkout
+(`skills/drivers/ticket/references/coordinator-mode.md` requires exactly
+this). It was never a hand-typed label. What was missing was turning that
+path into a stable repository identity two different checkouts of the same
+repository — the control checkout and a ticket worktree, say — would both
+resolve to.
+
+## Decision
+
+`ticket.py` gains `resolve_repo(path) -> Optional[str]`, tried in order and
+never raising:
+
+1. `git -C <path> remote get-url origin`, normalized so an ssh remote
+   (`git@host:owner/repo.git`) and an https remote
+   (`https://host/owner/repo.git`) for the same repository collide to one
+   string (`host/owner/repo`).
+2. On failure (no origin remote, or `path` is not a checkout at all),
+   `git -C <path> rev-parse --show-toplevel`, returned as-is.
+3. On failure of both, `None`.
+
+`command_claim` calls this on the same `project` value it already computes
+and stores the result as a new `repo` field on the claim, alongside the
+existing `project` field. No new `--repo` flag: repository identity is
+always derived from a checkout path already in play, never typed.
+
+`scan(ticket_id, projects_dir, current_repo)` takes the current repository as
+a third argument (`command_scan` and `command_record` compute it once, from
+`Path.cwd()` — no new CLI flag, since both already run from inside the
+ticket's own worktree) and partitions every claim `read_claims` returns into
+three groups: claims whose `repo` matches `current_repo` (these alone feed
+`session_count`, `claim_count`, `peak_context`, `subagent_peak`, and
+`sessions`, exactly as before); claims whose `repo` is set but differs
+(counted only, in `excluded_claims`); and claims whose `repo` is missing or
+`null` (named by session id in `unattributable`). `scan`'s result also
+reports `repo: current_repo`, so a reader can see which repository was
+measured. `command_record` persists all three new fields into
+`telemetry.jsonl`.
+
+A claim with no resolvable repository — written before this field existed,
+or one where resolution itself failed — is reported as unattributable, never
+counted into either repository's measurement. This mirrors ADR 70's decision
+for an unreadable transcript: a measurement that cannot attribute itself is a
+visible gap, not a silent zero and not a silent inclusion.
+`verdict()`'s `no-data` reason now distinguishes the two shapes of nothing:
+"no session claimed this ticket" (nothing at all) from "this ticket had
+claims, but none of them from this repository" (something claimed it, just
+not the repository asking).
+
+## Consequences
+
+- Two repositories sharing a ticket id now measure independently: each
+  repository's own `scan` reports only its own sessions, and sees the other
+  repository's claim named in `excluded_claims` rather than folded in.
+- A claim written before this change has no `repo` field. It reports under
+  `unattributable` rather than being silently absorbed into whichever
+  repository happens to scan it next, or silently zeroing out a ticket's
+  measurement.
+- A checkout that loses its origin remote between claiming and scanning
+  resolves to a different identity (its toplevel path) than before — silently,
+  from telemetry's point of view, the same way a moved or renamed remote
+  already made ADR 70's session ids brittle to environment drift.
+- Two checkouts of the same repository that both lack an origin remote
+  resolve to two different toplevel-based identities and are never treated as
+  the same repository. This is a known gap, not a case this change closes:
+  the origin remote is the only signal strong enough to collide two distinct
+  filesystem paths into one identity.
+- `references/slicing.md`'s existing anchor rows, which already collide
+  across repositories by ticket id, are unchanged by this ticket; disambiguating
+  them is out of scope here and remains the operator's call in an ordinary
+  pull request.

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -72,6 +74,63 @@ def validate_session_id(value: str) -> str:
     if forbidden & set(value):
         raise TelemetryError("session id must not contain glob or path characters")
     return value
+
+
+def _normalize_remote(url: str) -> str:
+    """Collide an ssh and an https remote for one repository to one string.
+
+    `git@github.com:owner/repo.git` and `https://github.com/owner/repo` name
+    the same repository; both fold to `github.com/owner/repo` so a claim made
+    through either form resolves to the same identity.
+    """
+    url = url.strip()
+    if url.endswith(".git"):
+        url = url[: -len(".git")]
+    scp_match = re.match(r"^[^/@]+@([^:]+):(.+)$", url)
+    if scp_match:
+        return f"{scp_match.group(1)}/{scp_match.group(2)}"
+    url_match = re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://(?:[^/@]+@)?([^/]+)/(.+)$", url)
+    if url_match:
+        return f"{url_match.group(1)}/{url_match.group(2)}"
+    return url
+
+
+def resolve_repo(path: Path) -> Optional[str]:
+    """Name the repository a checkout path belongs to, derived from disk.
+
+    Never raises: a missing `git`, a path outside any checkout, or a checkout
+    with no origin remote all fall through to the next step rather than
+    blocking whichever claim, scan, or record call needs this. Tried in order:
+    the origin remote (normalized so ssh and https collide), then the
+    checkout's own toplevel path, then `None`.
+    """
+    try:
+        remote = subprocess.run(
+            ["git", "-C", str(path), "remote", "get-url", "origin"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        remote = None
+    if remote is not None and remote.returncode == 0 and remote.stdout.strip():
+        return _normalize_remote(remote.stdout.strip())
+
+    try:
+        toplevel = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        toplevel = None
+    if toplevel is not None and toplevel.returncode == 0 and toplevel.stdout.strip():
+        return toplevel.stdout.strip()
+
+    return None
 
 
 def context_size(usage: dict) -> int:
@@ -244,17 +303,43 @@ def session_cost(claim: dict, projects_dir: Path) -> dict:
     }
 
 
-def scan(ticket_id: str, projects_dir: Path) -> dict:
-    sessions = [session_cost(claim, projects_dir) for claim in read_claims(ticket_id)]
+def scan(ticket_id: str, projects_dir: Path, current_repo: Optional[str]) -> dict:
+    """Report peak context for this ticket id, scoped to one repository.
+
+    A claim's `repo` was resolved once, at claim time, from the checkout it
+    ran in. Reading it back here keeps two repositories' same-numbered
+    tickets from merging into one measurement: a claim from another
+    repository is counted but never folded in, and a claim with no
+    resolvable repository (a pre-existing claim written before this field
+    existed, or a resolution failure) is named rather than silently dropped
+    or silently counted.
+    """
+    own_claims = []
+    excluded = 0
+    unattributable = []
+    for claim in read_claims(ticket_id):
+        repo = claim.get("repo")
+        if repo:
+            if repo == current_repo:
+                own_claims.append(claim)
+            else:
+                excluded += 1
+        else:
+            unattributable.append(claim["session_id"])
+
+    sessions = [session_cost(claim, projects_dir) for claim in own_claims]
     sessions.sort(key=lambda session: session["started"] or "")
     measured = [session for session in sessions if session["transcripts"]]
     return {
         "ticket_id": ticket_id,
+        "repo": current_repo,
         "session_count": len(measured),
         "claim_count": len(sessions),
         "unreadable": [
             session["session_id"] for session in sessions if not session["transcripts"]
         ],
+        "excluded_claims": excluded,
+        "unattributable": unattributable,
         "peak_context": max((session["peak_context"] for session in measured), default=0),
         "subagent_peak": max((session["subagent_peak"] for session in measured), default=0),
         "sessions": sessions,
@@ -276,6 +361,20 @@ def verdict(actual: dict, chunked: bool, chunks: int) -> tuple[str, str]:
                 "no-data",
                 f"{actual['claim_count']} session(s) claimed this ticket and their "
                 "transcripts are gone, so nothing could be measured",
+            )
+        excluded = actual.get("excluded_claims") or 0
+        unattributable = actual.get("unattributable") or []
+        if excluded or unattributable:
+            parts = []
+            if excluded:
+                parts.append(f"{excluded} claim(s) from another repository")
+            if unattributable:
+                parts.append(f"{len(unattributable)} claim(s) with no resolvable repository")
+            repo_name = actual.get("repo") or "this repository"
+            return (
+                "no-data",
+                "this ticket had claims, but " + " and ".join(parts)
+                + f", none of them from {repo_name}, so nothing measured it here",
             )
         return "no-data", "no session claimed this ticket, so nothing measured it"
     own = max(session["peak_context"] for session in actual["sessions"])
@@ -311,14 +410,16 @@ def append_record(record: dict) -> Path:
 
 def command_scan(arguments: argparse.Namespace) -> int:
     ticket_id = validate_ticket_id(arguments.ticket_id)
-    result = scan(ticket_id, arguments.projects_dir)
+    current_repo = resolve_repo(Path.cwd())
+    result = scan(ticket_id, arguments.projects_dir, current_repo)
     print(json.dumps(result, indent=2))
     return 0
 
 
 def command_record(arguments: argparse.Namespace) -> int:
     ticket_id = validate_ticket_id(arguments.ticket_id)
-    actual = scan(ticket_id, arguments.projects_dir)
+    current_repo = resolve_repo(Path.cwd())
+    actual = scan(ticket_id, arguments.projects_dir, current_repo)
     call, reason = verdict(actual, arguments.chunked, arguments.chunks)
     record = {
         "ticket_id": ticket_id,
@@ -327,9 +428,12 @@ def command_record(arguments: argparse.Namespace) -> int:
         "depth": arguments.depth,
         "chunked": arguments.chunked,
         "chunks": arguments.chunks,
+        "repo": actual["repo"],
         "session_count": actual["session_count"],
         "claim_count": actual["claim_count"],
         "unreadable": actual["unreadable"],
+        "excluded_claims": actual["excluded_claims"],
+        "unattributable": actual["unattributable"],
         "peak_context": actual["peak_context"],
         "subagent_peak": actual["subagent_peak"],
         "session_peaks": [
@@ -351,11 +455,13 @@ def command_claim(arguments: argparse.Namespace) -> int:
         validate_session_id(arguments.session) if arguments.session else None,
         arguments.agent,
     )
+    project = arguments.project or str(Path.cwd())
     claim = {
         "ticket_id": ticket_id,
         "session_id": session_id,
         "agent": agent,
-        "project": arguments.project or str(Path.cwd()),
+        "project": project,
+        "repo": resolve_repo(Path(project)),
         "claimed_at": datetime.now(timezone.utc).isoformat(),
     }
     written = append_claim(claim)

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -467,10 +467,10 @@ class TicketTelemetryTests(unittest.TestCase):
     def tearDown(self):
         self.temporary.cleanup()
 
-    def ticket(self, *arguments: str, environment: Optional[dict] = None):
+    def ticket(self, *arguments: str, environment: Optional[dict] = None, cwd: Optional[Path] = None):
         return run(
             ["python3", str(TICKET_SCRIPT), *arguments],
-            cwd=ROOT,
+            cwd=cwd or ROOT,
             env=environment or self.environment,
         )
 
@@ -588,7 +588,30 @@ class TicketTelemetryTests(unittest.TestCase):
         (directory / f"agent-{worker_id}-near-collision.jsonl").write_text(
             assistant_line(260_000, subagent=True) + "\n", encoding="utf-8"
         )
-        worker_project = "/tmp/synthetic-chunk-worktree"
+        # A synthetic chunk worktree of *this* repository: same origin as the
+        # real checkout, read at test time rather than hardcoded, so its
+        # resolved repository identity collides with the one `scan` (running
+        # with cwd=ROOT) resolves for itself. A bare `/tmp` path, or a
+        # toplevel-only fixture with no origin, resolves to a repository
+        # identity that can never collide with ROOT's — the claim then lands
+        # in `excluded_claims` instead of `sessions`, and this test would pass
+        # while measuring nothing.
+        origin = subprocess.run(
+            ["git", "-C", str(ROOT), "remote", "get-url", "origin"],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        worker_project = self.scratch / "synthetic-chunk-worktree"
+        worker_project.mkdir()
+        subprocess.run(
+            ["git", "init"], cwd=worker_project, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", origin], cwd=worker_project, check=True,
+        )
+        worker_project = str(worker_project)
         claim = self.ticket(
             "claim",
             "TICKET-20",
@@ -852,6 +875,102 @@ class TicketTelemetryTests(unittest.TestCase):
         claimed = self.claims.read_text(encoding="utf-8")
         self.assertNotIn("unrealistic", claimed)
         self.assertNotIn(secret_prose, claimed)
+
+    def make_repo_checkout(self, name: str, origin_url: str) -> Path:
+        checkout = self.scratch / name
+        checkout.mkdir()
+        subprocess.run(
+            ["git", "init"], cwd=checkout, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", origin_url], cwd=checkout, check=True,
+        )
+        return checkout
+
+    def test_scan_partitions_claims_by_repository(self):
+        # Two repositories sharing one ticket id: each one's own scan must see
+        # only its own session, and count the other repository's claim
+        # without folding it in. A plain temp directory with no `git init`
+        # cannot stand in for either side here, because two origin-less
+        # checkouts both resolve to `None` and would be indistinguishable.
+        repo_a = self.make_repo_checkout("repo-a", "https://example.com/org/repo-a.git")
+        repo_b = self.make_repo_checkout("repo-b", "https://example.com/org/repo-b.git")
+
+        self.write_session("proj-a", "session-a", [assistant_line(40_000)])
+        self.write_session("proj-b", "session-b", [assistant_line(70_000)])
+
+        claim_a = self.ticket(
+            "claim", "TICKET-21", "--session", "session-a", "--agent", "claude",
+            "--project", str(repo_a),
+        )
+        self.assertEqual(claim_a.returncode, 0, claim_a.stderr)
+        claim_b = self.ticket(
+            "claim", "TICKET-21", "--session", "session-b", "--agent", "claude",
+            "--project", str(repo_b),
+        )
+        self.assertEqual(claim_b.returncode, 0, claim_b.stderr)
+
+        scan_a = self.ticket("scan", "TICKET-21", cwd=repo_a)
+        scan_b = self.ticket("scan", "TICKET-21", cwd=repo_b)
+
+        self.assertEqual(scan_a.returncode, 0, scan_a.stderr)
+        self.assertEqual(scan_b.returncode, 0, scan_b.stderr)
+        payload_a = json.loads(scan_a.stdout)
+        payload_b = json.loads(scan_b.stdout)
+
+        self.assertEqual([s["session_id"] for s in payload_a["sessions"]], ["session-a"])
+        self.assertEqual(payload_a["peak_context"], 40_000)
+        self.assertEqual(payload_a["excluded_claims"], 1)
+        self.assertEqual(payload_a["unattributable"], [])
+
+        self.assertEqual([s["session_id"] for s in payload_b["sessions"]], ["session-b"])
+        self.assertEqual(payload_b["peak_context"], 70_000)
+        self.assertEqual(payload_b["excluded_claims"], 1)
+        self.assertEqual(payload_b["unattributable"], [])
+
+    def test_unlabelled_legacy_claim_is_unattributable_not_counted(self):
+        # A claim written before `repo` existed carries no such key at all.
+        # It must be named, not folded into either "nothing claimed this" or
+        # a real session count.
+        self.claims.parent.mkdir(parents=True, exist_ok=True)
+        legacy_claim = {
+            "ticket_id": "TICKET-22",
+            "session_id": "legacy-session",
+            "agent": "claude",
+            "project": "/some/old/path",
+            "claimed_at": "2026-01-01T00:00:00+00:00",
+        }
+        with self.claims.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(legacy_claim) + "\n")
+
+        scan_result = self.ticket("scan", "TICKET-22")
+        self.assertEqual(scan_result.returncode, 0, scan_result.stderr)
+        payload = json.loads(scan_result.stdout)
+        self.assertEqual(payload["session_count"], 0)
+        self.assertEqual(payload["claim_count"], 0)
+        self.assertEqual(payload["unattributable"], ["legacy-session"])
+
+        # `verdict` returns `no-data` for an unlabelled claim alone, and
+        # `command_record` never persists a `no-data` record — so a second,
+        # ordinary same-repository claim is needed for `record` to persist
+        # anything the `unattributable` field can be asserted against.
+        self.worked("TICKET-22", "proj-a", "session-real", [assistant_line(55_000)])
+
+        record_result = self.ticket(
+            "record", "TICKET-22", "--verb", "start", "--trait", "any", "--depth", "light"
+        )
+        self.assertEqual(record_result.returncode, 0, record_result.stderr)
+        payload = json.loads(record_result.stdout)
+        self.assertNotEqual(payload["verdict"], "no-data")
+        self.assertEqual(payload["unattributable"], ["legacy-session"])
+        self.assertEqual(payload["session_count"], 1)
+        self.assertEqual(payload["peak_context"], 55_000)
+
+        persisted = self.telemetry_records()[0]
+        self.assertEqual(persisted["unattributable"], ["legacy-session"])
+        self.assertEqual(persisted["session_count"], 1)
+        self.assertEqual(persisted["peak_context"], 55_000)
 
 
 if __name__ == "__main__":

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -973,5 +973,37 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(persisted["peak_context"], 55_000)
 
 
+    def test_ssh_and_https_remotes_for_one_repository_collide_to_the_same_identity(self):
+        # An ssh remote and an https remote naming the same repository must
+        # resolve to one identity, or a claim made through one form and a
+        # scan run from a checkout using the other form would wrongly land
+        # in excluded_claims instead of being recognised as the same
+        # repository. Exercised through claim/scan (the public interface),
+        # not by calling _normalize_remote directly.
+        ssh_checkout = self.make_repo_checkout(
+            "ssh-checkout", "git@github.com:fixture/repo.git"
+        )
+        https_checkout = self.make_repo_checkout(
+            "https-checkout", "https://github.com/fixture/repo.git"
+        )
+
+        self.write_session("proj-a", "session-ssh", [assistant_line(45_000)])
+
+        claimed = self.ticket(
+            "claim", "TICKET-23", "--session", "session-ssh", "--agent", "claude",
+            "--project", str(ssh_checkout),
+        )
+        self.assertEqual(claimed.returncode, 0, claimed.stderr)
+
+        scanned = self.ticket("scan", "TICKET-23", cwd=https_checkout)
+
+        self.assertEqual(scanned.returncode, 0, scanned.stderr)
+        payload = json.loads(scanned.stdout)
+        self.assertEqual([s["session_id"] for s in payload["sessions"]], ["session-ssh"])
+        self.assertEqual(payload["peak_context"], 45_000)
+        self.assertEqual(payload["excluded_claims"], 0)
+        self.assertEqual(payload["unattributable"], [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Ticket telemetry's `claim`, `scan`, and `record` now key their measurements by repository, not just ticket id, so two repositories that both happen to number an issue the same way stop merging into one number.

* `claim` resolves the repository a session claimed from (the origin remote of the checkout path already in play, never a new flag, never hand-typed), normalized so an ssh remote and an https remote for one repository collide to the same identity, falling back to the checkout's toplevel path, then to nothing resolvable at all, and stores it as `repo` alongside the existing `project` field.
* `scan` and `record` now compute the current repository from their own working directory and partition every claim on a ticket id into three groups: this repository's own claims (the ones that feed every count, exactly as before), another repository's claims (counted only, in a new `excluded_claims` field), and claims with no resolvable repository (named by session id in a new `unattributable` field).
* A claim written before this change (no `repo` field at all) is reported as unattributable rather than silently folded into whichever repository happens to scan it next.
* `verdict()`'s `no-data` reason now says which shape of nothing it is: no session ever claimed this ticket, versus something claimed it but none of it was this repository's.
* Not in this change: disambiguating the existing `references/slicing.md` anchor rows that already collide across repositories by ticket id (that stays the operator's call in an ordinary pull request, and that file was under active edit elsewhere while this was in flight).

## Why

`read_claims` filtered only on `ticket_id`. A claim made against one repository's ticket 42 and a claim made against a different repository's ticket 42 were indistinguishable to `scan`, so one repository's peak could silently absorb the other's session, understating one ticket's real cost and overstating the other's, with nothing about the output looking wrong, because the ticket id alone gave no reason to suspect it.

`claim` already resolved a real, checkout-derived working directory before this change (`arguments.project or str(Path.cwd())`, either the claiming process's own cwd, or a coordinator-supplied `--project <chunk-worktree>` naming a dispatched worker's real checkout, per `skills/drivers/ticket/references/coordinator-mode.md`). What was missing was turning that path into a stable identity two different checkouts of the same repository would both resolve to. ADR 70 already set the precedent this follows: a measurement that cannot attribute itself is reported as a visible gap, never silently absorbed into a count. See `docs/adr/adr-107-ticket-telemetry-repo-identity.md`.

Refs #107

## What to check

* `resolve_repo` never raises and stays Python 3.9-compatible: `ticket.py` runs under whatever `python3` is ambient in a verb's shell, which is 3.9 in this repo, even though the verification below runs it under 3.14.
* The fixture for `test_a_claimed_native_claude_worker_is_measured_as_its_own_session` now `git init`s a temp directory and gives it the *same* origin the real repo has, read at test time (`git -C ROOT remote get-url origin`) rather than hardcoded. A bare `git init` with only a toplevel identity would never collide with the current repository's origin-derived identity, and the claim would have silently landed in `excluded_claims` while the test's assertions kept passing against stale zero data.
* `test_unlabelled_legacy_claim_is_unattributable_not_counted` claims an unlabelled session directly into `claims.jsonl` alongside an ordinary same-repository claim, because an unlabelled claim alone makes `record` a no-op (`verdict` returns `no-data`, which `command_record` never persists). The second claim is what lets the test assert `unattributable` actually reaches `telemetry.jsonl`.
* `test_ssh_and_https_remotes_for_one_repository_collide_to_the_same_identity` claims from a checkout with an ssh-style origin and scans from a checkout with an https-style origin for the same fixture repository, and asserts the claim is recognized as that scan's own session rather than excluded. It is the only test covering the scp-style branch of the remote-normalizing regex.
* No new CLI flag anywhere (no `--repo`): repository identity is always derived from a checkout path already in play.
* Only `skills/drivers/ticket/scripts/ticket.py`, `tests/test_ticket.py`, and the new ADR changed; `skills/drivers/ticket/references/slicing.md` is untouched.

## Verification

```
$ /opt/homebrew/bin/python3 scripts/validate.py
validated 27 skills and 269 files

$ /opt/homebrew/bin/python3 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install
Ran 288 tests in 62.529s
OK (skipped=23)

$ /opt/homebrew/bin/python3 -m py_compile skills/tools/codebase-memory/scripts/install.py
(exit 0)
```

Fixes #107

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
