### PR TITLE
fix(cbm-onboard): unavailable, not exit 1, for a binary that produced nothing

### DIFF
--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -173,6 +173,10 @@ It prints one object, and the verb reports it verbatim:
   stderr, which names the cause — a path that is not a checkout, or an installed
   tool answering for the wrong project or root. Neither is a case where guessing a
   graph is safe.
+* The command never ran at all, no exit code, because the harness or sandbox
+  refused it (a permission classifier declining the Bash call, for example): say so
+  in one line and use ordinary discovery for the rest of the session, the same as
+  `unavailable`.
 
 Every session recomputes this from the checkout it just verified, never from chat
 memory or a remembered earlier run. It names one machine's paths, so it never goes

--- a/skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
+++ b/skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
@@ -115,6 +115,23 @@ def unavailable() -> "NoReturn":
     raise SystemExit(2)
 
 
+def envelope_or_unavailable(code: int, raw: str) -> tuple[dict, object]:
+    """Read one tool response, distinguishing "produced nothing" from "answered wrongly".
+
+    A nonzero exit paired with empty stdout means the binary could not operate
+    at all here (for example a sandbox that blocks the daemon endpoint it
+    needs) — the same degraded mode as a missing or too-old binary, reported
+    as `unavailable`. A zero exit with empty stdout is still a protocol
+    violation: the tool claimed success and said nothing, which is not a case
+    where "no graph is available" is a safe conclusion. Non-empty stdout that
+    fails to parse is always a protocol violation regardless of exit code.
+    """
+
+    if code != 0 and raw == "":
+        unavailable()
+    return read_envelope(raw)
+
+
 def usable_binary() -> str:
     configured = os.environ.get("CODEBASE_MEMORY_BIN") or shutil.which("codebase-memory-mcp")
     if not configured or not os.access(configured, os.X_OK):
@@ -157,7 +174,7 @@ def ensure(target: str) -> None:
     root, project = physical_identity(target)
 
     code, raw = call_tool(binary, ["index_status", "--project", project])
-    structured, reported_error = read_envelope(raw)
+    structured, reported_error = envelope_or_unavailable(code, raw)
     if code == 0:
         if not ready_for(structured, reported_error, project, root):
             fail(f"Codebase Memory did not report {project} ready for {root}")
@@ -171,7 +188,7 @@ def ensure(target: str) -> None:
         binary,
         ["index_repository", "--repo-path", root, "--mode", "full", "--name", project],
     )
