### PR TITLE
fix(cbm-onboard): file worktree hook refreshes by identity

### DIFF
--- a/docs/adr/adr-59-worktree-commits-file-under-their-own-identity.md
+++ b/docs/adr/adr-59-worktree-commits-file-under-their-own-identity.md
@@ -21,19 +21,21 @@ so it appended a second block instead of repairing the owned legacy one.
 
 ## Decision
 
-The reindex command classifies the checkout that fired the hook by comparing
-Git's absolute Git directory with its common Git directory. A maintained
-checkout keeps the established behavior: detached fast indexing with only its
-repository path, allowing Codebase Memory to derive the project name.
+The reindex command classifies the checkout that fired the hook by physically
+comparing Git's absolute Git directory with its common Git directory. A failed
+classification stops before either indexing path. A maintained checkout keeps
+the established behavior: detached fast indexing with only its repository path,
+allowing Codebase Memory to derive the project name.
 
 A linked worktree instead derives the deterministic
 `cbm-onboard-v1-<sha256>` identity through the existing lifecycle command and
 requests one detached fast index under that exact name. Classification and
 identity derivation ignore hook-provided `GIT_DIR` and `GIT_WORK_TREE` values so
 the firing checkout remains authoritative. The hook never falls back to a
-path-derived name. If the binary is missing, its version cannot support the
-identity lifecycle, or identity derivation fails, the hook prints one reason
-and exits successfully so the Git operation continues.
+path-derived name. If classification fails, the binary or detached launcher is
+missing, the binary version cannot support the identity lifecycle, or identity
+derivation fails, the hook prints one reason and exits successfully so the Git
+operation continues.
 
 Onboarding recognizes both its fenced managed block and the older unfenced
 marker. It removes the legacy marker and only an immediately following exact,

--- a/docs/adr/adr-59-worktree-commits-file-under-their-own-identity.md
+++ b/docs/adr/adr-59-worktree-commits-file-under-their-own-identity.md
@@ -1,0 +1,56 @@
+# ADR 59 - Worktree commits file under their own identity
+
+Date: 2026-08-23
+Status: accepted
+Issue: https://github.com/ConnorGriffin/skills/issues/59
+
+## Context
+
+Maintained repositories install one managed reindex block in their shared Git
+hooks. A linked worktree fires those hooks from the worktree that received the
+Git operation, but the reindex command historically supplied only that path.
+Codebase Memory therefore derived a second, path-named project instead of
+refreshing the deterministic project established for the worktree lifecycle.
+Teardown knew only the deterministic identity, so the duplicate survived after
+the worktree was removed.
+
+The hooks also retained the absolute reindex-command path written at enrollment
+time. Older enrollments used an unfenced marker and could point at another copy
+of the command. Re-running onboarding recognized only the current fenced block,
+so it appended a second block instead of repairing the owned legacy one.
+
+## Decision
+
+The reindex command classifies the checkout that fired the hook by comparing
+Git's absolute Git directory with its common Git directory. A maintained
+checkout keeps the established behavior: detached fast indexing with only its
+repository path, allowing Codebase Memory to derive the project name.
+
+A linked worktree instead derives the deterministic
+`cbm-onboard-v1-<sha256>` identity through the existing lifecycle command and
+requests one detached fast index under that exact name. Classification and
+identity derivation ignore hook-provided `GIT_DIR` and `GIT_WORK_TREE` values so
+the firing checkout remains authoritative. The hook never falls back to a
+path-derived name. If the binary is missing, its version cannot support the
+identity lifecycle, or identity derivation fails, the hook prints one reason
+and exits successfully so the Git operation continues.
+
+Onboarding recognizes both its fenced managed block and the older unfenced
+marker. It removes the legacy marker and only an immediately following exact,
+no-argument invocation of `cbm-reindex.sh`; malformed invocations and unrelated
+hook lines remain untouched. The replacement block points at the installation
+that ran onboarding, so re-running onboarding from the installed skill repairs
+stale enrollments without a new repair interface or repository registry.
+
+## Consequences
+
+- A linked-worktree commit refreshes the same deterministic project that its
+  lifecycle owns, and teardown no longer leaves a hook-created path-named twin.
+- Maintained repositories retain their existing derived-name behavior and
+  compatibility.
+- Re-running onboarding repairs one repository at a time while preserving hook
+  content the skill does not own.
+- Hook refresh remains detached, quiet after launch, and unable to fail a
+  commit, merge, or checkout; only refusal to launch is reported.
+- Existing duplicate projects are not renamed, migrated, or deleted by this
+  change.

