### PR TITLE
feat(ticket): give a chunked order's coordinator its own degradation verdict

### DIFF
--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -49,6 +49,7 @@ the helper's `scan` command, not estimates.
 | 10 | Proof-bounded I:C history across an analyzer, server projections, generated fixtures, and a lifecycle-gated Diagnose revision | multiple artifacts, live run, lockstep copies, lifecycle-gated surface revision | slice into four serial chunks: analyzer, server contract, generated projections/evidence, then surface lock and browser evidence | 3 chunks; peaked 244k |
 | 90 | One shared behavioural judgment across model view, two server projections, generated fixtures and mirrors, and browser replay | multiple artifacts, live run, lockstep copies | slice into three serial chunks: source judgment, projection contracts, then generated artifacts and live replay | 2 chunks; peaked 231k |
 | 62 (external) | Four pull-request-sized chunks delegated from one coordinator | multiple artifacts, lockstep copies | slice into four chunks | 4 chunks; coordinator peaked 387k, chunk workers unmeasured |
+| 109 (harmonic) | Two admission bars for candidate I:C estimators (a synthetic truth/placebo generator with its entry bar, a stable-era replay harness) plus a live read-only calibration run against a real snapshot | multiple artifacts, live run | three serial chunks | 3 chunks; chunk workers peaked 162k and 138k, coordination peaked 299k |
 | 90 (skills) | A shared graph-identity interface, its ticket-workflow consumers, and the separately installed discovery policy, with argv and response shapes discovered by probing a live external CLI | multiple artifacts, lockstep copies | slice into two serial chunks: the ensure interface with its spiked contract tests, then the workflow pages and discovery policy that consume it | flat; peaked 243k in one session |
 | 79 (harmonic) | A server projection with identity and association semantics, a bounded registry/concurrency/cache-lifetime/HTTP contract, a shipped browser consumer, generated mirrors, and a closed recovery matrix run against an offline server | multiple artifacts, live run, lockstep copies | slice into four: projection core; registry/HTTP lifecycle; browser consumer; generated evidence and live replay | 2 chunks; server and surface chunks peaked 237k/242k, lifecycle peak 244k |
 
@@ -62,6 +63,10 @@ grows with dispatches, returned results, review rounds and merges. Coordinator
 cost never tunes the thresholds below, in either direction, and this row is
 unusable for that.
 
+Row `109 (harmonic)` is also a shape anchor: its 299k is coordinator cost, not
+chunk cost. It was attributed by joining pre-role claims to their chunk worktrees,
+rather than read from role-tagged records. It tunes no threshold.
+
 ## Sizing
 
 Ground truth from mining 134 past sessions: 31 peaked above 180k, and every
@@ -70,7 +75,9 @@ review) before it touches the work.
 
 These numbers describe what one agent building one piece of work costs, so only a
 session claimed `--role worker` measures them. A coordinator's peak and a
-reviewer's are recorded separately and tune nothing here.
+reviewer's are recorded separately and tune nothing here. A coordinator over the
+band on an otherwise-held slice is `coordination-degraded`; carry less in that
+session, never cut more chunks.
 
 * Target each chunk at a projected peak under 180k.
 * Never slice below one pull-request-sized piece of work. A chunk that would peak

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -375,6 +375,11 @@ def verdict(actual: dict, chunked: bool, chunks: int) -> tuple[str, str]:
     A coordinator's context grows with dispatches, returned results, review
     rounds and merges, so slicing the same work more finely can raise it while
     lowering every chunk's peak: reading it as chunk size inverts the answer.
+    When every chunk worker held under the band but the coordinator did not,
+    `coordination-degraded` reports that the slice was right and coordination
+    was not. Incomplete worker coverage never yields `coordination-degraded`;
+    it falls through to `ok` only when no earlier branch fired, because an
+    unmeasured chunk could itself have crossed the band.
     `subagent_peak` cannot stand in either, because a coordinator dispatches
     review panels as sub-agents too and the transcript cannot tell the two
     apart — and per ADR 70 attribution comes from explicit claims, never from
@@ -453,6 +458,14 @@ def verdict(actual: dict, chunked: bool, chunks: int) -> tuple[str, str]:
             "ok",
             f"{len(worker_peaks)} of {chunks} chunk(s) measured an implementation worker, "
             f"peaking at {peak:,} tokens; too few to call it over-sliced",
+        )
+    if len(worker_peaks) >= chunks and actual["coordinator_peak"] >= DEGRADE_PEAK:
+        return (
+            "coordination-degraded",
+            f"{chunks} chunk(s) and every measured implementation worker held under the "
+            f"{DEGRADE_PEAK:,} degradation band, but the coordinator peaked at "
+            f"{actual['coordinator_peak']:,} tokens; the slice was right while the "
+            "coordinating session was not",
         )
     return "ok", f"implementation workers peaked at {peak:,} tokens across {chunks} chunk(s)"
 

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -62,6 +62,8 @@ the code host back to the tracker; this verb is that sync.
    * `under-sliced`: a flat order that peaked past the degradation band.
    * `still-degraded`: a chunked order whose chunks were themselves too big.
    * `over-sliced`: chunks that no single agent would have struggled with.
