### PR TITLE
fix(ui-craft): run CLIs through a symlinked skill directory

### DIFF
--- a/docs/scope/108-route-main-guard-symlink.md
+++ b/docs/scope/108-route-main-guard-symlink.md
@@ -22,6 +22,13 @@
 - Profile: none. No `Harden:` line in the repo's `CLAUDE.md` repo facts. `inline`
 - Surface lifecycle: none. CLI script; `CLAUDE.md` declares `ui-surfaces: none`. `inline`
 
+- Q1 fix shape settled by the user: **A** — extract one shared predicate into
+  `skills/drivers/ui-craft/scripts/lib/main-guard.mjs` and migrate all four call
+  sites (`route.mjs`, `critique-storage.mjs`, `context-signals.mjs`,
+  `context.mjs`). Why: three copies of one predicate already exist in that
+  directory and the fourth has drifted into a broken variant, which is the
+  divergence the charter's reuse rule names. `inline`
+
 ### Risk contract
 
 - **Must prevent:** a CLI in this pack exiting 0 with no output when it was asked
@@ -39,7 +46,7 @@
 
 ## Open questions
 
-- Q1 fix shape (below), pending user.
+- none. Q1 settled (see Decisions).
 
 ## Spawned tasks
 

--- a/docs/scope/108-route-main-guard-symlink.md
+++ b/docs/scope/108-route-main-guard-symlink.md
@@ -1,0 +1,46 @@
+# Scope — 108 route.mjs main-guard under a symlinked skill dir
+
+## Decisions
+
+- Route: interview mode. One bounded fix-shape decision; everything else is
+  grounded and reproduced. `inline`
+- Bug confirmed live, not from docs: through a symlinked `ui-craft` directory,
+  `node .../scripts/route.mjs --embodiment greenfield ...` prints nothing and
+  exits 0; the same command on the real path prints
+  `{"mode":"lock","reason":"the app has no shipped embodiment"}`. `inline`
+- Three working copies of the same predicate already exist in the same scripts
+  directory: `critique-storage.mjs` `isMainModule()` (realpath, with a
+  `pathToFileURL` fallback and a comment naming the symlink cause),
+  `context-signals.mjs` and `context.mjs` `invokedAsScript()` (realpath,
+  byte-identical to each other). `route.mjs` is the only raw-string comparison
+  left. `inline`
+- `skills/drivers/ui-craft/scripts/lib/` is the established home for shared
+  helpers in this skill (5 modules today). `inline`
+- Existing route.mjs coverage (`tests/test_behavior.py:1163`) invokes the script
+  by its real path from repo root, so it passes today and can never catch this;
+  new evidence must invoke through a symlink. `inline`
+- Profile: none. No `Harden:` line in the repo's `CLAUDE.md` repo facts. `inline`
+- Surface lifecycle: none. CLI script; `CLAUDE.md` declares `ui-surfaces: none`. `inline`
+
+### Risk contract
+
+- **Must prevent:** a CLI in this pack exiting 0 with no output when it was asked
+  to do work — the silent-incorrect-success default, and the exact defect here.
+- **Must recover:** nothing automatic. The script is a one-shot read-only router.
+- **Accepted failure:** on a platform where `realpathSync` throws, the guard falls
+  back to a URL comparison and, failing that, does not run; a clear no-op the
+  operator sees, not a wrong route.
+- **Unsupported:** invocation shapes other than `node <path> <flags>` — no
+  `npx`, no shell wrapper, no Windows guarantee beyond the fallback.
+- **Evidence owed:** `route.mjs` invoked through a symlinked skill directory
+  prints route JSON and exits 0/2 exactly as the real-path invocation does.
+- **Why:** the failure is silent and already cost a live triage run a detour.
+- **Disposition:** `inline` — copy into the work order.
+
+## Open questions
+
+- Q1 fix shape (below), pending user.
+
+## Spawned tasks
+
+- none