--- a/docs/scope/cbm-hook-repair.md
+++ b/docs/scope/cbm-hook-repair.md
@@ -108,12 +108,15 @@ Disposition: inline in the work order.
   ```sh
   gd="$(git rev-parse --absolute-git-dir)"
   cd_="$(git rev-parse --git-common-dir)"
-  case "$cd_" in /*) : ;; *) cd_="$(cd "$cd_" && pwd)" ;; esac
+  case "$cd_" in /*) : ;; *) cd_="$(cd "$cd_" && pwd -P)" ;; esac
   [ "$gd" = "$cd_" ] && echo maintained || echo linked
   ```
 
   Resolving a relative `--git-common-dir` against the toplevel instead of `$PWD`
   misclassified `main/sub` as linked, so the relative case is resolved against `$PWD`.
+  Full implementation review also reproduced a maintained checkout reached through a
+  logical symlink whose absolute Git directory used the physical spelling; `pwd -P`
+  keeps both sides of the classification in the same physical namespace.
 - Legacy-block recognition, run against a hook holding a user line, the dotfiles
   marker comment, its invocation, and a trailing user line, left both user lines and
   removed exactly the two managed lines:

--- a/docs/scope/cbm-hook-repair.md
+++ b/docs/scope/cbm-hook-repair.md
@@ -1,0 +1,143 @@
+# Scope: cbm-onboard reindex hooks
+
+Issue: ConnorGriffin/skills#59
+
+## Decisions
+
+- Classify the ticket as `code`: it lands as one pull request in this repository.
+  Why: the deliverable is the pack's hook installer, its reindex command, their tests,
+  and the skill page.
+  Disposition: inline.
+- Route scope to interview mode.
+  Why: grounding settled the facts; what remains is three choices about behavior that
+  only the operator can make.
+  Disposition: inline.
+
+- A commit inside a linked worktree refreshes that worktree's own graph under the
+  identity the ticket bound it to, never a path-derived one.
+  Why: agents read the worktree they are working in, and PR #12's rule that the firing
+  checkout is the one that matters still holds; only the name it is filed under was wrong.
+  Disposition: inline.
+- Onboarding gains a repair that rewrites the managed block of hooks it already installed.
+  Why: a hook pointing at a script that no longer exists fails silently, so nothing
+  reports which repositories stopped refreshing.
+  Disposition: inline.
+- The dotfiles fork of this tooling is retired rather than kept in parallel.
+  Why: one behavior with two implementations diverges, and the machines actually run the
+  dotfiles copy, so the pack fix is inert until the fork goes.
+  Disposition: issue (ConnorGriffin/dotfiles).
+- dotfiles issue 73 does not already cover the retirement.
+  Why: it moves the `codebase-memory` skill bundle to the public pack and is blocked by
+  skills#65; the private `scripts/cbm-onboard.sh`, `scripts/cbm-reindex.sh`, and
+  `tests/cbm-onboard.test.sh` are outside it.
+  Disposition: inline.
+
+- Skipping the refresh prints one line saying why; it never blocks the commit.
+  Why: silent skipping is the failure that hid dead hooks in the first place, and a line
+  of output costs a commit nothing.
+  Disposition: inline.
+- Repair is not a new mode. Re-running onboarding already rewrites its managed block, so
+  the work is teaching it to recognize the legacy unfenced marker as its own.
+  Why: the live hooks carry `# codebase-memory-mcp: reindex on commit (managed by
+  cbm-onboard - cbm-reindex)` rather than the pack's fence, so re-running today stacks a
+  second block instead of replacing it. No registry of enrolled repositories is invented.
+  Disposition: inline.
+- Repair takes over any block this tooling owns, legacy marker included, one repository
+  per run.
+  Why: it is what retires the fork on the machines, and it needs no new interface.
+  Disposition: inline.
+
+### Risk contract
+
+- **Must prevent:** deleting or truncating a hook the tooling does not own; leaving a
+  repository with two reindex blocks; filing a checkout's graph under any name other
+  than its deterministic identity; silent success after a failed or malformed index call.
+- **Must recover:** none automatically.
+- **Accepted failure:** an unresolvable identity, a missing binary, or a too-old binary
+  skips the refresh with one line on stderr and exits 0, so the commit still lands.
+- **Unsupported:** non-Git targets, foreign non-shell hooks, and Codebase Memory older
+  than the version the ephemeral lifecycle already requires.
+- **Evidence owed:** a commit in a linked worktree files under the deterministic name and
+  creates no path-derived project; a commit in a maintained checkout keeps its existing
+  derived name; re-running onboarding over a legacy-marker hook leaves exactly one block
+  and repoints it; a skipped refresh says so and still exits 0; a foreign hook is still
+  left unchanged.
+
+Why: the tooling writes into other repositories' hooks and into shared graph state, and
+both wrong-name filing and hook clobbering are silent until something else breaks.
+
+Disposition: inline in the work order.
+
+## Grounded facts
+
+- The pack's `skills/tools/cbm-onboard/scripts/cbm-reindex.sh` has no worktree guard at
+  all: it resolves `$PWD`'s toplevel and calls `index_repository` with `repo_path` only,
+  so Codebase Memory derives a path-named project.
+- Hooks install into `git-common-dir/hooks` (or `core.hooksPath`), which linked
+  worktrees share, so a commit inside a worktree fires them with the worktree as `$PWD`.
+- Every enrolled repository checked on this machine (`skills`, `dotfiles`, `brewgen`)
+  calls `<dotfiles>/scripts/cbm-reindex.sh`, not the
+  pack's copy. The two have forked; only the dotfiles copy has a guard, and it matches
+  `*/.claude/worktrees/*` and `*-wt`, never a worktree root outside those two shapes.
+- `the installed skill directory` is a symlink to the pack's source directory, so hooks
+  written against the installed path survive a move inside the source repository.
+- PR #12 (5a8ff31) deliberately made the hook reindex the checkout that fired it rather
+  than the main root.
+- `docs/scope/cbm-worktree-lifecycle.md` (issue 66) settled that maintained-checkout
+  onboarding keeps derived names and that the deterministic identity belongs to the
+  hookless ephemeral lifecycle.
+- A sweep on 2026-08-23 deleted 34 projects, 30 of them orphans whose checkout was gone.
+- The repository declares no `Harden:` line, so the ticket runs the default workflow.
+
+## Open questions
+
+- None. The frontier is empty.
+
+## Spawned tasks
+
+- Retire the dotfiles fork of cbm-onboard/cbm-reindex and repoint enrolled hooks at the
+  pack: filed as ConnorGriffin/dotfiles#76, blocked by this ticket. Disposition discharged.
+
+## Generated facts
+
+- `git --version` here is 2.50.1 (Apple Git-155).
+- Linked-checkout detection, run against a disposable repository plus one added
+  worktree, classified `main`, `main/sub`, `wt`, and `wt/sub` as
+  maintained/maintained/linked/linked:
+
+  ```sh
+  gd="$(git rev-parse --absolute-git-dir)"
+  cd_="$(git rev-parse --git-common-dir)"
+  case "$cd_" in /*) : ;; *) cd_="$(cd "$cd_" && pwd)" ;; esac
+  [ "$gd" = "$cd_" ] && echo maintained || echo linked
+  ```
+
+  Resolving a relative `--git-common-dir` against the toplevel instead of `$PWD`
+  misclassified `main/sub` as linked, so the relative case is resolved against `$PWD`.
+- Legacy-block recognition, run against a hook holding a user line, the dotfiles
+  marker comment, its invocation, and a trailing user line, left both user lines and
+  removed exactly the two managed lines:
+
+  ```sh
+  awk '
+    /^# codebase-memory-mcp: reindex on .* \(managed by cbm-onboard/ { skip=1; next }
+    skip == 1 { skip=0; if ($0 ~ /cbm-reindex\.sh/) next }
+    { print }
+  '
+  ```
+
+  An earlier unbounded form of this fragment, which cleared the skip only on the next
+  line matching the invocation, was refuted in review and must not be used. Against a
+  hook whose legacy invocation carried an extra argument, it kept that stale invocation
+  and deleted an unrelated `exec` line four lines further down, which is both a line the
+  tooling does not own and a second reindex block left behind. The bounded form above
+  was run against that same hook and against the plain legacy hook, and left every
+  unowned line intact in both.
+
+- The live hook this matches, in three enrolled repositories checked, is exactly:
+
+  ```sh
+  #!/bin/sh
+  # codebase-memory-mcp: reindex on commit (managed by cbm-onboard — cbm-reindex)
+  "<dotfiles>/scripts/cbm-reindex.sh"
+  ```