+   * `coordination-degraded`: a chunked order whose chunks all held, but whose
+     coordinator peaked past the degradation band.
    * `coordinator-only`: a chunked order where no implementation worker was
      measured, so its cost was recorded but chunk size was not measured.
    * `no-data`: no session claimed this ticket, so nothing measured it.
@@ -73,15 +75,17 @@ the code host back to the tracker; this verb is that sync.
 
    **Roles decide what counts.** This verb's own session claims itself under the
    shared rule's default, `--role coordinator`, like every session that drives a
-   ticket rather than building or reviewing one chunk of it. A chunked order's verdict comes from the peaks of
-   the sessions claimed `--role worker` and from nothing else. The coordinator's
-   own peak and the reviewers' are recorded beside them, as `coordinator_peak` and
-   `reviewer_peak`, and neither can make a chunked order read as under-sliced:
-   coordinating more chunks costs the coordinator more, not less. A flat order is
-   judged on its own execution peak, with review-only sessions excluded there too.
-   Claims written before roles existed read back as `legacy` and are never guessed
-   into a role, which is why a chunked ticket claimed entirely under legacy claims
-   returns `coordinator-only`.
+   ticket rather than building or reviewing one chunk of it. A chunked order's
+   slice-size judgment comes from the peaks of the sessions claimed `--role
+   worker` and from nothing else. The coordinator's own peak and the reviewers'
+   are recorded beside them, as `coordinator_peak` and `reviewer_peak`; the former
+   can separately return `coordination-degraded` when every chunk worker held, but
+   neither can make a chunked order read as under-sliced: coordinating more chunks
+   costs the coordinator more, not less. A flat order is judged on its own
+   execution peak, with review-only sessions excluded there too. Claims written
+   before roles existed read back as `legacy` and are never guessed into a role,
+   which is why a chunked ticket claimed entirely under legacy claims returns
+   `coordinator-only`.
    `python3 <ticket-skill-directory>/scripts/ticket.py scan <ticket-id>` reports peak
    context per claimed session without recording anything, which is the way to look
    before committing a record.
@@ -96,14 +100,18 @@ the code host back to the tracker; this verb is that sync.
    pull request they approve. The skill never amends its own rubric, and never edits
    `references/slicing.md` itself.
 
-   `no-data` and `coordinator-only` are not mispredictions, and neither drafts an
-   amendment. `no-data` has two readings the report keeps apart: no session claimed
-   the ticket, so it ran outside this machine's transcripts, or sessions claimed it
-   and their transcripts are gone. `coordinator-only` means the ticket's cost was
-   recorded but its chunk size was not measured, so say that plainly — the reason
-   names how many worker claims existed and how many were readable, which is the
-   difference between a forgotten `--role worker` and a lost transcript. Never
-   report it as evidence that the chunks were the wrong size in either direction.
+   `no-data`, `coordinator-only`, and `coordination-degraded` are not
+   mispredictions, and none drafts an amendment. `no-data` has two readings the
+   report keeps apart: no session claimed the ticket, so it ran outside this
+   machine's transcripts, or sessions claimed it and their transcripts are gone.
+   `coordinator-only` means the ticket's cost was recorded but its chunk size was
+   not measured, so say that plainly — the reason names how many worker claims
+   existed and how many were readable, which is the difference between a forgotten
+   `--role worker` and a lost transcript. Never report it as evidence that the
+   chunks were the wrong size in either direction. `coordination-degraded` means
+   the slice was right while the coordinating session was not: report the cost and
+   advise carrying less in that session, with fewer review rounds held in its own
+   context or a handoff between chunks, never more chunks.
 
 4. **Abandoned path** (pull request closed unmerged, or the work cancelled): comment
    why, then on explicit user confirmation run the same teardown as step 2f. Never

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -861,7 +861,7 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(self.telemetry_records()[0]["verdict"], "coordinator-only")
         self.assertEqual(self.telemetry_records()[0]["coordinator_peak"], 387_156)
 