-    structured, reported_error = read_envelope(raw)
+    structured, reported_error = envelope_or_unavailable(code, raw)
     if (
         code != 0
         or reported_error is not False
@@ -183,7 +200,7 @@ def ensure(target: str) -> None:
     # index_repository never echoes the root it indexed, so the binding is only
     # proven by asking for the project's own root afterwards.
     code, raw = call_tool(binary, ["index_status", "--project", project])
-    structured, reported_error = read_envelope(raw)
+    structured, reported_error = envelope_or_unavailable(code, raw)
     if code != 0 or not ready_for(structured, reported_error, project, root):
         fail(f"Codebase Memory did not report {project} ready for {root} after indexing")
     json.dump({"root_path": root, "project": project, "status": "indexed"}, sys.stdout)

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -82,6 +82,8 @@ with open(os.environ["CBM_FAKE_REQUESTS"], "a", encoding="utf-8") as handle:
     handle.write(json.dumps(sys.argv[1:]) + "\\n")
 
 indexed = os.environ["CBM_FAKE_INDEXED"]
+if os.environ.get("CBM_FAKE_EMPTY_FAIL") == "1":
+    raise SystemExit(1)
 if os.environ.get("CBM_FAKE_MALFORMED") == "1":
     print("not json")
     raise SystemExit(0)
@@ -242,6 +244,23 @@ raise SystemExit(9)
                 self.assertEqual(json.loads(result.stdout), {"status": "unavailable"})
                 self.environment["CODEBASE_MEMORY_BIN"] = str(self.binary)
                 self.environment.pop("CBM_FAKE_VERSION", None)
+
+    def test_a_nonzero_exit_with_empty_stdout_is_the_unavailable_outcome(self):
+        """A binary that can't operate here (e.g. a sandbox blocking its daemon
+        endpoint) fails with a nonzero exit and no stdout at all. That is the
+        same degraded mode as a missing or too-old binary, not a protocol
+        violation: ensure must report unavailable, not fail hard."""
+
+        self.environment["CBM_FAKE_EMPTY_FAIL"] = "1"
+
+        result = self.ensure()
+
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertEqual(json.loads(result.stdout), {"status": "unavailable"})
+        self.assertEqual(
+            self.issued(),
+            [["cli", "--json", "index_status", "--project", self.project_for(self.repo)]],
+        )
 
     def test_a_response_for_another_project_root_or_state_stops_the_binding(self):
         self.indexed.touch()

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -258,6 +258,14 @@ class TicketSkillContractTests(unittest.TestCase):
             self.assertIn(trap, normalized)
         self.assertIn("recomputes", normalized)
         self.assertIn("ordinary discovery", normalized)
+        self.assertIn("no exit code", normalized)
+        self.assertIn("harness or sandbox", normalized)
+        self.assertIn("refused it", normalized)
+        self.assertEqual(
+            normalized.count("ordinary discovery"),
+            2,
+            "the never-ran outcome must reuse the unavailable outcome's rule, not restate it",
+        )
 
         for page, worktree, code in (
             (triage, "Cut or reuse the worktree", "5. **Ground.**"),


### PR DESCRIPTION
## What changed

`ensure` (the command every `/ticket` verb runs to bind a checkout to its Codebase
Memory graph before reading code) now tells apart two failures that used to look
identical: the Codebase Memory tool answering with garbage, versus the tool
producing nothing at all because it couldn't run here. Only the first is a real
protocol violation. The second (a nonzero exit with no output, the shape you get
when a sandbox blocks the tool's daemon endpoint) now reports the same
"no graph available, fall back to ordinary discovery" outcome as a missing or
too-old binary, instead of stopping the whole ticket verb.

The `/ticket` skill page also gained the outcome it was missing: sometimes the
`ensure` command doesn't run at all, because the harness's permission layer
refuses the call outright. There's no exit code to read in that case. The page
now says, in one line, to treat that the same as "no graph available" too, so an
agent hitting a permission refusal doesn't have to invent a rule on the spot.

## Why

Both gaps shipped in #105 and showed up in real runs: a Codex `read-only` sandbox
producing `chmod 0700 failed` on the tool's coordination socket, and Claude Code's
auto-mode classifier declining the `ensure` Bash call outright (nondeterministically:
identical commands produced one success and one refusal in separate subagents).
Neither is a reason to stop a ticket that's otherwise healthy; both were being
treated as "stop the verb" because the failure contract didn't have a slot for
"the tool couldn't answer" as distinct from "the tool answered wrong."

I deliberately left a zero exit with empty stdout as a protocol violation rather
than folding it into unavailable: a zero exit is the tool claiming success, so
silence on success isn't a case where "no graph is available" is a safe
conclusion. That combination is the tool lying about its own state, which should
keep failing loudly.

## What to check

- `skills/tools/cbm-onboard/scripts/cbm-lifecycle.py`: `ensure` now routes every
  response through `envelope_or_unavailable`, which only treats a *nonzero exit
  paired with empty stdout* as the degraded "unavailable" case. A zero exit with
  empty stdout, or any non-empty stdout that fails to parse (regardless of exit
  code), still fails hard exactly as before.
- `skills/drivers/ticket/SKILL.md`, "The graph identity": one added bullet for the
  "command never ran, no exit code" outcome, next to the existing three. It defers
  to the same "ordinary discovery" fallback as `unavailable` rather than restating
  the rule.
- `tests/test_behavior.py`: `CbmEnsureTests` gets a new fake-binary mode
  (`CBM_FAKE_EMPTY_FAIL`) and a test asserting nonzero exit + empty stdout yields
  exit 2 and `{"status": "unavailable"}`. The existing "malformed" subtest (nonzero
  parse of non-empty stdout, `CBM_FAKE_MALFORMED`) is untouched and still asserts
  exit 1.
- `tests/test_ticket.py`: extends the graph-identity pinning test to require the
  new fourth-outcome language in the skill page, and to fail if it's written as a
  restatement rather than a defer-to-unavailable one-liner.

## Verification

```
$ /opt/homebrew/bin/python3 scripts/validate.py
validated 27 skills and 271 files

$ /opt/homebrew/bin/python3 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco
Ran 292 tests in 60.864s
OK (skipped=23)

$ /opt/homebrew/bin/python3 -m py_compile skills/tools/codebase-memory/scripts/install.py skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
(no output, exit 0)
```

Fixes #115

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