--- a/skills/tools/cbm-onboard/SKILL.md
+++ b/skills/tools/cbm-onboard/SKILL.md
@@ -41,7 +41,18 @@ directory containing several repositories.
    Linked worktrees share the control checkout's Git hooks; they cannot have
    independent hooks. Pass `--this-checkout` only to select the supplied
    checkout's `.cbmignore` and initial index. Hook installation still resolves
-   through Git's shared hooks directory.
+   through Git's shared hooks directory. When one of those shared hooks fires
+   from a linked worktree, it refreshes that worktree in fast mode under the
+   same deterministic identity used by the ephemeral lifecycle. It never falls
+   back to a path-derived project. A missing binary, an unsupported version, or
+   an identity that cannot be derived prints one reason and lets the Git
+   operation continue.
+
+   Re-run onboarding from the installed skill directory to repair an enrollment
+   whose managed hook points at a stale or foreign installation. Onboarding
+   replaces both its current fenced block and the older unfenced
+   `codebase-memory-mcp: reindex` marker, preserves every line it does not own,
+   and writes one managed block pointing at the installation that invoked it.
 
 3. For an ephemeral checkout, run the complete lifecycle:
 
@@ -90,10 +101,11 @@ directory containing several repositories.
 7. Tell the user that `.cbmignore` is tracked and should be committed. The Git
    hooks are clone-local, so rerun onboarding after a fresh clone.
 
