### PR TITLE
fix(cbm): let a consumer skip settings.json and detect $HOME hook takeover

### DIFF
--- a/docs/scope/cbm-hook-name-takeover.md
+++ b/docs/scope/cbm-hook-name-takeover.md
@@ -1,0 +1,148 @@
+# Codebase Memory hook-name takeover
+
+Issue [#110](https://github.com/ConnorGriffin/skills/issues/110).
+
+## Decisions
+
+- Classify issue #110 as code work delivered through a pull request. The fix changes
+  `skills/tools/codebase-memory/scripts/install.py` and its tests. `inline`
+- Treat the ticket's "any future install or upgrade silently rewrites the hook names"
+  premise as refuted for `codebase-memory-mcp` 0.10.8. Its own installer refuses to
+  rewrite hook files it does not own and says so. `inline`
+- Keep both existing guards intact. ADR 65 settled that a conflicting registration
+  stops before any write and leaves manual recovery to the operator; the fix may not
+  convert either guard into an automatic repair without superseding that decision.
+  `inline`
+- Exclude installing, upgrading, or configuring `codebase-memory-mcp` from this work.
+  ADR 65's scope doc already lists that as unsupported. `inline`
+
+## Grounding evidence (verified live this session, 2026-08-23)
+
+- External tool version on this machine: `codebase-memory-mcp 0.10.8`, at
+  `$HOME/.local/bin/codebase-memory-mcp`. It ships `install`, `update`, and
+  `uninstall` subcommands, so its config pass reruns on upgrade.
+- `codebase-memory-mcp install --dry-run -n` against the real Claude home reports both
+  managed names "would be skipped — the file there is not ours (modified, or written by
+  another install), so the rewrite is refused and existing hook entries are left
+  untouched". The takeover is not silent at this version.
+- A clean external install into a scratch HOME writes three hook files:
+  `cbm-code-discovery-gate`, `cbm-session-reminder`, and `cbm-subagent-reminder`. The
+  first two collide with the pack's managed names; the third does not.
+- The external hook files carry no pack ownership text. Their own headers read
+  `# codebase-memory-mcp search augmenter (Claude Code PreToolUse).` and
+  `# SessionStart context adapter installed by codebase-memory-mcp.`
+- The external tool registers its hooks as `"$HOME/.claude/hooks/<name>"` — a literal
+  shell variable inside double quotes — across `PreToolUse` (Grep|Glob),
+  `PostToolUse` (Read), `SessionStart` (startup/resume/clear/compact), and
+  `SubagentStart`. The ticket recorded a `~/.claude/hooks/...` form, so both forms
+  exist across versions.
+- Reproduced, external-first ordering, pack installer second: it stops at the first
+  guard with `managed target is not owned: <path>/hooks/cbm-code-discovery-gate`,
+  exit 1, nothing written.
+- Reproduced, foreign hook files moved aside, foreign registrations left in place: the
+  pack installer **exits 0 and prints success**, leaving the foreign
+  `"$HOME/..."` entries beside its own absolute-path entries. Result: the Grep|Glob
+  gate and all four SessionStart reminders are registered twice, plus an orphaned
+  `PostToolUse` Read entry and a `SubagentStart` entry the pack neither owns nor
+  reports. The registration-conflict guard never fires, because `command_target()`
+  expands `~` but not `$HOME`, so the foreign command resolves to a path under the
+  process working directory instead of the managed target.
+- That silent success contradicts ADR 65's own risk contract, which lists "reporting
+  success after partial, conflicting, or non-executable activation" under
+  **Must prevent**.
+- Real machine state right now: `~/.claude/settings.json` carries pack-only cbm
+  registrations and both installed hook files carry the pack ownership marker. The
+  manual repair held; the defect is latent here, not active.
+- Baseline verification on the ticket branch is green: `python3 scripts/validate.py`
+  exits 0, `tests.test_codebase_memory_install` runs 15 tests OK.
+- `.agents/` and `.claude/` are gitignored; CI regenerates the vendored copy with the
+  skills CLI before its `cmp` gate, so no vendored copy is edited by this work.
+- The repo has no `Harden:` line in `CLAUDE.md` repo facts, so the hardening profile
+  is unavailable for this ticket.
+
+- Ship an installer option that skips the `settings.json` merge and still installs the
+  three managed hook files. A consumer that owns its own settings needs the pack's
+  hooks without the pack's registrations; skipping both would leave the installer
+  nothing to do. User decision. `inline`
+- Correct the collision source: the tilde registrations came from the private
+  `dotfiles` repo's `claude/settings.json`, added in `ea8f2f4`, not from the external
+  tool. `inline`
+- Change `dotfiles` to drop its own Codebase Memory registrations and call the pack
+  installer instead, which also means it stops symlinking `claude/settings.json` (the
+  installer refuses a symlinked settings file). User decision.
+  `→ issue`
+- Fix the registration matcher to resolve `$HOME` and `${HOME}`, so a foreign
+  registration in that form is visible to the conflict guard instead of silently
+  passing. Not a mechanism choice: silent success is on ADR 65's must-prevent list.
+  `inline`
+- Name `codebase-memory-mcp` and the repair in the not-owned error, rather than
+  printing only the path. That is the ticket's actual ask. `inline`
+- Keep the fix inside the existing installer interface. No new command, no reclaim
+  path, no rename of the managed hook names. `inline`
+
+### Risk contract
+
+- **Must prevent:** reporting success after a partial or conflicting activation;
+  clobbering hook registrations the pack does not own; following a symlink at a
+  managed path into an external target.
+- **Must recover:** every managed-file and settings write stays atomic and converges
+  on rerun without duplicate registrations.
+- **Accepted failure:** a foreign owner at a managed hook path, or a conflicting
+  registration, stops before any write, exits non-zero naming the exact path and the
+  likely owner, and leaves repair to the operator.
+- **Unsupported:** installing, upgrading, or configuring `codebase-memory-mcp`;
+  reclaiming or rewriting another tool's hook files or registrations; concurrent
+  mutation of the selected Claude home while the installer runs.
+- **Evidence owed:** the skip-settings option installs the managed files and leaves
+  `settings.json` byte-identical; a `"$HOME/..."` registration at a managed target is
+  detected as a conflict and stops before any write; the not-owned failure names the
+  likely owner; existing clean-install, idempotence, and no-write failure behavior is
+  unchanged.
+
+Why: the installer writes user configuration at a trust boundary, and the pack is
+consumed by machines the author does not control.
+
+Disposition: copy unchanged into the issue #110 work order.
+
+## Spike
+
+Ran against the real registration forms with `HOME` set to the operator's home, comparing today's
+`command_target` to the candidate that adds `os.path.expandvars`:
+
+| Registration form | Today | With `expandvars` |
+|---|---|---|
+| `$HOME_ABS/.claude/hooks/cbm-code-discovery-gate` (an absolute path) | match | match |
+| `~/.claude/hooks/cbm-code-discovery-gate` | match | match |
+| `"$HOME/.claude/hooks/cbm-code-discovery-gate"` | **no match** | match |
+| `${HOME}/.claude/hooks/cbm-code-discovery-gate` | **no match** | match |
+| `"$UNSET_VAR/.claude/hooks/cbm-code-discovery-gate"` | no match | no match |
+
+Today's unresolved results are also unstable: `abspath` resolves them against the
+process working directory, so the same settings file compares differently depending
+on where the installer was invoked from.
+
+## Open questions
+
+- None.
+
+## Spawned tasks
+
+- A `dotfiles` issue to drop its Codebase Memory registrations and call the pack
+  installer. Pending.
+
+## Review rounds
+
+- Panel 1 was not cold: agent spawning is disabled in this session, so the order's
+  author reviewed it and the pass is recorded as non-independent. Three blockers, all
+  `authoring`: the admitted risk contract was never copied into the order; the order
+  justified keeping the not-owned message's first line on an assertion that does not
+  exist (`test_every_non_regular_or_unowned_managed_node_is_a_no_write_failure` checks
+  only the exit status and an unchanged external target); and the list of guards
+  surviving `--skip-settings` omitted the hooks-directory symlink check that
+  `test_symlinked_hooks_directory_fails_without_writing_through_it` pins. Delta
+  re-check caught one fix that silently failed to apply and reapplied it. Injected
+  blockers: zero.
+- Noted, not blocking: `--skip-settings` ships without a first caller, since `dotfiles`
+  will call the installer rather than use the flag. The charter's rule against building
+  a seam before the second caller exists would forbid it; the user asked for it on the
+  public pack's behalf, so it is a recorded decision rather than an objection.

