### PR TITLE
feat(drive-local-webapp): click by coordinate, and truth the optional list

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,29 +91,25 @@ globally. Review skill instructions and scripts before running them; several
 skills intentionally start processes, modify repositories, or install Git
 hooks.
 
-## Optional upstream skills
+## Optional integrations
 
-Optional integrations are enhancements, not hidden runtime requirements:
+Optional integrations are enhancements, not hidden runtime requirements. Only
+Codebase Memory is external; the other three ship in this pack and are optional
+because a partial install can leave them out:
 
 - **`codebase-memory-mcp`:** the external executable/server used by the included
   `codebase-memory` skill for graph queries. Without the server, the discovery
   augmentation hook fails open and ordinary repository search and file reads remain
   available; installing or activating the skill does not install the server.
-- **`codebase-design`:** referenced by `tdd`; helps shape non-trivial module
-  interfaces. Without it, keep the shipping module shape and preserve locality.
-- **`domain-modeling`:** referenced by `scope`'s interview mode and `wayfinder`; maintains a
-  project's domain vocabulary. Without it, ground terms in the repo's own docs.
-- **`impeccable`:** adds a final visual-quality audit. Without it, run the
-  explicit contrast, focus, overflow, and target-size checks.
-- **`persona-review`:** referenced by `plan-review` for load-bearing plans; convenes
-  a panel of persistent reviewer personas. Without it, `plan-review` proceeds on its
-  own fresh-cold-pass termination alone.
-
-Install Matt Pocock's optional skills from their repository:
-
-```sh
-npx skills add mattpocock/skills --skill codebase-design --skill domain-modeling
-```
+- **`codebase-design`:** ships in this pack; referenced by `tdd`; helps shape
+  non-trivial module interfaces. Without it, keep the shipping module shape and
+  preserve locality.
+- **`domain-modeling`:** ships in this pack; referenced by `scope`'s interview mode
+  and `wayfinder`; maintains a project's domain vocabulary. Without it, ground terms
+  in the repo's own docs.
+- **`persona-review`:** ships in this pack; referenced by `plan-review` for
+  load-bearing plans; convenes a panel of persistent reviewer personas. Without it,
+  `plan-review` proceeds on its own fresh-cold-pass termination alone.
 
 ## Attribution
 

--- a/docs/scope/43-mouse-click-readme-truth.md
+++ b/docs/scope/43-mouse-click-readme-truth.md
@@ -1,0 +1,53 @@
+# Scope ledger — issue 43
+
+Coordinate click for the bundled browser driver, plus truthing the README's
+optional-skills section.
+
+Route: interview mode (one concrete either/or about how far the README fix reaches).
+
+## Decisions
+
+- Flat order, not chunked. One slicing trait fires (live run inside the ticket:
+  the self-check needs real Chromium). Lockstep copies does not fire: the command
+  list has exactly two encodings, `driver.mjs`'s header comment and `SKILL.md`'s
+  `## Commands` block. `inline`
+- Review depth: targeted. New opt-in command in a shared, pinned tool; no existing
+  command's behavior changes and nothing in the sensitivity floor is touched. `inline`
+- Profile: none. No `Harden:` line in `AGENTS.md` or `CLAUDE.md` repo facts. `inline`
+- Surface lifecycle: none. No rendered surface changes. `inline`
+- Refuted from the prior contested round: the acceptance criterion claiming a
+  command list in `self-check.mjs`. Reproduced against the file: it invokes six
+  commands and enumerates none. The order names two encodings, not three. `inline`
+- Corrected against CI: `npm run self-check` is a real gate, run by
+  `.github/workflows/validate.yml` after `npm ci` and `npx playwright install
+  chromium`. It is outside the Python gate, not outside CI. `inline`
+
+- Q1 settled (operator, option A): the README's optional list becomes one list of
+  four true entries under a renamed header that no longer says "upstream"; the three
+  bundled entries are marked as shipping in this pack; the
+  `npx skills add mattpocock/skills --skill codebase-design --skill domain-modeling`
+  command is deleted, because after the fix it names nothing external. Why: four of
+  the five entries ship here, so "upstream" is the false word.
+  `CONTRIBUTING.md:16` still holds, since Codebase Memory remains documented there.
+  `inline`
+- Spike, executed rather than prosed. Two scratch scripts were run during triage and
+  are not committed: this repo's `docs/scope` ledgers are markdown only, and the
+  charter forbids dead code, so the executed results are recorded here instead.
+  - Coordinate parse, 15 table cases, all passing. It caught a real trap that prose
+    would have shipped: `Number("")` is `0`, so `"640,"` and `",360"` parse as
+    `640,0` and `0,360` unless each side is rejected when empty *before* `Number()`.
+    Accepted: `640,360`, `  640 , 360 `, `0,0`, `12.5,20.5`, `1e2,1e2`.
+    Rejected: `640`, empty, `640,`, `,360`, `a,360`, `-1,10`, `10,-1`, `1,2,3`,
+    `Infinity,10`, `NaN,10`.
+  - Real Chromium against pinned `playwright` 1.61.1: `page.mouse.click` is a
+    function, a click at `(120, 80)` lands at exactly that viewport CSS point, the
+    default viewport is 1280x720, and the landing point is readable back through the
+    driver's existing `eval` command. `inline`
+
+## Open questions
+
+(none)
+
+## Spawned tasks
+
+- none