-    def test_a_coordinator_over_the_band_cannot_make_small_chunks_read_as_too_big(self):
+    def test_a_coordinator_over_the_band_degrades_an_otherwise_held_slice(self):
         self.worked("TICKET-25", "proj-a", "coordinator-1", [assistant_line(300_000)])
         for chunk, peak in enumerate((150_000, 140_000), start=1):
             self.worked(
@@ -875,10 +875,87 @@ class TicketTelemetryTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
-        self.assertEqual(payload["verdict"], "ok")
-        self.assertIn("150,000", payload["reason"])
+        self.assertEqual(payload["verdict"], "coordination-degraded")
+        self.assertIn("300,000", payload["reason"])
+        self.assertIn("180,000", payload["reason"])
+        self.assertIn("slice was right", payload["reason"])
         self.assertEqual(payload["coordinator_peak"], 300_000)
         self.assertEqual(payload["worker_peaks"], [150_000, 140_000])
+
+    def test_degraded_worker_wins_over_degraded_coordinator(self):
+        self.worked("TICKET-125B", "proj-a", "coordinator-1", [assistant_line(299_000)])
+        for chunk, peak in enumerate((190_000, 138_000), start=1):
+            self.worked(
+                "TICKET-125B", "proj-a", f"worker-{chunk}", [assistant_line(peak)], role="worker"
+            )
+
+        result = self.ticket(
+            "record", "TICKET-125B", "--verb", "start", "--trait", "wide-scope",
+            "--depth", "deep", "--chunked", "--chunks", "2",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["verdict"], "still-degraded")
+
+    def test_over_sliced_workers_win_over_degraded_coordinator(self):
+        self.worked("TICKET-125C", "proj-a", "coordinator-1", [assistant_line(299_000)])
+        for chunk, peak in enumerate((50_000, 60_000), start=1):
+            self.worked(
+                "TICKET-125C", "proj-a", f"worker-{chunk}", [assistant_line(peak)], role="worker"
+            )
+
+        result = self.ticket(
+            "record", "TICKET-125C", "--verb", "start", "--trait", "narrow-scope",
+            "--depth", "light", "--chunked", "--chunks", "2",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["verdict"], "over-sliced")
+
+    def test_chunked_order_with_held_workers_and_coordinator_is_ok(self):
+        self.worked("TICKET-125D", "proj-a", "coordinator-1", [assistant_line(150_000)])
+        for chunk, peak in enumerate((162_000, 138_000), start=1):
+            self.worked(
+                "TICKET-125D", "proj-a", f"worker-{chunk}", [assistant_line(peak)], role="worker"
+            )
+
+        result = self.ticket(
+            "record", "TICKET-125D", "--verb", "start", "--trait", "wide-scope",
+            "--depth", "deep", "--chunked", "--chunks", "2",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["verdict"], "ok")
+
+    def test_chunked_order_with_held_workers_and_no_coordinator_is_ok(self):
+        for chunk, peak in enumerate((162_000, 138_000), start=1):
+            self.worked(
+                "TICKET-125E", "proj-a", f"worker-{chunk}", [assistant_line(peak)], role="worker"
+            )
+
+        result = self.ticket(
+            "record", "TICKET-125E", "--verb", "start", "--trait", "wide-scope",
+            "--depth", "deep", "--chunked", "--chunks", "2",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["verdict"], "ok")
+        self.assertEqual(payload["coordinator_peak"], 0)
+
+    def test_partial_worker_coverage_with_degraded_coordinator_is_ok(self):
+        self.worked("TICKET-125F", "proj-a", "coordinator-1", [assistant_line(299_000)])
+        self.worked(
+            "TICKET-125F", "proj-a", "worker-1", [assistant_line(162_000)], role="worker"
+        )
+
+        result = self.ticket(
+            "record", "TICKET-125F", "--verb", "start", "--trait", "wide-scope",
+            "--depth", "deep", "--chunked", "--chunks", "2",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["verdict"], "ok")
 
     def test_one_worker_over_the_band_is_still_degraded_under_a_small_coordinator(self):
         self.worked("TICKET-26", "proj-a", "coordinator-1", [assistant_line(60_000)])


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

A chunked ticket whose chunks each held under the context band, but whose
coordinating session blew past it, used to close out as a clean pass. It now
gets its own verdict saying the coordination, not the slice, was too heavy.

* Finalize reports `coordination-degraded` when every chunk had a measured
  builder, every one of those builders stayed under the degradation band, and
  the session coordinating them peaked past it. The remedy it prints is to carry
  less in that coordinating session (fewer review rounds held in its own
  context, or a handoff between chunks), never to cut more chunks, which is what
  the existing "chunks were too big" verdict would have advised.
* Precedence is deliberate and pinned: a builder that was itself over the band
  still reports that the chunks were too big, and an order sliced finer than one
  agent needed still reports over-slicing. The new verdict only fires when
  neither of those did.
* A ticket where some chunk has no measured builder is unchanged. It still
  reads as a pass, because an unmeasured chunk could itself have crossed the
  band and the slice cannot be called right on partial evidence.
* Like the existing coordinator-only verdict, this one reports and advises and
  never drafts a rubric amendment: the slicing guidance predicted correctly here,
  so there is nothing to amend.
* The slicing guidance records the distinction and gains a calibration row from
  the ticket that exposed it: three chunks, builders peaking at 162k and 138k,
  coordination peaking at 299k. That 299k is annotated as coordinator cost,
  attributed by joining pre-role claims to their chunk worktrees rather than read
  from role-tagged records, and it tunes no threshold.

Not in this change: any threshold moved, any change to how sessions claim roles,
and no change to how a single-agent ticket is judged.

## What to check

* The remedy printed for the new verdict points at the coordinating session, not
  at cutting more chunks.
* Nothing that used to report a too-big or over-sliced slice now reports the new
  verdict instead.

## Verification

```text
$ python3 scripts/validate.py && python3 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco && python3 -m py_compile skills/tools/codebase-memory/scripts/install.py
validated 27 skills and 279 files
----------------------------------------------------------------------
Ran 334 tests in 101.308s

OK (skipped=23)
```

`py_compile` exited 0. Run on Python 3.14 (the repo's tests need 3.10 or newer).

Closes #125