--- a/skills/tools/codebase-memory/SKILL.md
+++ b/skills/tools/codebase-memory/SKILL.md
@@ -44,6 +44,27 @@ exist, be a directory, and be writable and searchable; a symlinked target or an
 unusable parent is a no-write failure. A parent reached through a symlinked
 directory is fine, which is how a versioned checkout is usually wired.
 
+For a consumer that manages its own `settings.json` hook registrations, add
+`--skip-settings`:
+
+```sh
+python3 <installed-skill>/scripts/install.py --claude-home PATH --skip-settings
+```
+
+This installs the three managed hook files and stops there: it does not read,
+parse, validate, merge, or write `settings.json` at all. The consumer owns
+registering the installed hooks in its own settings. All the other guards
+still run: source ownership, the hooks-directory symlink check, and the
+unowned-managed-file check. `--skip-settings` and `--settings-file` name two
+different settings targets, so the installer refuses both together at the
+command-line level rather than picking one.
+
+The external tool `codebase-memory-mcp` installs its own hooks at two of the
+same names (`cbm-code-discovery-gate`, `cbm-session-reminder`). Activation does
+not reclaim a name another tool already owns; it stops and names the likely
+owner and the repair (move the foreign files out of `hooks/`, remove that
+tool's registrations from `settings.json`, then rerun).
+
 ## Graph-query vocabulary
 
 - `list_projects` and `index_status` report indexed-project inventory and health.

--- a/skills/tools/codebase-memory/scripts/install.py
+++ b/skills/tools/codebase-memory/scripts/install.py
@@ -38,13 +38,25 @@ def arguments() -> argparse.Namespace:
         default=Path.home() / ".claude",
         help="Claude Code home directory (default: $HOME/.claude)",
     )