-The initial index uses full mode. Maintained-checkout post-commit/post-merge/post-checkout
-indexing uses fast mode in a detached process and always exits 0, so a broken
-index never fails a commit, merge, or checkout. Re-running onboarding is
-idempotent.
+The initial index uses full mode. Post-commit/post-merge/post-checkout indexing
+uses fast mode in a detached process and always exits 0, so a broken index never
+fails a commit, merge, or checkout. Maintained checkouts keep their derived
+project name; linked worktrees use their deterministic lifecycle identity.
+Re-running onboarding is idempotent.
 
 Repositories dominated by YAML, prose, or shell may produce a thin graph; say
 so rather than refusing to index them.

--- a/skills/tools/cbm-onboard/SKILL.md
+++ b/skills/tools/cbm-onboard/SKILL.md
@@ -44,9 +44,9 @@ directory containing several repositories.
    through Git's shared hooks directory. When one of those shared hooks fires
    from a linked worktree, it refreshes that worktree in fast mode under the
    same deterministic identity used by the ephemeral lifecycle. It never falls
-   back to a path-derived project. A missing binary, an unsupported version, or
-   an identity that cannot be derived prints one reason and lets the Git
-   operation continue.
+   back to a path-derived project. Failed checkout classification, a missing
+   binary or detached launcher, an unsupported version, or an identity that
+   cannot be derived prints one reason and lets the Git operation continue.
 
    Re-run onboarding from the installed skill directory to repair an enrollment
    whose managed hook points at a stale or foreign installation. Onboarding

