### PR TITLE
docs(ticket): take the four-part slice on single-projection evidence work

### DIFF
--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -49,6 +49,7 @@ the helper's `scan` command, not estimates.
 | 10 | Proof-bounded I:C history across an analyzer, server projections, generated fixtures, and a lifecycle-gated Diagnose revision | multiple artifacts, live run, lockstep copies, lifecycle-gated surface revision | slice into four serial chunks: analyzer, server contract, generated projections/evidence, then surface lock and browser evidence | 3 chunks; peaked 244k |
 | 90 | One shared behavioural judgment across model view, two server projections, generated fixtures and mirrors, and browser replay | multiple artifacts, live run, lockstep copies | slice into three serial chunks: source judgment, projection contracts, then generated artifacts and live replay | 2 chunks; peaked 231k |
 | 90 (skills) | A shared graph-identity interface, its ticket-workflow consumers, and the separately installed discovery policy, with argv and response shapes discovered by probing a live external CLI | multiple artifacts, lockstep copies | slice into two serial chunks: the ensure interface with its spiked contract tests, then the workflow pages and discovery policy that consume it | flat; peaked 243k in one session |
+| 79 (harmonic) | A server projection with identity and association semantics, a bounded registry/concurrency/cache-lifetime/HTTP contract, a shipped browser consumer, generated mirrors, and a closed recovery matrix run against an offline server | multiple artifacts, live run, lockstep copies | slice into four: projection core; registry/HTTP lifecycle; browser consumer; generated evidence and live replay | 2 chunks; server and surface chunks peaked 237k/242k, lifecycle peak 244k |
 
 When a ticket's traits match an anchor row, take that row's shape. When it sits
 between rows, say which two and pick the more conservative one.
@@ -109,10 +110,14 @@ chunk 1".
   with the operator and folds what the run exposes back into the code and the
   runbook.
 * When **multiple deliverable artifacts**, **live run inside the ticket**, and
-  **lockstep copies of one fact** all fire across multiple server projections,
-  keep projection integration separate from generated-artifact and browser
-  evidence: source judgment, projection contracts, then generated artifacts and
-  live replay.
+  **lockstep copies of one fact** all fire together, a server sub-order must not
+  own both domain projection/association semantics and registry, concurrency, or
+  cache-lifetime behavior, and a surface sub-order must not own both the shipped
+  consumer state machine and its generated fixture/mirror/recovery-matrix
+  evidence: slice into four — source/projection semantics, registry and
+  lifecycle contract, shipped consumer, then generated evidence and live
+  replay — folding a piece back into its neighbour only when it would fall
+  below the 120k floor.
 
 ## Orchestrator tier
 


### PR DESCRIPTION
## What changed

The ticket skill's slicing rubric now takes the four-part split whenever multiple deliverable artifacts, a live run, and lockstep copies of one fact fire together, keeping projection semantics separate from registry/lifecycle behavior and the shipped consumer separate from generated evidence; before, that rule only applied when the work spanned multiple server projections. The harmonic ticket-79 measurement joins the anchor table as the evidence behind the change.

* Harmonic 79 ran as two chunks and both blew the degradation band (peaks near 240k against a 180k target), which is the shape the old wording permitted on single-projection work.
* The generalized rule keeps its escape: a piece that would fall below the 120k floor folds back into its neighbour instead of forcing four undersized chunks.
* No thresholds move. Both measured tickets held the 180k band and 120k floor; the misses were shape, not calibration constants.
* The remaining calibration from the issue (the lockstep trait reword and the skills-90 anchor) already landed in #111; the telemetry id collision landed in #114.

## Why

Two finalized tickets measured the same failure from opposite directions: a chunked order still degraded and a flat order under-sliced, both because the rubric's four-part split was gated on a precondition (multiple projections) the work did not meet. The measured actuals and the drafted amendment are in issue 99.

## What to check

* The new anchor row's figures match the actuals recorded on the issue.
* The rewritten chunk-shape bullet reads as one rule: four-part split by default, fold-back only below the floor.
* The trait table is untouched.

## Verification

```
Ran 299 tests in 163.780s
FAILED (failures=1, skipped=23)
Ran 38 tests in 7.673s (tests.test_ticket)
OK
py_compile exit 0
```

The one failure asserts the history validator's exit code and does not come from this diff: an unpushed sibling ticket branch in the local shared object store carries an unredacted path the validator rejects, and any local checkout of this repo currently fails the same way. CI clones do not contain that branch, so the check of record is the PR's own CI run.

Fixes #99

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