--- a/docs/scope/43-mouse-click-readme-truth.md
+++ b/docs/scope/43-mouse-click-readme-truth.md
@@ -51,3 +51,22 @@ Route: interview mode (one concrete either/or about how far the README fix reach
 ## Spawned tasks
 
 - none
+
+## Outcome
+
+- Shipped `mouse-click <x>,<y>` in `skills/tools/drive-local-webapp/scripts/driver.mjs`,
+  one branch in the existing chain calling `page.mouse.click` after rejecting any
+  argument that is not exactly two non-empty, finite, non-negative parts. The command
+  list is carried in the two encodings the order named and both now read the same
+  eleven commands in the same order: the `// Commands:` header comment in `driver.mjs`
+  and the `## Commands` block in `SKILL.md`. `scripts/self-check.mjs` gained one phase
+  pinning it — a valid-only run asserting the click lands at exactly 120,80, and a
+  rejection-only run asserting the `640,`, `,360` and `1,2,3` refusals by their exact
+  `FAIL mouse-click ... ::` prefixes. `SKILL.md` says what coordinate clicking is for
+  and warns that `screenshot` is full-page while `mouse-click` is viewport-relative.
+- `README.md`'s "Optional upstream skills" section is now "Optional integrations":
+  the `impeccable` bullet is gone, `codebase-design`, `domain-modeling` and
+  `persona-review` are marked as shipping in this pack with their degradation guidance
+  intact, `codebase-memory-mcp` remains the one external entry (which is what keeps
+  `CONTRIBUTING.md:16` satisfied), and the `npx skills add mattpocock/skills` command
+  block is deleted. `NOTICE` is unchanged.

--- a/skills/tools/drive-local-webapp/SKILL.md
+++ b/skills/tools/drive-local-webapp/SKILL.md
@@ -67,6 +67,7 @@ Do not use this driver as a general-purpose browser for untrusted sites.
 nav <url>
 wait-for <selector>
 click <selector>
+mouse-click <x>,<y>
 fill <selector> :: <value>
 set <selector> :: <value>
 press <key>
@@ -78,6 +79,10 @@ console --errors
 
 Use `:text-is("Label")` for exact text. Playwright's `:has-text()` is
 case-insensitive substring matching and can silently click the wrong control.
+
+Use `mouse-click` for a target with no addressable element, such as a canvas, an
+embedded map, or a region inside a chart. Prefer a selector wherever one exists;
+coordinates go stale as soon as the layout moves.
 
 Keep screenshots outside the target repository. The driver defaults to the
 system temporary directory, or use `DRIVER_SCREENSHOT_DIR`. It refuses to
@@ -94,3 +99,8 @@ overwrite an existing screenshot path.
   chart.
 - A client-side token gate may leave the screen loading without a console
   error. Inspect the application's setup UI and use a demo token.
+- `screenshot` captures the full page, but `mouse-click` addresses the visible
+  viewport. On a page taller than the viewport, a point measured off a screenshot
+  is not the point that gets clicked, and a point past the viewport still reports
+  `OK` while hitting nothing. Scroll the target into view first, and assert on the
+  effect rather than on the `OK` line.

--- a/skills/tools/drive-local-webapp/scripts/driver.mjs
+++ b/skills/tools/drive-local-webapp/scripts/driver.mjs
@@ -5,6 +5,7 @@
 //   nav <url>
 //   wait-for <selector>
 //   click <selector>
+//   mouse-click <x>,<y>
 //   fill <selector> :: <value>
 //   set <selector> :: <value>
 //   press <key>
@@ -96,6 +97,18 @@ async function main() {
       } else if (command === "click") {
         await page.click(selector(argument), { timeout: 15000 });
         console.log(`OK click ${argument}`);
+      } else if (command === "mouse-click") {
+        const parts = argument.split(",");
+        if (parts.length !== 2 || parts.some((part) => !part.trim())) {
+          throw new Error('mouse-click needs "<x>,<y>"');
+        }
+        const x = Number(parts[0]);
+        const y = Number(parts[1]);
+        if (!Number.isFinite(x) || !Number.isFinite(y) || x < 0 || y < 0) {
+          throw new Error("mouse-click needs non-negative numbers");
+        }
+        await page.mouse.click(x, y);
+        console.log(`OK mouse-click ${x},${y}`);
       } else if (command === "fill" || command === "set") {
         const separator = argument.indexOf(" :: ");
         if (separator === -1) {

--- a/skills/tools/drive-local-webapp/scripts/self-check.mjs
+++ b/skills/tools/drive-local-webapp/scripts/self-check.mjs
@@ -69,4 +69,44 @@ if (
   process.exit(1);
 }
 
+const clickTarget =
+  "data:text/html," +
+  encodeURIComponent(
+    '<div id="ready" style="position:fixed;inset:0" onclick="window.hit=event.clientX+\',\'+event.clientY"></div>',
+  );
+const coordinate = await runDriver([
+  `nav ${clickTarget}`,
+  "wait-for #ready",
+  "mouse-click 120,80",
+  "eval window.hit",
+]);
+if (
+  coordinate.status !== 0 ||
+  !coordinate.output.includes("OK mouse-click 120,80") ||
+  !coordinate.output.includes('OK eval -> "120,80"')
+) {
+  console.error("SELF_CHECK_MOUSE_CLICK_FAILED");
+  process.exit(1);
+}
+
+const rejection = await runDriver([
+  `nav ${clickTarget}`,
+  "mouse-click 640,",
+  "mouse-click ,360",
+  "mouse-click 1,2,3",
+]);
+const refused = [
+  "FAIL mouse-click 640, ::",
+  "FAIL mouse-click ,360 ::",
+  "FAIL mouse-click 1,2,3 ::",
+];
+if (
+  rejection.status === 0 ||
+  rejection.output.includes("OK mouse-click") ||
+  refused.some((line) => !rejection.output.includes(line))
+) {
+  console.error("SELF_CHECK_MOUSE_CLICK_REJECTION_FAILED");
+  process.exit(1);
+}
+
 console.log("SELF_CHECK_OK");


### PR DESCRIPTION
## What changed

The bundled browser driver can now click a position, so a target with no
addressable element (a canvas, an embedded map, a region inside a chart) is
reachable at all. Before, every clicking path went through a selector, and
anything drawn rather than built from elements had no name to give it.

* A position is refused when it is not two parts, when either side is empty, and
  when either side is negative or not a number. The empty check is the
  load-bearing one: an empty side reads as zero, so `640,` would otherwise click
  the top of the window while reporting success.
* The driver's own self-check pins those refusals by their exact failure lines,
  so a rejection cannot regress into a silent mis-click without failing a gate.
* The install page's optional list drops a visual-quality skill that was folded
  into `ui-craft` and has nowhere to be installed from, and stops framing three
  skills that ship in this pack as living in someone else's. Codebase Memory is
  the one genuinely external entry left, which is what `CONTRIBUTING.md` asks the
  README to document.

## Why

The workaround for an unreachable target is a synthetic click dispatched through
the driver's JavaScript escape hatch. That does not go through the browser's
input path, so a page listening for pointer events never sees it and the check
passes on a click that never happened.

## What to check

* A click at a position lands at that position. The page records where it was
  hit, and the recorded point is read back rather than inferred from a success
  line.
* A malformed position fails and leaves the run non-zero, `640,` above all.
* The install page names nothing that cannot be installed, and `NOTICE` is
  unchanged.

Known residue: a position past the edge of the visible window is accepted and
reports `OK` while hitting nothing. On a 1280x720 window, `mouse-click 5000,5000`
prints `OK` and the page records no click. Bounding a position to the window is
outside this ticket's rules for refusing one, which cover shape, sign and numeric
validity only. The skill's common-failures list now states that a point past the
window still reports `OK`, and that a check should assert on the effect rather
than on the success line.

## Verification

```
validated 27 skills and 274 files
Ran 302 tests in 73.904s
OK (skipped=23)
SELF_CHECK_OK
```

The self-check phase predates the command. Against the driver without it, it
failed for the right reason rather than by coincidence:

```
FAIL mouse-click 120,80 :: unknown command: mouse-click
SELF_CHECK_MOUSE_CLICK_FAILED
```

The Python gate is fully clean. This ticket permitted one failure there while a
pre-existing error on an unrelated local branch stood, and that error did not
appear, so the allowance went unused. The browser gate's provisioning step
completed separately on the final pass, because an unrelated project held
Playwright's global browser-cache lock. That gate launches real Chromium, so its
passing is what shows the browser is present.

Fixes #43

> Written by an AI agent. Verify before relying on it.