-    parser.add_argument(
+    settings_target = parser.add_mutually_exclusive_group()
+    settings_target.add_argument(
         "--settings-file",
         type=Path,
         default=None,
         help=(
             "settings file to merge registrations into "
             "(default: <claude-home>/settings.json)"
+        ),
+    )
+    settings_target.add_argument(
+        "--skip-settings",
+        action="store_true",
+        help=(
+            "Install the managed hook files only; do not read, parse, validate, "
+            "merge, or write settings.json. For a consumer that owns its own "
+            "hook registrations. Not allowed together with --settings-file: a "
+            "named settings target is meaningless when no settings file is "
+            "touched at all."
         ),
     )
     return parser.parse_args()
@@ -80,7 +92,30 @@ def command_target(command: object) -> str | None:
         return None
     if not words:
         return None
-    return os.path.abspath(os.path.expanduser(words[0]))
+    return os.path.abspath(os.path.expandvars(os.path.expanduser(words[0])))
+
+
+def unresolved_managed_reference(command: object) -> str | None:
+    """Detect a registration whose target still contains an unresolved
+    variable (an unset one, since $HOME/${HOME} now resolve above) but whose
+    final path component names a managed file. Such a registration cannot be
+    matched to a resolved target, so it must fail closed as a conflict rather
+    than silently pass the merge as an unrelated command.
+    """
+    if not isinstance(command, str):
+        return None
+    try:
+        words = shlex.split(command)
+    except ValueError:
+        return None
+    if not words:
+        return None
+    expanded = os.path.expandvars(os.path.expanduser(words[0]))
+    if "$" not in expanded:
+        return None
+    if os.path.basename(expanded) not in MANAGED_FILES:
+        return None
+    return command
 
 
 def merge_settings(existing: dict, canonical: dict) -> dict:
@@ -108,6 +143,14 @@ def merge_settings(existing: dict, canonical: dict) -> dict:
             entry_hooks = entry.get("hooks", [])
             if not isinstance(entry_hooks, list):
                 raise ValueError(f"settings hooks.{event} entry hooks must be an array")
+            for hook in entry_hooks:
+                if not isinstance(hook, dict):
+                    continue
+                unresolved = unresolved_managed_reference(hook.get("command"))
+                if unresolved is not None:
+                    raise ValueError(
+                        f"conflicting managed hook registration for {unresolved}"
+                    )
             managed_targets = {
                 command_target(hook.get("command"))
                 for hook in entry_hooks
@@ -138,21 +181,26 @@ def merge_settings(existing: dict, canonical: dict) -> dict:
 def main() -> int:
     options = arguments()
     claude_home = options.claude_home.expanduser().absolute()
+    skip_settings = options.skip_settings
     hooks_directory = claude_home / "hooks"
-    if options.settings_file is None:
-        settings_path = claude_home / "settings.json"
-        settings_label = "settings.json"
-    else:
-        settings_path = options.settings_file.expanduser().absolute()
-        settings_label = str(settings_path)
-        container = settings_path.parent
-        if not container.is_dir() or not os.access(container, os.W_OK | os.X_OK):
-            raise SystemExit(
-                f"settings file needs an existing writable directory: {container}"
-            )
-    settings_stat = lstat_or_none(settings_path)
-    if settings_stat is not None and not stat.S_ISREG(settings_stat.st_mode):
-        raise SystemExit(f"{settings_label} must be a regular non-symlink file")
+    settings_path = None
+    settings_label = None
+    settings_stat = None
+    if not skip_settings:
+        if options.settings_file is None:
+            settings_path = claude_home / "settings.json"
+            settings_label = "settings.json"
+        else:
+            settings_path = options.settings_file.expanduser().absolute()
+            settings_label = str(settings_path)
+            container = settings_path.parent
+            if not container.is_dir() or not os.access(container, os.W_OK | os.X_OK):
+                raise SystemExit(
+                    f"settings file needs an existing writable directory: {container}"
+                )
+        settings_stat = lstat_or_none(settings_path)
+        if settings_stat is not None and not stat.S_ISREG(settings_stat.st_mode):
+            raise SystemExit(f"{settings_label} must be a regular non-symlink file")
     hooks_stat = lstat_or_none(hooks_directory)
     if hooks_stat is not None and not stat.S_ISDIR(hooks_stat.st_mode):
         raise SystemExit("hooks must be a real non-symlink directory")
@@ -174,7 +222,23 @@ def main() -> int:
                     f"managed target must be a regular non-symlink file: {destination}"
                 )
             if OWNERSHIP.encode() not in destination.read_bytes():
-                raise SystemExit(f"managed target is not owned: {destination}")
+                raise SystemExit(
+                    f"managed target is not owned: {destination} "
+                    "(codebase-memory-mcp is known to install its own hooks at "
+                    "this name; move its files out of the hooks directory, "
+                    "remove its registrations from settings.json, then rerun)"
+                )
+
+    if skip_settings:
+        claude_home.mkdir(parents=True, exist_ok=True)
+        hooks_directory.mkdir(exist_ok=True)
+        for name, (planned_content, mode) in planned_files.items():
+            atomic_write(hooks_directory / name, planned_content, mode)
+        print(
+            f"Installed codebase-memory discovery hook files in {claude_home}; "
+            "no settings.json registrations were written."
+        )
+        return 0
 
     template = json.loads(
         (SKILL_DIRECTORY / "config" / "claude-settings.json").read_text(

--- a/tests/test_codebase_memory_install.py
+++ b/tests/test_codebase_memory_install.py
@@ -550,6 +550,268 @@ class CodebaseMemoryInstallTests(unittest.TestCase):
         self.assertTrue(all(item.stdout == expected_reminder for item in outputs[1:]))
         self.assertFalse((self.scratch / "SHOULD_NOT_EXIST").exists())
 
+    def test_skip_settings_with_settings_file_is_a_clean_argparse_error(self):
+        before = filesystem_snapshot(self.scratch)
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(INSTALLER),
+                "--claude-home",
+                str(self.claude_home),
+                "--settings-file",
+                str(self.scratch / "elsewhere-settings.json"),
+                "--skip-settings",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("not allowed with argument", result.stderr)
+        self.assertEqual(filesystem_snapshot(self.scratch), before)
+
+    def test_skip_settings_installs_hooks_without_touching_absent_settings(self):
+        result = subprocess.run(
+            [
+                "python3",
+                str(INSTALLER),
+                "--claude-home",
+                str(self.claude_home),
+                "--skip-settings",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        hooks = self.claude_home / "hooks"
+        gate = hooks / "cbm-code-discovery-gate"
+        session = hooks / "cbm-session-reminder"
+        reminder = hooks / "cbm-code-discovery-reminder.md"
+        for path in (gate, session, reminder):
+            self.assertTrue(path.is_file(), path)
+            self.assertIn(OWNERSHIP, path.read_text(encoding="utf-8"))
+        self.assertTrue(os.access(gate, os.X_OK))
+        self.assertTrue(os.access(session, os.X_OK))
+        self.assertFalse((self.claude_home / "settings.json").exists())
+
+    def test_skip_settings_leaves_an_existing_settings_file_byte_identical(self):
+        self.claude_home.mkdir()
+        settings_path = self.claude_home / "settings.json"
+        original = (
+            json.dumps(
+                {
+                    "model": "opus",
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Write|Edit",
+                                "hooks": [{"type": "command", "command": "unrelated-hook"}],
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n"
+        ).encode()
+        settings_path.write_bytes(original)
+        settings_path.chmod(0o640)
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(INSTALLER),
+                "--claude-home",
+                str(self.claude_home),
+                "--skip-settings",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(settings_path.read_bytes(), original)
+        self.assertEqual(settings_path.stat().st_mode & 0o777, 0o640)
+        hooks = self.claude_home / "hooks"
+        for name in (
+            "cbm-code-discovery-gate",
+            "cbm-session-reminder",
+            "cbm-code-discovery-reminder.md",
+        ):
+            self.assertTrue((hooks / name).is_file())
+
+    def test_skip_settings_still_fails_without_writes_on_an_unowned_hook_file(self):
+        self.claude_home.mkdir()
+        hooks = self.claude_home / "hooks"
+        hooks.mkdir()
+        foreign = hooks / "cbm-code-discovery-gate"
+        foreign.write_text("not managed", encoding="utf-8")
+        before = filesystem_snapshot(self.claude_home)
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(INSTALLER),
+                "--claude-home",
+                str(self.claude_home),
+                "--skip-settings",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("managed target is not owned", result.stderr)
+        self.assertFalse((self.claude_home / "settings.json").exists())
+        self.assertEqual(filesystem_snapshot(self.claude_home), before)
+
+    def test_dollar_home_registration_target_is_a_conflict(self):
+        home = self.scratch / "home"
+        claude_home = home / ".claude"
+        claude_home.mkdir(parents=True)
+        settings_path = claude_home / "settings.json"
+        dollar_home = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Grep|Glob",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": '"$HOME/.claude/hooks/cbm-code-discovery-gate"',
+                                "timeout": 5,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        original = (json.dumps(dollar_home) + "\n").encode()
+        settings_path.write_bytes(original)
+        environment = os.environ.copy()
+        environment["HOME"] = str(home)
+
+        result = subprocess.run(
+            ["python3", str(INSTALLER), "--claude-home", str(claude_home)],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("conflicting managed hook registration", result.stderr)
+        self.assertEqual(settings_path.read_bytes(), original)
+        self.assertFalse((claude_home / "hooks").exists())
+
+    def test_braced_dollar_home_registration_target_is_a_conflict(self):
+        home = self.scratch / "home"
+        claude_home = home / ".claude"
+        claude_home.mkdir(parents=True)
+        settings_path = claude_home / "settings.json"
+        braced_home = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Grep|Glob",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "${HOME}/.claude/hooks/cbm-code-discovery-gate",
+                                "timeout": 5,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        original = (json.dumps(braced_home) + "\n").encode()
+        settings_path.write_bytes(original)
+        environment = os.environ.copy()
+        environment["HOME"] = str(home)
+
+        result = subprocess.run(
+            ["python3", str(INSTALLER), "--claude-home", str(claude_home)],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("conflicting managed hook registration", result.stderr)
+        self.assertEqual(settings_path.read_bytes(), original)
+        self.assertFalse((claude_home / "hooks").exists())
+
+    def test_unresolvable_variable_registration_at_a_managed_name_is_a_conflict(self):
+        self.claude_home.mkdir()
+        settings_path = self.claude_home / "settings.json"
+        unresolvable = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Grep|Glob",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": '"$SOME_UNSET_VARIABLE/.claude/hooks/cbm-code-discovery-gate"',
+                                "timeout": 5,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        original = (json.dumps(unresolvable) + "\n").encode()
+        settings_path.write_bytes(original)
+        environment = os.environ.copy()
+        environment.pop("SOME_UNSET_VARIABLE", None)
+
+        result = subprocess.run(
+            ["python3", str(INSTALLER), "--claude-home", str(self.claude_home)],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("conflicting managed hook registration", result.stderr)
+        self.assertEqual(settings_path.read_bytes(), original)
+        self.assertFalse((self.claude_home / "hooks").exists())
+
+    def test_not_owned_failure_names_the_offending_path_and_the_likely_owner(self):
+        self.claude_home.mkdir()
+        hooks = self.claude_home / "hooks"
+        hooks.mkdir()
+        foreign = hooks / "cbm-code-discovery-gate"
+        foreign.write_text("not managed", encoding="utf-8")
+
+        result = self.install()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(str(foreign), result.stderr)
+        self.assertIn("codebase-memory-mcp", result.stderr)
+
     def test_copied_skill_uses_home_for_the_default_claude_home(self):
         home = self.scratch / "home"
         installed_skill = home / ".claude" / "skills" / "codebase-memory"


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## What changed

A machine that manages its own Claude Code settings can now turn on this pack's
code-discovery hooks without handing the pack its `settings.json`. Run the
installer with a new `--skip-settings` flag and it places the three hook files
and stops there. It never reads, edits, or writes `settings.json`, so a
consumer that registers those hooks itself keeps full control of its own
configuration file.

Separately, the installer's take-over guard is now sharper. The external
`codebase-memory-mcp` tool registers its own hooks under the same two names
this pack uses, and it writes that registration as `"$HOME/.claude/hooks/..."`
(a literal shell variable) rather than a plain path. The installer's
conflict check used to miss that form entirely, so it could report success
while quietly leaving both the pack's hook and the foreign one registered side
by side. It now resolves `$HOME`/`${HOME}` the same way it already resolves
`~`, so that registration is caught as a conflict and the install stops before
writing anything, exactly like the existing guard already does for other
conflicting registrations. A registration whose target still can't be resolved
(an unset variable) but whose file name matches one of ours now also stops the
install rather than passing through unnoticed.

Last, when the installer finds a hook file at one of its three managed names
that it doesn't own, the failure message now says plainly that
`codebase-memory-mcp` is a known tool that takes over those same names, and
what to do about it (move the foreign files aside, remove that tool's
registrations from `settings.json`, then rerun), instead of printing a bare
file path and leaving the operator to work that out themselves.

Nothing about the two existing safety guards changed: a conflicting
registration or an unowned hook file still stops before any file is written,
exactly as before.

`--skip-settings` lands beside the recently added `--settings-file` (naming a
settings target outside the Claude home). The two are mutually exclusive: a
named settings target is meaningless when no settings file is touched at all,
so passing both together is a plain argparse error and writes nothing.

## Why

Documented in `docs/scope/cbm-hook-name-takeover.md`, written for issue #110.
On a machine where both this pack and `codebase-memory-mcp` are installed, the
external tool's hook registration used a form our installer's matcher didn't
recognize, so a manual repair (moving files aside, hand-editing
`settings.json`) was needed to get a clean install, and nothing in the tool
said why. The fix lets a consumer sidestep the collision entirely by managing
its own registrations, and makes the collision itself loud and actionable when
it does happen.

## What to check

- Run `python3 skills/tools/codebase-memory/scripts/install.py --claude-home
  <scratch-dir> --skip-settings` against a directory that already has an
  unrelated `settings.json` in place: the three hook files land, and that
  file stays untouched, byte for byte.
- Point a `settings.json` at `"$HOME/.claude/hooks/cbm-code-discovery-gate"`
  and run the installer (no `--skip-settings`); it exits non-zero with
  `conflicting managed hook registration`, and nothing on disk changes.
- Put an unowned file at one of the three managed hook names and run the
  installer: the error now names both the file and `codebase-memory-mcp`.
- Pass `--skip-settings` and `--settings-file` together: argparse rejects the
  combination before anything runs.

## Verification

```
$ python3 scripts/validate.py
validated 27 skills and 275 files

$ /opt/homebrew/bin/python3.14 -m unittest tests.test_behavior tests.test_pr_body \
    tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket \
    tests.test_codebase_memory_install
Ran 312 tests in 70.429s

OK (skipped=23)

$ python3 -m py_compile skills/tools/codebase-memory/scripts/install.py
(silent, exit 0)
```

The system `python3` on the machine that ran this is 3.9.6; 32 tests in
`test_behavior` use `TemporaryDirectory(ignore_cleanup_errors=)`, which needs
3.10+, so the unittest run above used `/opt/homebrew/bin/python3.14` (CI runs
3.12). `validate.py` and `py_compile` ran under the system `python3`.

Fixes #110.
