### PR TITLE
feat(codebase-memory): let activation target a versioned settings file

### DIFF
--- a/docs/scope/cbm-explicit-settings-target.md
+++ b/docs/scope/cbm-explicit-settings-target.md
@@ -1,0 +1,71 @@
+# Scope — explicit settings target for Codebase Memory activation
+
+Ticket: [#76](https://github.com/ConnorGriffin/skills/issues/76)
+Route: interview mode (a concrete plan exists, untested).
+
+## Decisions
+
+- Flag name is `--settings-file`, taking a path. Why: mirrors `--claude-home`'s
+  noun-for-what-it-names style and reads as the file it writes. `inline`
+- Hook files and rendered hook commands stay rooted in `--claude-home` regardless of
+  `--settings-file`. Why: the ticket's consumer versions settings only; hooks must
+  still execute from the live Claude home. `inline`
+- Symlink refusal applies to whichever settings path is selected, default or
+  explicit, and the default path keeps its current message text. Why: the existing
+  test pins that message, and weakening symlink protection is the one thing the
+  ticket forbids. `inline`
+- A missing parent directory of an explicit `--settings-file` is a no-write refusal
+  naming the missing directory, not a created tree. Why: the caller already owns the
+  versioned checkout, and creating directories outside the Claude home is the one way
+  this option could write somewhere unintended. `inline`
+- An explicit target's parent must exist, be a directory, and pass
+  `os.access(parent, W_OK | X_OK)`; symlinks are resolved when judging the parent,
+  and only the final settings node must be a regular non-symlink file. Why: review
+  reproduced that a 0o600 directory passes `is_dir` and `W_OK` yet raises
+  PermissionError on both lstat and mkstemp after the hook files are already written,
+  and a settings file reached through a symlinked checkout is the ticket's main
+  audience. `inline`
+- Verification compares validate.py's `ERROR:` lines against a captured origin/main
+  baseline, not exit codes. Why: this clone is known-red from a sibling branch's
+  commits, and validate.py accumulates all errors behind one exit 1, so a new error
+  would hide. `inline`
+- Change record: `docs/adr` tree exists but this is an additive option under the
+  interface ADR 65 already settled; no new ADR. Why: nothing hard-to-reverse is
+  being decided beyond the flag itself. `inline`
+
+### Risk contract
+
+- **Must prevent:** writing through a symlink at either settings target; clobbering
+  unrelated settings or unrelated hook registrations; changing behavior of the
+  existing no-option command.
+- **Must recover:** nothing automatically; the installer is a one-shot command.
+- **Accepted failure:** any refusal (symlink, malformed JSON, conflicting managed
+  registration, unwritable target) is a clear stop with no partial write, recovered
+  by the operator fixing the target and rerunning.
+- **Unsupported:** creating a settings file's parent directory tree, non-regular
+  settings targets, and settings files the installer does not own the hooks block of.
+- **Evidence owed:** through the copy-runnable installer interface — an explicit
+  target outside the Claude home, preservation of unrelated settings at that target,
+  idempotent rerun byte-stability, unchanged default-path behavior, and symlink
+  refusal at the explicit target.
+
+Why: the installer edits live agent configuration on a real machine; a bad write is
+recoverable by hand but a followed symlink is not contained.
+Disposition: copy into the work order at admission.
+
+## Open questions
+
+- none open. Q1 (parent-directory behavior) settled as a refusal, above.
+
+## Review
+
+- Two cold panels against the draft order; three blockers in round one (baseline-red
+  verification gate, unwritable-parent partial install, no-referent change record),
+  three in round two (search-bit-less parent, unspecified symlinked-parent branch,
+  failure-level rather than line-level baseline comparison). All six reproduced
+  independently before acting; all `authoring`, none `injected`. Order rewritten clean
+  after round one, patched after round two.
+
+## Spawned tasks
+
+- none

--- a/skills/tools/codebase-memory/SKILL.md
+++ b/skills/tools/codebase-memory/SKILL.md
@@ -29,6 +29,21 @@ unrelated settings and hook registrations. Malformed settings, conflicting
 registrations, symlinks, and unowned managed-path files are no-write failures.
 Its scope is the bundled files and registrations.
 
+To merge the registrations into a settings file kept outside the Claude home, for
+example one versioned in a dotfiles checkout:
+
+```sh
+python3 <installed-skill>/scripts/install.py --claude-home PATH \
+  --settings-file PATH/TO/settings.json
+```
+
+`--settings-file` moves only the settings file. The three hook files, and the
+paths rendered into the registrations, still follow `--claude-home`. The named
+target must be a regular non-symlink file, and its parent directory must already
+exist, be a directory, and be writable and searchable; a symlinked target or an
+unusable parent is a no-write failure. A parent reached through a symlinked
+directory is fine, which is how a versioned checkout is usually wired.
+
 ## Graph-query vocabulary
 
 - `list_projects` and `index_status` report indexed-project inventory and health.

--- a/skills/tools/codebase-memory/scripts/install.py
+++ b/skills/tools/codebase-memory/scripts/install.py
@@ -38,6 +38,15 @@ def arguments() -> argparse.Namespace:
         default=Path.home() / ".claude",
         help="Claude Code home directory (default: $HOME/.claude)",
     )