--- a/docs/scope/108-route-main-guard-symlink.md
+++ b/docs/scope/108-route-main-guard-symlink.md
@@ -131,3 +131,35 @@ Round 2 — same reviewer, re-checking only round 1's deltas as fresh attack sur
 
 Injected blockers by round: 0, then 2. The climb is the rewrite-clean signal, and
 round 2's fixes are confined to the two steps that produced them.
+
+Round 3 — the cap. Spent on round 2's deltas, because round 2's fixes had changed
+the helper's semantics rather than only a test.
+
+* Blockers: 1, `injected`, and it retracted round 2's own second blocker. The
+  trailing-separator normalization guards a state that cannot occur: Node resolves
+  and normalizes the entry path before the module sees it, so `process.argv[1]`
+  never carries a trailing separator. Reproduced independently on this machine's
+  Node 26.7.0 — `node probe.mjs`, `node probe.mjs/`, and `node probe.mjs//` all
+  report the same normalized path. `detect-antipatterns.mjs:49` is therefore dead
+  code, and round 2's fix accommodated a clause that should have been deleted.
+* Resolution taken, rather than a fourth round: delete the normalization, and delete
+  line 49 as dead code while naming the invariant that makes its state unreachable,
+  which is what this repo's charter requires of a guard removal. The trailing-
+  separator test pair is kept and reframed — it no longer claims to prove a
+  normalization the helper does not perform; it pins the invariant the deletion
+  rests on, and fails loudly if a future runtime stops normalizing. The order also
+  gained a boundary forbidding the guard from being re-added.
+* Supporting evidence gathered here, not from the reviewer: line 49 arrived in a
+  bulk categorization commit (`3bc9c25`, #56) with no recorded rationale, and the
+  repo's CI pins no Node version.
+* Residual, stated rather than hidden: the invariant was measured on Node 26.7.0
+  and no Node 20 runtime was available on this machine. The step 5 pair is what
+  converts that gap from an assumption into a test.
+* Notes: 0 new. Deltas B and D were confirmed clean.
+* The reviewer also closed the false-TRUE question I could not settle by
+  construction: `argv[1]` is the path Node resolved for the entry it loaded, so a
+  realpath match implies the module is the entry at all five call sites.
+
+Injected blockers by round: 0, 2, 1 — and round 3's retracted round 2's. Reviewing
+stopped at the cap with the order rewritten to the simpler shape rather than the
+accommodating one.

--- a/docs/scope/108-route-main-guard-symlink.md
+++ b/docs/scope/108-route-main-guard-symlink.md
@@ -92,3 +92,42 @@ the draft.
   sent back for attack on the scope and cost axes.
 
 Order rewritten clean rather than patched.
+
+Round 2 — same reviewer, re-checking only round 1's deltas as fresh attack surface.
+
+* Blockers: 2, both tagged `injected` — each was introduced by a round-1 fix, not
+  present in the original draft.
+  * The differential-parity idiom that replaced the golden literals (the reviewer's
+    own round-1 recommendation) is satisfied by two silent runs: if the migrated
+    guard never fires, both halves produce empty stdout and exit 0, so the test
+    passes green while four of the five CLIs are dead. Fixed by asserting the
+    real-path run's stdout is non-empty before comparing the pair — which pins that
+    the CLI ran, not what it printed, so it still invents no baseline.
+  * Folding in the fifth call site would have deleted
+    `detect-antipatterns.mjs:49`, the trailing-separator spelling
+    (`...endsWith('detect-antipatterns.mjs/')`), with nothing naming the invocation
+    shape it exists for. `node <path>/detect-antipatterns.mjs/ --help` works today.
+    `realpath` of `file/` resolves on darwin but raises `ENOTDIR` on some platforms,
+    where the fallback would compare `file:///…mjs/` against `file:///…mjs` and
+    reintroduce this ticket's defect at a new site. Fixed in the helper rather than
+    only in a test: strip a trailing separator before comparing. Spiked and executed
+    — all four shapes (real path and symlink, each with and without the trailing
+    separator) fire, and the fallback compare holds once stripped.
+* Notes: 1, `injected`. The `--help` justification cited
+  `detector/cli/main.mjs:137`, which only computes the flag; handling is at 164, and
+  lines 149 and 155 read from `process.cwd()` first, so the invocation is
+  cwd-sensitive and the same-cwd requirement is load-bearing rather than incidental.
+  Corrected, with the writes-nothing claim re-grounded (no write call exists
+  anywhere in the detector tree).
+* One reviewer claim was checked and did not reproduce on first run — that all four
+  pinned invocations emit output today. Re-run without the quoting artifact in the
+  probe, all four do. Claim upheld, not forwarded on the strength of the first
+  reading.
+* The fifth call site was attacked on the scope and cost axes as asked and cleared:
+  a genuine fifth copy of the same predicate, one constant plus one test pair of
+  marginal diff, and `detect.mjs` reaches `detectCli` by dynamic import with
+  `argv[1]` pointing at `detect.mjs`, which is false under both the old and new
+  predicates.
+
+Injected blockers by round: 0, then 2. The climb is the rewrite-clean signal, and
+round 2's fixes are confined to the two steps that produced them.

--- a/docs/scope/108-route-main-guard-symlink.md
+++ b/docs/scope/108-route-main-guard-symlink.md
@@ -163,3 +163,17 @@ the helper's semantics rather than only a test.
 Injected blockers by round: 0, 2, 1 — and round 3's retracted round 2's. Reviewing
 stopped at the cap with the order rewritten to the simpler shape rather than the
 accommodating one.
+
+## Implementation notes (added by `/ticket start`)
+
+* Correction to the Decisions entry above: `route.mjs` was **not** the only raw
+  string comparison left in that scripts directory. `detect-csp.mjs:195` is a sixth
+  main guard, spelled as the same loose suffix match plus trailing-separator clause
+  that this ticket deleted from `detect-antipatterns.mjs`. It is outside this
+  order's enumerated five sites, so it was left alone rather than migrated in
+  flight; it is carried in the pull request body as a known issue and wants its own
+  ticket. Recorded here so the next reader does not conclude the directory is
+  single-sourced.
+* The trailing-separator test pair needed the separator appended as a string, after
+  pathlib: `Path(...).joinpath('x.mjs/')` strips it, which had quietly made the pair
+  a byte-identical rerun of the plain case and left the invariant unpinned.

--- a/docs/scope/108-route-main-guard-symlink.md
+++ b/docs/scope/108-route-main-guard-symlink.md
@@ -66,3 +66,29 @@ with a `pathToFileURL` fallback and an `argv[1]` absent guard:
 | no `process.argv[1]` (`node --input-type=module -e`) | returns false, no throw |
 
 All four passed. The literal the order carries is that predicate, not prose.
+
+## Review rounds
+
+Round 1 — one cold panel (`/plan-review`, ordinary stakes), reviewer had no hand in
+the draft.
+
+* Grounding: clean. Every cited line number, path, module list, quoted command, and
+  pinned output literal was independently reproduced, including the bug itself.
+* Blockers: 1, tagged `authoring`. Step 5 demanded the three migrated CLIs "still
+  produce existing output" when no baseline exists for any of them — zero test
+  coverage outside `route.mjs` — so the executing agent would have had to invent
+  golden literals for three previously untested commands, one of which emits
+  absolute paths. Fixed by making step 5 differential: same invocation, real path
+  versus symlink, assert equality. No goldens.
+* Notes: 2, both `authoring`. The Done-when `import.meta.url` grep was not
+  mechanically satisfiable (10 hits before and after the fix, 6 of them legitimate
+  directory resolution) — replaced with two greps that genuinely flip. And step 1's
+  comment spec dropped the why-not-`endsWith` rationale that step 3 told the agent
+  to delete from `context.mjs:945-947`.
+* Injected blockers: 0.
+* Found by the reviewer, outside the original scope: a fifth copy of the predicate
+  at `detector/detect-antipatterns.mjs:48`, using the loose suffix match
+  `context.mjs` warns against. Not symlink-broken. Folded into the migration and
+  sent back for attack on the scope and cost axes.
+
+Order rewritten clean rather than patched.

--- a/docs/scope/108-route-main-guard-symlink.md
+++ b/docs/scope/108-route-main-guard-symlink.md
@@ -51,3 +51,18 @@
 ## Spawned tasks
 
 - none
+
+## Spike — the guard predicate, executed
+
+Run in the session scratchpad (not on the branch: triage writes no shipping code).
+A four-case harness over the proposed `isMainModule(moduleUrl)` — realpath compare
+with a `pathToFileURL` fallback and an `argv[1]` absent guard:
+
+| Case | Result |
+|---|---|
+| invoked by its real path | runs |
+| invoked through a symlinked skill directory | runs |
+| imported by another module, not the entry point | does not run |
+| no `process.argv[1]` (`node --input-type=module -e`) | returns false, no throw |
+
+All four passed. The literal the order carries is that predicate, not prose.

--- a/skills/drivers/ui-craft/scripts/context-signals.mjs
+++ b/skills/drivers/ui-craft/scripts/context-signals.mjs
@@ -19,10 +19,10 @@
 import fs from 'node:fs';
 import net from 'node:net';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { loadContext, extractRegister } from './context.mjs';
 import { getCritiqueDir } from './lib/impeccable-paths.mjs';
+import { isMainModule } from './lib/main-guard.mjs';
 
 /** Is there code here at all, or just context files / an empty repo? */
 function hasCode(cwd) {
@@ -210,16 +210,6 @@ async function cli() {
   process.stdout.write(`${JSON.stringify(signals, null, 2)}\n`);
 }
 
-function invokedAsScript() {
-  const arg = process.argv[1];
-  if (!arg) return false;
-  try {
-    return fs.realpathSync(arg) === fs.realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
-}
-
-if (invokedAsScript()) {
+if (isMainModule(import.meta.url)) {
   cli();
 }

--- a/skills/drivers/ui-craft/scripts/context.mjs
+++ b/skills/drivers/ui-craft/scripts/context.mjs
@@ -21,6 +21,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseTargetOptions } from './lib/target-args.mjs';
+import { isMainModule } from './lib/main-guard.mjs';
 
 const PRODUCT_NAMES = ['PRODUCT.md', 'Product.md', 'product.md'];
 const DESIGN_NAMES = ['DESIGN.md', 'Design.md', 'design.md'];
@@ -942,20 +943,6 @@ function buildTargetSelectionDirective(selection) {
   );
 }
 
-// Run cli() only when this module is the entry point. Compare realpaths
-// rather than endsWith(): a loose suffix match also fires for unrelated
-// scripts like `load-context.mjs`, and realpath tolerates symlinked
-// invocation (the test harness symlinks the skill dir).
-function invokedAsScript() {
-  const arg = process.argv[1];
-  if (!arg) return false;
-  try {
-    return fs.realpathSync(arg) === fs.realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
-}
-
-if (invokedAsScript()) {
+if (isMainModule(import.meta.url)) {
   cli();
 }

--- a/skills/drivers/ui-craft/scripts/critique-storage.mjs
+++ b/skills/drivers/ui-craft/scripts/critique-storage.mjs
@@ -27,8 +27,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
 import { getCritiqueDir } from './lib/impeccable-paths.mjs';
+import { isMainModule } from './lib/main-guard.mjs';
 
 const SLUG_MAX = 50;
 
@@ -222,21 +222,6 @@ function main(argv) {
   }
 }
 
-function isMainModule() {
-  if (!process.argv[1]) return false;
-  try {
-    return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(process.argv[1]);
-  } catch {
-    // pathToFileURL normalizes Windows paths; keep it as a fallback for any
-    // environment where realpath is unavailable.
-    return import.meta.url === pathToFileURL(process.argv[1]).href;
-  }
-}
-
-// Why the realpath check: generated skills are often reached through symlinked
-// harness directories (for example a demo repo's `.agents` -> source `.agents`).
-// Node resolves import.meta.url to the real file, while process.argv[1] keeps
-// the symlink path. Comparing canonical paths prevents a silent exit-0 no-op.
-if (isMainModule()) {
+if (isMainModule(import.meta.url)) {
   main(process.argv.slice(2));
 }

--- a/skills/drivers/ui-craft/scripts/detector/detect-antipatterns.mjs
+++ b/skills/drivers/ui-craft/scripts/detector/detect-antipatterns.mjs
@@ -9,6 +9,7 @@
  */
 
 import { detectCli } from './cli/main.mjs';
+import { isMainModule } from '../lib/main-guard.mjs';
 
 export { ANTIPATTERNS, RULE_ENGINE_SUPPORT, getAntipattern, getRulesForCategory, getRuleEngineSupport } from './registry/antipatterns.mjs';
 export { SAFE_TAGS, BORDER_SAFE_TAGS, OVERUSED_FONTS, GENERIC_FONTS, KNOWN_SERIF_FONTS } from './shared/constants.mjs';
@@ -45,6 +46,4 @@ export {
 } from './node/file-system.mjs';
 export { formatFindings, detectCli } from './cli/main.mjs';
 
-const isMainModule = process.argv[1]?.endsWith('detect-antipatterns.mjs') ||
-  process.argv[1]?.endsWith('detect-antipatterns.mjs/');
-if (isMainModule) detectCli();
+if (isMainModule(import.meta.url)) detectCli();

--- a/skills/drivers/ui-craft/scripts/lib/main-guard.mjs
+++ b/skills/drivers/ui-craft/scripts/lib/main-guard.mjs
@@ -1,0 +1,28 @@
+/**
+ * Decide whether a module is the process entry point ("was I run directly?").
+ *
+ * Why realpath on both sides: skill directories are reached through symlinks
+ * (the normal install path links the pack into the agent's skills directory).
+ * Node resolves `import.meta.url` to the real file while `process.argv[1]`
+ * keeps the symlink path, so a raw string comparison is false through a link
+ * and the CLI exits 0 without ever running — a silent no-op, not an error.
+ *
+ * Why realpath rather than `endsWith()`: a loose suffix match also fires for an
+ * unrelated script whose filename ends the same way (`load-context.mjs` for
+ * `context.mjs`), running the wrong CLI.
+ */
+
+import fs from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export function isMainModule(moduleUrl) {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return fs.realpathSync(entry) === fs.realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    // pathToFileURL normalizes Windows paths; keep it as a fallback for any
+    // environment where realpath is unavailable.
+    return moduleUrl === pathToFileURL(entry).href;
+  }
+}

--- a/skills/drivers/ui-craft/scripts/lib/main-guard.mjs
+++ b/skills/drivers/ui-craft/scripts/lib/main-guard.mjs
@@ -8,8 +8,8 @@
  * and the CLI exits 0 without ever running — a silent no-op, not an error.
  *
  * Why realpath rather than `endsWith()`: a loose suffix match also fires for an
- * unrelated script whose filename ends the same way (`load-context.mjs` for
- * `context.mjs`), running the wrong CLI.
+ * unrelated script whose filename ends the same way (any `*-context.mjs` would
+ * satisfy an `endsWith('context.mjs')` test), running the wrong CLI.
  */
 
 import fs from 'node:fs';

--- a/skills/drivers/ui-craft/scripts/route.mjs
+++ b/skills/drivers/ui-craft/scripts/route.mjs
@@ -1,3 +1,5 @@
+import { isMainModule } from './lib/main-guard.mjs';
+
 const VALID_EMBODIMENTS = new Set(['greenfield', 'shipped']);
 const VALID_DECLARATIONS = new Set(['absent', 'complete', 'incomplete', 'ambiguous']);
 const VALID_RUNNABILITY = new Set(['runnable', 'unavailable']);
@@ -64,7 +66,7 @@ function parseArgs(argv) {
   };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   try {
     const result = routeSurface(parseArgs(process.argv.slice(2)));
     process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3488,16 +3488,22 @@ class UiCraftCliMainGuardTests(unittest.TestCase):
                 self.assertEqual(result.returncode, exit_code, result.stderr)
                 self.assertEqual(json.loads(result.stdout)["mode"], mode)
 
-    def assert_symlink_parity(self, parts: tuple[str, ...], arguments: list[str]):
+    def assert_symlink_parity(
+        self, parts: tuple[str, ...], arguments: list[str], suffix: str = ""
+    ):
         """One read-only invocation run twice: by real path, then through the link.
 
         Non-emptiness is load-bearing. Bare parity is satisfied by two silent
         runs, so a guard that never fires would pass this test green — the very
         defect being repaired.
+
+        `suffix` is appended to the path as a string, after pathlib is done with
+        it: pathlib strips a trailing separator, which would silently turn the
+        trailing-separator case into a rerun of the plain one.
         """
         real, linked = self.script(*parts)
-        real_run = run(["node", str(real), *arguments], cwd=self.workdir)
-        linked_run = run(["node", str(linked), *arguments], cwd=self.workdir)
+        real_run = run(["node", f"{real}{suffix}", *arguments], cwd=self.workdir)
+        linked_run = run(["node", f"{linked}{suffix}", *arguments], cwd=self.workdir)
         self.assertTrue(real_run.stdout.strip(), real_run.stderr)
         self.assertEqual(linked_run.stdout, real_run.stdout, linked_run.stderr)
         self.assertEqual(linked_run.returncode, real_run.returncode, linked_run.stderr)
@@ -3520,7 +3526,9 @@ class UiCraftCliMainGuardTests(unittest.TestCase):
         `process.argv[1]` never carries a trailing separator. If a future runtime
         stops normalizing, this fails loudly instead of exiting 0 in silence.
         """
-        self.assert_symlink_parity(("detector", "detect-antipatterns.mjs/"), ["--help"])
+        self.assert_symlink_parity(
+            ("detector", "detect-antipatterns.mjs"), ["--help"], suffix="/"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3439,5 +3439,89 @@ class ReviewRouteResolverTests(unittest.TestCase):
             self.assertTrue(row["for"].strip())
 
 
+class UiCraftCliMainGuardTests(unittest.TestCase):
+    """Every ui-craft CLI runs the same way through a symlinked skill directory.
+
+    Skill packs are installed by symlink, so a CLI whose main guard compares raw
+    path strings exits 0 without running. `route.mjs` is pinned against its own
+    documented output; the other four are pinned differentially, against
+    themselves, so no baseline is invented for output this repo never recorded.
+    """
+
+    UI_CRAFT = ROOT / "skills" / "drivers" / "ui-craft"
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.workdir = Path(self.temporary.name)
+        self.linked = self.workdir / "ui-craft-link"
+        self.linked.symlink_to(self.UI_CRAFT, target_is_directory=True)
+
+    def script(self, *parts: str) -> tuple[Path, Path]:
+        """The same script by its real path and through the symlinked directory."""
+        relative = Path("scripts").joinpath(*parts)
+        return self.UI_CRAFT / relative, self.linked / relative
+
+    def test_route_prints_its_decision_through_a_symlinked_skill_directory(self):
+        cases = (
+            (("greenfield", "runnable", "complete", "manufactured"), 0, "lock"),
+            (("shipped", "unavailable", "complete", "synthetic"), 2, "refuse"),
+        )
+        _, linked_route = self.script("route.mjs")
+        for arguments, exit_code, mode in cases:
+            with self.subTest(arguments=arguments):
+                result = run(
+                    [
+                        "node",
+                        str(linked_route),
+                        "--embodiment",
+                        arguments[0],
+                        "--runnability",
+                        arguments[1],
+                        "--declaration",
+                        arguments[2],
+                        "--data-source",
+                        arguments[3],
+                    ],
+                    cwd=self.workdir,
+                )
+                self.assertEqual(result.returncode, exit_code, result.stderr)
+                self.assertEqual(json.loads(result.stdout)["mode"], mode)
+
+    def assert_symlink_parity(self, parts: tuple[str, ...], arguments: list[str]):
+        """One read-only invocation run twice: by real path, then through the link.
+
+        Non-emptiness is load-bearing. Bare parity is satisfied by two silent
+        runs, so a guard that never fires would pass this test green — the very
+        defect being repaired.
+        """
+        real, linked = self.script(*parts)
+        real_run = run(["node", str(real), *arguments], cwd=self.workdir)
+        linked_run = run(["node", str(linked), *arguments], cwd=self.workdir)
+        self.assertTrue(real_run.stdout.strip(), real_run.stderr)
+        self.assertEqual(linked_run.stdout, real_run.stdout, linked_run.stderr)
+        self.assertEqual(linked_run.returncode, real_run.returncode, linked_run.stderr)
+
+    def test_migrated_clis_behave_identically_through_a_symlinked_directory(self):
+        cases = (
+            (("context-signals.mjs",), []),
+            (("context.mjs",), []),
+            (("critique-storage.mjs",), ["trend", "no-such-target"]),
+            (("detector", "detect-antipatterns.mjs"), ["--help"]),
+        )
+        for parts, arguments in cases:
+            with self.subTest(script=parts[-1]):
+                self.assert_symlink_parity(parts, arguments)
+
+    def test_detector_entry_path_arrives_normalized_with_a_trailing_separator(self):
+        """Pins the invariant that let the `endsWith('...mjs/')` clause be deleted.
+
+        Node normalizes the entry path before the module sees it, so
+        `process.argv[1]` never carries a trailing separator. If a future runtime
+        stops normalizing, this fails loudly instead of exiting 0 in silence.
+        """
+        self.assert_symlink_parity(("detector", "detect-antipatterns.mjs/"), ["--help"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

A ui-craft command reached through an installed skill directory now answers instead of
exiting silently. The command that decides how a surface change is routed checked
whether it had been run directly by comparing two spellings of its own path; through
the symlink every install creates, those spellings disagree, so it did nothing and
reported success. All five commands in that directory now share one predicate for that
check.

* Four sibling commands carried their own private copy of the same check, in three
  variants. One had already drifted into the broken spelling, and another matched the
  tail of a filename loosely enough that an unrelated script satisfied it.
* Routing decisions are untouched. The decision table, the arguments, the usage text,
  and the exit codes all behave as they did before.
* The four working commands are pinned against themselves rather than a baseline: the
  branch promises only that a link and a real path agree, not what any of them prints.
* One loose check is deleted rather than kept, because the runtime hands the entry path
  over already normalized. A test now holds that invariant, so a runtime that stops
  normalizing fails loudly instead of going quiet.

## Why

The failure mode is a command that exits 0 with nothing on stdout, which reads as
success to everything downstream. A live triage run hit it and had to import the module
to get an answer. The existing coverage invokes the command by its real location, so it
passes today and can never see this. The decisions behind the shared predicate are in
the scope ledger under `docs/scope/`.

## What to check

* The routing command prints the same JSON and the same exit code through a symlinked
  directory as it does by its real location, for both an accepted case and a refusal.
* The other four commands produce byte-identical output and exit codes either way,
  including the trailing-separator spelling of the one whose loose check was removed.
* Nothing outside those five commands changed spelling, including the places that
  resolve a directory rather than guard an entry point.

## Verification

```
validated 27 skills and 275 files
Ran 305 tests in 72.269s
OK (skipped=23)
py_compile exit 0
```

Clean single-branch clone on Python 3.14. The new test was red before the fix for the
right reason, empty stdout and exit 0 through the symlink, and forcing the shared
predicate to refuse fails all three new tests.

Two environment notes for anyone reproducing this locally, neither from this diff. The
suite needs Python 3.10 or newer and a stock macOS interpreter is 3.9, which errors on
32 tests by itself. The structural validator scans every branch reachable in the
checkout, so in a shared clone carrying several task worktrees it reports content from
unrelated branches.

## Known issue, not fixed here

A sixth command in the same directory, `detect-csp.mjs`, carries the same loose check
including the trailing-separator clause deleted elsewhere in this branch. It works
today and sits outside this ticket's enumerated scope, so it was left alone rather than
migrated in flight, and it wants its own ticket. The scope ledger records it so the next
reader does not conclude the directory is single-sourced.

Fixes #108

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