--- a/skills/tools/cbm-onboard/scripts/cbm-onboard.sh
+++ b/skills/tools/cbm-onboard/scripts/cbm-onboard.sh
@@ -213,6 +213,11 @@ for HOOK_NAME in post-commit post-merge post-checkout; do
       END {
         i = 1
         while (i <= n) {
+          if (lines[i] ~ /^# codebase-memory-mcp: reindex on .* \(managed by cbm-onboard/) {
+            i++
+            if (i <= n && lines[i] ~ /^"[^"]*\/cbm-reindex\.sh"[ \t]*$/) i++
+            continue
+          }
           if (lines[i] == begin) {
             found = 0
             for (j = i + 1; j <= n; j++) {

--- a/skills/tools/cbm-onboard/scripts/cbm-reindex.sh
+++ b/skills/tools/cbm-onboard/scripts/cbm-reindex.sh
@@ -4,10 +4,46 @@
 set -u
 
 BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true)}"
-[ -n "$BIN" ] && [ -x "$BIN" ] || exit 0
+[ -n "$BIN" ] && [ -x "$BIN" ] || {
+  printf '%s\n' "Codebase Memory refresh skipped: binary is not executable" >&2
+  exit 0
+}
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LIFECYCLE="$SCRIPT_DIR/cbm-lifecycle.py"
 
 ROOT="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD" && git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$ROOT" ] || exit 0
+
+GIT_DIR_ABS="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD" && git rev-parse --absolute-git-dir 2>/dev/null || true)"
+COMMON_DIR="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD" && git rev-parse --git-common-dir 2>/dev/null || true)"
+case "$COMMON_DIR" in
+  /*) : ;;
+  *) COMMON_DIR="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD/$COMMON_DIR" 2>/dev/null && pwd || true)" ;;
+esac
+
+if [ -n "$GIT_DIR_ABS" ] && [ -n "$COMMON_DIR" ] && [ "$GIT_DIR_ABS" != "$COMMON_DIR" ]; then
+  VERSION_TMP="$(mktemp 2>/dev/null || true)"
+  if [ -z "$VERSION_TMP" ] ||
+    ! "$BIN" --version >"$VERSION_TMP" 2>/dev/null ||
+    ! python3 "$LIFECYCLE" version "$VERSION_TMP" >/dev/null 2>&1; then
+    [ -z "$VERSION_TMP" ] || rm -f "$VERSION_TMP"
+    printf '%s\n' "Codebase Memory refresh skipped: binary version is unsupported" >&2
+    exit 0
+  fi
+  rm -f "$VERSION_TMP"
+  IDENTITY="$(unset GIT_DIR GIT_WORK_TREE; python3 "$LIFECYCLE" identity "$ROOT" 2>/dev/null || true)"
+  PROJECT="$(printf '%s' "$IDENTITY" | python3 -c \
+    'import json,sys; print(json.load(sys.stdin)["project"])' 2>/dev/null || true)"
+  [ -n "$PROJECT" ] || {
+    printf '%s\n' "Codebase Memory refresh skipped: worktree identity could not be derived" >&2
+    exit 0
+  }
+  nohup "$BIN" cli --json index_repository \
+    --repo-path "$ROOT" --mode fast --name "$PROJECT" \
+    >/dev/null 2>&1 </dev/null &
+  exit 0
+fi
 
 PAYLOAD="$(python3 -c \
   'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "fast"}))' \
@@ -15,3 +51,5 @@ PAYLOAD="$(python3 -c \
 
 nohup "$BIN" cli index_repository "$PAYLOAD" \
   >/dev/null 2>&1 </dev/null &
+
+exit 0

--- a/skills/tools/cbm-onboard/scripts/cbm-reindex.sh
+++ b/skills/tools/cbm-onboard/scripts/cbm-reindex.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
-# Reindex one maintained checkout in fast mode after a commit.
+# Reindex the checkout that fired a managed Git hook.
 
 set -u
 
 BIN="${CODEBASE_MEMORY_BIN:-$(command -v codebase-memory-mcp 2>/dev/null || true)}"
 [ -n "$BIN" ] && [ -x "$BIN" ] || {
   printf '%s\n' "Codebase Memory refresh skipped: binary is not executable" >&2
+  exit 0
+}
+LAUNCHER="$(command -v nohup 2>/dev/null || true)"
+[ -n "$LAUNCHER" ] && [ -x "$LAUNCHER" ] || {
+  printf '%s\n' "Codebase Memory refresh skipped: detached launcher is unavailable" >&2
   exit 0
 }
 
@@ -19,10 +24,14 @@ GIT_DIR_ABS="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD" && git rev-parse --absolut
 COMMON_DIR="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD" && git rev-parse --git-common-dir 2>/dev/null || true)"
 case "$COMMON_DIR" in
   /*) : ;;
-  *) COMMON_DIR="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD/$COMMON_DIR" 2>/dev/null && pwd || true)" ;;
+  *) COMMON_DIR="$(unset GIT_DIR GIT_WORK_TREE; cd "$PWD/$COMMON_DIR" 2>/dev/null && pwd -P || true)" ;;
 esac
+[ -n "$GIT_DIR_ABS" ] && [ -n "$COMMON_DIR" ] || {
+  printf '%s\n' "Codebase Memory refresh skipped: checkout classification failed" >&2
+  exit 0
+}
 
-if [ -n "$GIT_DIR_ABS" ] && [ -n "$COMMON_DIR" ] && [ "$GIT_DIR_ABS" != "$COMMON_DIR" ]; then
+if [ "$GIT_DIR_ABS" != "$COMMON_DIR" ]; then
   VERSION_TMP="$(mktemp 2>/dev/null || true)"
   if [ -z "$VERSION_TMP" ] ||
     ! "$BIN" --version >"$VERSION_TMP" 2>/dev/null ||
@@ -39,7 +48,7 @@ if [ -n "$GIT_DIR_ABS" ] && [ -n "$COMMON_DIR" ] && [ "$GIT_DIR_ABS" != "$COMMON
     printf '%s\n' "Codebase Memory refresh skipped: worktree identity could not be derived" >&2
     exit 0
   }
-  nohup "$BIN" cli --json index_repository \
+  "$LAUNCHER" "$BIN" cli --json index_repository \
     --repo-path "$ROOT" --mode fast --name "$PROJECT" \
     >/dev/null 2>&1 </dev/null &
   exit 0
@@ -49,7 +58,7 @@ PAYLOAD="$(python3 -c \
   'import json,sys; print(json.dumps({"repo_path": sys.argv[1], "mode": "fast"}))' \
   "$ROOT")" || exit 0
 
-nohup "$BIN" cli index_repository "$PAYLOAD" \
+"$LAUNCHER" "$BIN" cli index_repository "$PAYLOAD" \
   >/dev/null 2>&1 </dev/null &
 
 exit 0

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -482,6 +482,52 @@ raise SystemExit(exit_code)
         )
         self.assertNotIn("--name", requests[0])
 
+    def test_logical_checkout_path_is_still_classified_as_maintained(self):
+        self.seed_repository()
+        self.configure_lifecycle_binary()
+        logical_root = self.scratch / "logical checkout"
+        logical_root.symlink_to(self.repo, target_is_directory=True)
+        real_git = shutil.which("git")
+        self.assertIsNotNone(real_git)
+        shim_directory = self.scratch / "bin"
+        shim_directory.mkdir()
+        git_shim = shim_directory / "git"
+        git_shim.write_text(
+            f"""#!{sys.executable}
+import os
+import sys
+
+if "--show-toplevel" in sys.argv:
+    print({str(logical_root)!r})
+    raise SystemExit(0)
+if "--absolute-git-dir" in sys.argv:
+    print({str(self.repo.resolve() / '.git')!r})
+    raise SystemExit(0)
+if "--git-common-dir" in sys.argv:
+    print(".git")
+    raise SystemExit(0)
+os.execv({real_git!r}, [{real_git!r}, *sys.argv[1:]])
+""",
+            encoding="utf-8",
+        )
+        git_shim.chmod(0o755)
+        environment = self.environment | {
+            "PATH": f"{shim_directory}{os.pathsep}{self.environment['PATH']}",
+            "PWD": str(logical_root),
+        }
+
+        result = run([str(CBM_REINDEX)], cwd=logical_root, env=environment)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        requests = self.wait_for_requests(1)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0][:2], ["cli", "index_repository"])
+        self.assertEqual(
+            json.loads(requests[0][2]),
+            {"repo_path": str(logical_root), "mode": "fast"},
+        )
+        self.assertNotIn("--name", requests[0])
+
     def test_commit_lands_when_reindex_binary_is_missing_and_names_the_reason(self):
         self.seed_repository()
         self.configure_lifecycle_binary()
@@ -494,6 +540,61 @@ raise SystemExit(exit_code)
         self.assertEqual(
             committed.stderr.splitlines(),
             ["Codebase Memory refresh skipped: binary is not executable"],
+        )
+        self.assertEqual(self.issued(), [])
+
+    def test_reindex_names_a_missing_detached_launcher(self):
+        self.seed_repository()
+        self.configure_lifecycle_binary()
+        shim_directory = self.scratch / "bin"
+        shim_directory.mkdir()
+        for command in ("dirname", "git", "python3"):
+            executable = shutil.which(command)
+            self.assertIsNotNone(executable)
+            (shim_directory / command).symlink_to(executable)
+        environment = self.environment | {"PATH": str(shim_directory)}
+
+        result = run([str(CBM_REINDEX)], cwd=self.repo, env=environment)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stderr.splitlines(),
+            ["Codebase Memory refresh skipped: detached launcher is unavailable"],
+        )
+        self.assertEqual(self.issued(), [])
+
+    def test_reindex_skips_when_checkout_classification_fails(self):
+        self.seed_repository()
+        self.configure_lifecycle_binary()
+        real_git = shutil.which("git")
+        self.assertIsNotNone(real_git)
+        shim_directory = self.scratch / "bin"
+        shim_directory.mkdir()
+        git_shim = shim_directory / "git"
+        git_shim.write_text(
+            f"""#!{sys.executable}
+import os
+import sys
+
+if "--absolute-git-dir" in sys.argv:
+    raise SystemExit(1)
+os.execv({real_git!r}, [{real_git!r}, *sys.argv[1:]])
+""",
+            encoding="utf-8",
+        )
+        git_shim.chmod(0o755)
+        environment = self.environment | {
+            "PATH": f"{shim_directory}{os.pathsep}{self.environment['PATH']}"
+        }
+
+        result = run(
+            [str(CBM_REINDEX)], cwd=self.repo, env=environment
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stderr.splitlines(),
+            ["Codebase Memory refresh skipped: checkout classification failed"],
         )
         self.assertEqual(self.issued(), [])
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -23,6 +23,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 CBM_SCRIPT = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-onboard.sh"
+CBM_REINDEX = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-reindex.sh"
 CBM_TEARDOWN = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-teardown.sh"
 CBM_LIFECYCLE = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-lifecycle.py"
 SPIN_SCRIPT = ROOT / "skills" / "tools" / "spin-worktree" / "scripts" / "spin-worktree.py"
@@ -382,6 +383,172 @@ raise SystemExit(exit_code)
         self.binary.chmod(0o755)
         self.environment["CBM_FAKE_REQUESTS"] = str(self.requests)
         self.environment["CBM_FAKE_DELETE_STATE"] = str(self.scratch / "deleted")
+
+    def issued(self) -> list[list[str]]:
+        if not self.requests.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in self.requests.read_text(encoding="utf-8").splitlines()
+        ]
+
+    def wait_for_requests(self, count: int) -> list[list[str]]:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            requests = self.issued()
+            if len(requests) >= count:
+                return requests
+            time.sleep(0.01)
+        return self.issued()
+
+    def seed_repository(self):
+        run(["git", "config", "user.name", "Test User"], cwd=self.repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=self.repo)
+        (self.repo / "README.md").write_text("fixture\n", encoding="utf-8")
+        run(["git", "add", "README.md"], cwd=self.repo)
+        result = run(["git", "commit", "-m", "fixture"], cwd=self.repo)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def add_linked_worktree(self) -> Path:
+        worktree = self.scratch / "linked worktree"
+        result = run(
+            ["git", "worktree", "add", "-b", "fixture-worktree", str(worktree)],
+            cwd=self.repo,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return worktree
+
+    def install_reindex_hooks(self, environment=None):
+        result = run(
+            [str(CBM_SCRIPT), str(self.repo)],
+            cwd=ROOT,
+            env=(environment or self.environment) | {"CBM_SKIP_INDEX": "1"},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def commit_change(self, checkout: Path, message: str, environment=None):
+        (checkout / "README.md").write_text("changed\n", encoding="utf-8")
+        run(
+            ["git", "add", "README.md"],
+            cwd=checkout,
+            env=environment or self.environment,
+        )
+        return run(
+            ["git", "commit", "-m", message],
+            cwd=checkout,
+            env=environment or self.environment,
+        )
+
+    def test_worktree_commit_reindexes_once_under_its_deterministic_identity(self):
+        self.seed_repository()
+        worktree = self.add_linked_worktree()
+        self.configure_lifecycle_binary()
+        self.install_reindex_hooks()
+
+        committed = self.commit_change(worktree, "exercise reindex hook")
+
+        self.assertEqual(committed.returncode, 0, committed.stderr)
+        canonical = str(worktree.resolve())
+        expected_name = "cbm-onboard-v1-" + hashlib.sha256(os.fsencode(canonical)).hexdigest()
+        self.assertEqual(
+            self.wait_for_requests(1),
+            [[
+                "cli",
+                "--json",
+                "index_repository",
+                "--repo-path",
+                canonical,
+                "--mode",
+                "fast",
+                "--name",
+                expected_name,
+            ]],
+        )
+
+    def test_maintained_checkout_commit_keeps_derived_name_reindexing(self):
+        self.seed_repository()
+        self.configure_lifecycle_binary()
+        self.install_reindex_hooks()
+
+        committed = self.commit_change(self.repo, "exercise reindex hook")
+
+        self.assertEqual(committed.returncode, 0, committed.stderr)
+        requests = self.wait_for_requests(1)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0][:2], ["cli", "index_repository"])
+        self.assertEqual(
+            json.loads(requests[0][2]),
+            {"repo_path": str(self.repo.resolve()), "mode": "fast"},
+        )
+        self.assertNotIn("--name", requests[0])
+
+    def test_commit_lands_when_reindex_binary_is_missing_and_names_the_reason(self):
+        self.seed_repository()
+        self.configure_lifecycle_binary()
+        self.install_reindex_hooks()
+        self.binary.unlink()
+
+        committed = self.commit_change(self.repo, "exercise missing binary")
+
+        self.assertEqual(committed.returncode, 0, committed.stderr)
+        self.assertEqual(
+            committed.stderr.splitlines(),
+            ["Codebase Memory refresh skipped: binary is not executable"],
+        )
+        self.assertEqual(self.issued(), [])
+
+    def test_worktree_commit_skips_an_unsupported_binary_without_falling_back(self):
+        self.seed_repository()
+        worktree = self.add_linked_worktree()
+        self.configure_lifecycle_binary()
+        environment = self.environment | {"CBM_FAKE_VERSION": "codebase-memory-mcp 0.10.7"}
+        self.install_reindex_hooks(environment)
+
+        committed = self.commit_change(
+            worktree, "exercise unsupported binary", environment
+        )
+
+        self.assertEqual(committed.returncode, 0, committed.stderr)
+        self.assertEqual(
+            committed.stderr.splitlines(),
+            ["Codebase Memory refresh skipped: binary version is unsupported"],
+        )
+        self.assertEqual(self.issued(), [])
+
+    def test_worktree_commit_skips_when_identity_cannot_be_derived(self):
+        self.seed_repository()
+        worktree = self.add_linked_worktree()
+        self.configure_lifecycle_binary()
+        self.install_reindex_hooks()
+        shim_directory = self.scratch / "bin"
+        shim_directory.mkdir()
+        python_shim = shim_directory / "python3"
+        python_shim.write_text(
+            f"""#!{sys.executable}
+import os
+import sys
+
+if len(sys.argv) > 2 and sys.argv[1].endswith("cbm-lifecycle.py") and sys.argv[2] == "identity":
+    raise SystemExit(1)
+os.execv({sys.executable!r}, [{sys.executable!r}, *sys.argv[1:]])
+""",
+            encoding="utf-8",
+        )
+        python_shim.chmod(0o755)
+        environment = self.environment | {
+            "PATH": f"{shim_directory}{os.pathsep}{self.environment['PATH']}"
+        }
+
+        committed = self.commit_change(
+            worktree, "exercise missing identity helper", environment
+        )
+
+        self.assertEqual(committed.returncode, 0, committed.stderr)
+        self.assertEqual(
+            committed.stderr.splitlines(),
+            ["Codebase Memory refresh skipped: worktree identity could not be derived"],
+        )
+        self.assertEqual(self.issued(), [])
 
     def test_hookless_onboarding_indexes_exact_worktree_without_touching_hooks(self):
         run(["git", "config", "user.name", "Test User"], cwd=self.repo)
@@ -746,6 +913,77 @@ raise SystemExit(exit_code)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("refusing symlink without a regular-file target", result.stderr)
         self.assertFalse((self.scratch / "does-not-exist").exists())
+
+    def test_reonboarding_replaces_only_the_legacy_hook_block(self):
+        legacy_marker = (
+            "# codebase-memory-mcp: reindex on commit "
+            "(managed by cbm-onboard — cbm-reindex)"
+        )
+        legacy_script = self.scratch / "legacy install" / "cbm-reindex.sh"
+        unrelated_script = self.scratch / "other" / "cbm-reindex.sh"
+        cases = (
+            (f'"{legacy_script}"', (f'exec "{unrelated_script}"',)),
+            (
+                f'"{legacy_script}" --extra',
+                (f'"{legacy_script}" --extra', f'exec "{unrelated_script}"'),
+            ),
+        )
+
+        for invocation, preserved in cases:
+            with self.subTest(invocation=invocation):
+                hook = self.repo / ".git" / "hooks" / "post-commit"
+                hook.write_text(
+                    "#!/bin/sh\n"
+                    "printf 'before\\n'\n"
+                    f"{legacy_marker}\n"
+                    f"{invocation}\n"
+                    "printf 'after\\n'\n"
+                    f'exec "{unrelated_script}"\n',
+                    encoding="utf-8",
+                )
+                hook.chmod(0o755)
+
+                result = run(
+                    [str(CBM_SCRIPT), str(self.repo)],
+                    cwd=ROOT,
+                    env=self.environment | {"CBM_SKIP_INDEX": "1"},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                contents = hook.read_text(encoding="utf-8")
+                self.assertNotIn(legacy_marker, contents)
+                self.assertEqual(contents.count(BEGIN_HOOK), 1)
+                self.assertEqual(contents.count(f'"{CBM_REINDEX}"'), 1)
+                self.assertIn("printf 'before\\n'", contents)
+                self.assertIn("printf 'after\\n'", contents)
+                for line in preserved:
+                    self.assertIn(line, contents)
+
+    def test_repaired_legacy_hook_reindexes_the_next_commit(self):
+        self.seed_repository()
+        legacy_script = self.scratch / "legacy install" / "cbm-reindex.sh"
+        hook = self.repo / ".git" / "hooks" / "post-commit"
+        hook.write_text(
+            "#!/bin/sh\n"
+            "# codebase-memory-mcp: reindex on commit "
+            "(managed by cbm-onboard — cbm-reindex)\n"
+            f'"{legacy_script}"\n',
+            encoding="utf-8",
+        )
+        hook.chmod(0o755)
+        self.configure_lifecycle_binary()
+        self.install_reindex_hooks()
+
+        committed = self.commit_change(self.repo, "exercise repaired hook")
+
+        self.assertEqual(committed.returncode, 0, committed.stderr)
+        request = self.wait_for_requests(1)
+        self.assertEqual(len(request), 1)
+        self.assertEqual(
+            json.loads(request[0][2]),
+            {"repo_path": str(self.repo.resolve()), "mode": "fast"},
+        )
+
     def test_preserves_unmatched_markers_foreign_hook_and_is_idempotent(self):
         run(
             ["git", "config", "core.hooksPath", ".custom-hooks"],


### PR DESCRIPTION
## What changed

Codebase Memory's managed Git hooks now refresh the checkout that fired them under the project identity that checkout owns. Linked worktree commits stop minting path-named twin graphs, while maintained checkouts keep their existing derived-name refresh.

* Re-running onboarding replaces the older unfenced hook block with one block pointing at the installation that performed the repair, while preserving every hook line it does not own.
* A refresh that cannot classify the checkout, find its binary or detached launcher, support the identity lifecycle, or derive the worktree identity says why and lets the Git operation continue without a fallback request.
* Existing duplicate projects are not renamed, migrated, or deleted. The decision and consequences are recorded in ADR 59.

## Why

Linked worktrees share the maintained checkout's hooks, but the old refresh supplied only the firing path. Codebase Memory derived a second project from that path, while worktree teardown knew only the deterministic lifecycle identity and left the twin behind. Older enrollments could also keep calling a moved copy of the refresh command because onboarding did not recognize their unfenced marker as managed content.

## What to check

* One linked worktree commit produces one detached fast refresh under its deterministic identity and no path-derived request.
* One maintained checkout commit retains the existing detached fast request with derived naming.
* Repair leaves one managed block, preserves malformed and unrelated user lines, and the next commit refreshes again.
* Missing prerequisites and failed classification each produce one refusal line, no index request, and a successful Git operation.

## Verification

```
validated 27 skills and 273 files
Ran 299 tests in 92.238s
OK (skipped=23)
Ran 3 tests in 0.725s
OK
py_compile exit 0
Full review: 15 Standards rules and 9 Spec criteria checked across two rounds; original blocking findings fixed; Spec converged.
```

Fixes #59

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