+    parser.add_argument(
+        "--settings-file",
+        type=Path,
+        default=None,
+        help=(
+            "settings file to merge registrations into "
+            "(default: <claude-home>/settings.json)"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -127,12 +136,23 @@ def merge_settings(existing: dict, canonical: dict) -> dict:
 
 
 def main() -> int:
-    claude_home = arguments().claude_home.expanduser().absolute()
+    options = arguments()
+    claude_home = options.claude_home.expanduser().absolute()
     hooks_directory = claude_home / "hooks"
-    settings_path = claude_home / "settings.json"
+    if options.settings_file is None:
+        settings_path = claude_home / "settings.json"
+        settings_label = "settings.json"
+    else:
+        settings_path = options.settings_file.expanduser().absolute()
+        settings_label = str(settings_path)
+        container = settings_path.parent
+        if not container.is_dir() or not os.access(container, os.W_OK | os.X_OK):
+            raise SystemExit(
+                f"settings file needs an existing writable directory: {container}"
+            )
     settings_stat = lstat_or_none(settings_path)
     if settings_stat is not None and not stat.S_ISREG(settings_stat.st_mode):
-        raise SystemExit("settings.json must be a regular non-symlink file")
+        raise SystemExit(f"{settings_label} must be a regular non-symlink file")
     hooks_stat = lstat_or_none(hooks_directory)
     if hooks_stat is not None and not stat.S_ISDIR(hooks_stat.st_mode):
         raise SystemExit("hooks must be a real non-symlink directory")
@@ -174,7 +194,7 @@ def main() -> int:
             settings = json.loads(settings_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as error:
             raise SystemExit(
-                f"settings.json is not valid JSON: {error.msg}"
+                f"{settings_label} is not valid JSON: {error.msg}"
             ) from error
         settings_mode = stat.S_IMODE(settings_stat.st_mode)
     else:

--- a/tests/test_codebase_memory_install.py
+++ b/tests/test_codebase_memory_install.py
@@ -48,14 +48,21 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
     def tearDown(self):
         self.temporary.cleanup()
 
-    def install(self, claude_home: Path | None = None) -> subprocess.CompletedProcess[str]:
+    def install(
+        self,
+        claude_home: Path | None = None,
+        settings_file: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            "python3",
+            str(INSTALLER),
+            "--claude-home",
+            str(claude_home or self.claude_home),
+        ]
+        if settings_file is not None:
+            command += ["--settings-file", str(settings_file)]
         return subprocess.run(
-            [
-                "python3",
-                str(INSTALLER),
-                "--claude-home",
-                str(claude_home or self.claude_home),
-            ],
+            command,
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,
@@ -139,6 +146,114 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
             for path in [settings_path, *sorted((self.claude_home / "hooks").iterdir())]
         }
         self.assertEqual(second_bytes, first_bytes)
+
+    def test_explicit_settings_target_takes_the_registrations_alone(self):
+        versioned = self.scratch / "dotfiles"
+        versioned.mkdir()
+        settings_path = versioned / "settings.json"
+
+        result = self.install(settings_file=settings_path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        hooks = self.claude_home / "hooks"
+        for name in (
+            "cbm-code-discovery-gate",
+            "cbm-session-reminder",
+            "cbm-code-discovery-reminder.md",
+        ):
+            self.assertTrue((hooks / name).is_file(), name)
+        self.assertFalse((self.claude_home / "settings.json").exists())
+
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        commands = [
+            hook["command"]
+            for entries in settings["hooks"].values()
+            for entry in entries
+            for hook in entry["hooks"]
+        ]
+        self.assertTrue(commands)
+        for command in commands:
+            self.assertTrue(command.startswith(f"{hooks}/"), command)
+        self.assertEqual(settings_path.stat().st_mode & 0o777, 0o600)
+
+    def test_explicit_settings_target_is_merged_and_reruns_are_byte_stable(self):
+        versioned = self.scratch / "dotfiles"
+        versioned.mkdir()
+        settings_path = versioned / "settings.json"
+        original = {
+            "model": "opus",
+            "hooks": {"Stop": [{"hooks": [{"type": "command", "command": "stop-hook"}]}]},
+        }
+        settings_path.write_text(json.dumps(original), encoding="utf-8")
+
+        first = self.install(settings_file=settings_path)
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        merged = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertEqual(merged["model"], "opus")
+        self.assertEqual(merged["hooks"]["Stop"], original["hooks"]["Stop"])
+        self.assertIn("SessionStart", merged["hooks"])
+        first_bytes = settings_path.read_bytes()
+
+        second = self.install(settings_file=settings_path)
+
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(settings_path.read_bytes(), first_bytes)
+
+    def test_explicit_settings_target_installs_through_a_symlinked_directory(self):
+        real = self.scratch / "checkout"
+        real.mkdir()
+        link = self.scratch / "linked-checkout"
+        link.symlink_to(real, target_is_directory=True)
+
+        result = self.install(settings_file=link / "settings.json")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        settings = json.loads((real / "settings.json").read_text(encoding="utf-8"))
+        self.assertIn("SessionStart", settings["hooks"])
+
+    def test_symlinked_explicit_settings_target_fails_before_any_write(self):
+        versioned = self.scratch / "dotfiles"
+        versioned.mkdir()
+        external = self.scratch / "external-settings.json"
+        original = b'{"external": true}\n'
+        external.write_bytes(original)
+        settings_path = versioned / "settings.json"
+        settings_path.symlink_to(external)
+
+        result = self.install(settings_file=settings_path)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be a regular non-symlink file", result.stderr)
+        self.assertIn(str(settings_path), result.stderr)
+        self.assertTrue(settings_path.is_symlink())
+        self.assertEqual(external.read_bytes(), original)
+        self.assertFalse((self.claude_home / "hooks").exists())
+
+    def test_an_unusable_explicit_parent_is_a_no_write_failure(self):
+        cases = ["missing", "regular-file", "mode-500", "mode-600"]
+        for name in cases:
+            with self.subTest(parent=name):
+                claude_home = self.scratch / f"claude-home-{name}"
+                container = self.scratch / f"container-{name}"
+                if name == "regular-file":
+                    container.write_text("not a directory", encoding="utf-8")
+                elif name != "missing":
+                    container.mkdir()
+                    container.chmod(0o500 if name == "mode-500" else 0o600)
+                settings_path = container / "settings.json"
+
+                try:
+                    result = self.install(claude_home, settings_file=settings_path)
+                finally:
+                    if name in ("mode-500", "mode-600"):
+                        container.chmod(0o700)
+
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn(str(container), result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+                self.assertFalse((claude_home / "hooks").exists())
+                self.assertFalse(settings_path.exists())
 
     def test_malformed_settings_fail_before_any_write(self):
         self.claude_home.mkdir()
@@ -491,6 +606,7 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
         self.assertNotIn("Use `index_repository` only", skill)
         self.assertIn("~/.claude/skills/codebase-memory/reminder.md", profile)
         self.assertIn("python3 ~/.claude/skills/codebase-memory/scripts/install.py", readme)
+        self.assertIn("--settings-file", skill)
         self.assertIn("portable skill-owned hooks", overlay.lower())
         self.assertIn('"tools/codebase-memory"', validator)
         self.assertIn("tests.test_codebase_memory_install", workflow)


### PR DESCRIPTION
## What changed

Codebase Memory activation can now be told which settings file to merge its hook
registrations into, so someone who keeps Claude settings in a versioned checkout gets
a complete activation from the command instead of copying the registrations across by
hand afterwards. Before, the registrations always landed in the settings file inside
the Claude home being activated.

* Only the settings file moves. The three hook files, and the paths rendered into the
  registrations, still follow the Claude home, so the hooks keep executing from the
  live home while their registrations sit in the versioned copy.
* The no-option command is unchanged in every respect, including the wording of its
  refusal to write through a symlinked settings file.
* A named settings file must be a real file whose containing directory already exists
  and is both writable and searchable. Activation does not create that directory, and
  a directory reached through a symlink is accepted, which is how a versioned checkout
  is usually wired.

## Why

A directory that is writable but not searchable passes the checks an installer would
naturally make and then raises on the first attempt to stat the file inside it. That
attempt happens after the three hook files are already on disk, so without the search
bit in the check, a bad path leaves activation half-applied and prints a traceback.
Refusing before the first write is what keeps every failure a no-write failure. The
decisions behind the option are recorded in the scope ledger under `docs/scope/`.

## What to check

* The no-option command behaves as it does on `main`, creating the Claude home when
  absent and emitting the unchanged symlink refusal.
* With a named settings file, the hooks land in the Claude home, the registrations
  land in the named file pointing back inside the Claude home, and no settings file
  appears in the Claude home.
* A symlink at either settings target, and each of the four unusable containing
  directories, exits nonzero having written nothing anywhere.

## Verification

```
validated 27 skills and 274 files
Ran 307 tests in 264.850s
OK (skipped=23)
Ran 20 tests in 8.074s (tests.test_codebase_memory_install)
OK
py_compile exit 0
```

The installer suite went from 15 tests to 20. `origin/main` was run in the same clone
first as a baseline and started red (three history-validator errors plus one test
failing behind them), then went green partway through when an unrelated branch sharing
this clone moved and took the offending commits out of reach. Neither state came from
this diff: the validator is byte-identical on both sides of it.

Fixes #76

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
