### PR TITLE
Add /epic driver: ticket batches as one integration branch and one PR

### DIFF
--- a/docs/scope/epic-manager.md
+++ b/docs/scope/epic-manager.md
@@ -1,0 +1,71 @@
+# Scope ledger — epic-manager
+
+Driver skill atop /orchestrate: an epic-level architect that splits work into
+workstreams at real seams, briefs per-workstream coordinator leads, and verifies
+boundaries only.
+
+## Status
+
+Redefined 2026-08-24: the architect-over-parallel-leads design stays shelved
+(base rate: one 3+-seam epic, #133, in harmonic's history). The live design is
+a sequential integration-batch driver, proven by harmonic PR #160 (tickets
+#95-#106 as one integration branch, coordinator-merged sub-PRs, full gate per
+merge, one human-merged PR to main). The skill codifies that prompt's generic
+skeleton; repo specifics stay in work orders and repo CLAUDE.md.
+
+Generic skeleton: coordinator-only atop /orchestrate; integration branch from
+fresh origin/main; ordered tickets whose newest WORK ORDER comment is the
+verbatim brief (no re-triage); rebase each ticket branch onto the current
+integration tip before /ticket start; sub-PRs target the integration branch
+and only those may be coordinator-merged; full repo gate after every merge;
+claims measured from the current tip, never copied from orders; parked-ticket
+list is untouchable; escalate to owner only for trust failures and unsettled
+design decisions; report each state change in the first sentence after it.
+
+## Decisions
+
+- Hierarchy is capped at two levels: architect over coordinator leads — evidence
+  degrades past two relays; inline
+- Leads run /orchestrate internally; the epic manager never routes models itself —
+  keeps the routing table and its verification loop intact; inline
+- Coordination is written artifacts (contract briefs, ledger), not agent-to-agent
+  chat; inline
+- Architect verifies boundaries: integration gates, composition, one spot-checked
+  diff per workstream, evidence pasted not summarized; inline
+- Leads run as sub-agents of the epic session, continued via SendMessage; the
+  session lives as long as the epic and is re-seedable from this ledger; inline
+- Below three seams: refuse, fall back to plain /orchestrate; inline
+- Briefs and epic ledger live in docs/scope/<epic>.md, per-workstream
+  sections; inline
+- A dead or drifting lead is replaced via /handoff from the ledger; inline
+- No automatic rollback on a bad integration; human pre-merge review is the
+  guardrail; inline
+- Epics with open decisions: manager routes decisions to the operator and
+  dispatches only unblocked workstreams (harmonic epics are decision-gated);
+  inline
+- Entry point: standalone driver skill named /epic, invoked with the ordered
+  ticket list, integration branch name, and parked list (supersedes the earlier
+  ticket-verb idea); inline
+- Model routing per the orchestrate table; the #160 Codex-only force was a
+  per-run budget instruction and is not codified; inline
+- /epic may launch sub-coordinators (an orchestrate session owning a slice of
+  the batch) when a slice is genuinely independent; two levels maximum;
+  default is the sequential loop; decide the spawn rule at implementation;
+  inline
+
+## Open questions
+
+- Dispatch mechanic for leads (SendMessage sub-agents vs manual sessions vs remote)
+- Workstream-count threshold and fallback behavior
+- Where contract briefs and the epic ledger live
+- Relationship to scope/handoff skills (reuse vs own format)
+- Category placement and skill boundaries in the pack
+
+## Spawned tasks
+
+- Sonnet exploration of harmonichq/harmonic issue history (done, verified):
+  ~88 issues, 2026-08-18 to 2026-08-24. Epic candidates: #19 I:C rework (serial,
+  decision-gated), #133 Diagnose evidence canvas (sub-issues #134-#139 plus
+  handoffs #143-#145; the one genuine 3+ parallel-seam epic), #82 cold-start
+  (serial, blocks the others), CI/tooling cluster (loose theme, ~2 streams).
+  Spot-check: #133 sub-issues confirmed via API.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -22,6 +22,7 @@ EXPECTED = {
     "drivers/openspec-adopt",
     "drivers/ui-craft",
     "drivers/orchestrate",
+    "drivers/epic",
     "drivers/ticket",
     "tools/cbm-onboard",
     "tools/codebase-memory",

--- a/skills/drivers/epic/SKILL.md
+++ b/skills/drivers/epic/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: epic
+description: Drive a batch of triaged tickets as one integration branch ending in one pull request — the coordinator merges gated sub-PRs into the integration branch, ticket by ticket, and a human merges the final PR. Use when the user invokes /epic with an ordered ticket list, or asks to ship several work-ordered tickets as a single batch/mega PR.
+---
+
+# Epic — integration-batch coordinator
+
+Run a batch of already-triaged tickets as **one integration branch, one final
+pull request**. This skill composes `/orchestrate` and `/ticket`: invoke
+`orchestrate` first — the session is coordinator-only for the life of the epic,
+and every routing, verification, and escalation rule there applies unchanged.
+Nothing here overrides the routing table; a per-run model restriction is the
+operator's instruction for that run, never part of this skill.
+
+The session **is** the epic: it lives until the final PR merges or the operator
+kills it. Either way its ledger is the durable state — a killed epic restarts by
+reading the ledger (via `/handoff` when one exists), not by re-deriving the
+batch from chat.
+
+## Inputs — refuse without them
+
+1. **Ordered ticket list.** Every ticket has a posted, countersigned work order
+   (per `/ticket`: the newest comment containing a fenced `WORK ORDER` block).
+   The order is the verbatim brief — never re-triage, never improvise scope. A
+   ticket without an order stops the batch at its slot: report it, ask the
+   operator to run `/ticket triage` or drop it from the list.
+2. **Integration branch name.** Created from a **freshly fetched**
+   `origin/main`, pushed immediately.
+3. **Parked list** (may be empty). Parked tickets are untouchable: never read
+   into scope, never "quickly fixed" because the code is nearby.
+
+Open a ledger at `docs/scope/<epic-slug>.md` (scope's convention) before the
+first dispatch: the ticket order with per-ticket status, decisions as they
+settle, and the parked list.
+
+## The loop — strictly in order
+
+For each ticket:
+
+1. **Rebase** the ticket's branch onto the **current integration tip**. Reuse
+   an existing worktree for the ticket when one exists (`spin-worktree`
+   convention); never respin over uncommitted work.
+2. **`/ticket start <n>`** with the worktree on that rebased branch. Its PR
+   targets the **integration branch, never main**. Delegation, review depth,
+   and escalation belong to `/ticket` and `/orchestrate`; the epic coordinator
+   does not re-review inside the ticket.
+3. **Merge** the sub-PR into the integration branch once its review passes and
+   its gates are green. The coordinator's merge authority covers the
+   integration branch **only** — merging to main is always the human's.
+4. **Full repo gate** on the new integration tip: every check the repo's own
+   docs name as the merge bar, not just the changed ticket's tests. A red gate
+   stops the loop — route the failure back to the ticket's agent before the
+   next ticket starts.
+5. **Re-measure, never copy.** Any figure a work order states (test counts,
+   replay totals, fixture sizes) was measured against an older base. Claims in
+   commits, comments, and the final PR body come from commands run on the
+   current tip, reading the actual summary line.
+
+Gated orders (one ticket's order requiring another's change on the tip) are
+honored by the ordering; if a gate condition fails, stop and surface it rather
+than reordering silently.
+
+## Sub-coordinators
+
+Default is the sequential loop above. When the batch contains a **genuinely
+independent slice** — tickets sharing no files, fixtures, or ledger sections
+with the rest — the epic session may hand that slice to one sub-coordinator: an
+`/orchestrate` session with its own ticket order and its own ledger section,
+merging into the same integration branch through the same loop. Two levels
+maximum, ever: a sub-coordinator never spawns another. When in doubt about
+independence, stay sequential — a false-parallel slice pays merge conflicts for
+no wall-clock win.
+
+## Finishing
+
+When every ticket is merged and the integration tip is green: write the PR body
+with `/pr-body` where available, in product terms, closing every batch ticket,
+with per-ticket evidence. Open **one** PR from the integration branch to main
+and stop — a human merges it. `/ticket finalize` runs per ticket only after
+that merge.
+
+## Operator contract
+
+- Escalate only trust failures (an agent gone untrustworthy per orchestrate's
+  verification rules) and design decisions the work orders leave unsettled.
+  Everything else is the coordinator's.
+- Report every externally visible state change — branch pushed, PR opened,
+  sub-PR merged, comment posted — in the first sentence after it happens.
+- Repo-specific hazards (ports, publish guards, ledger append rules) come from
+  the repo's own agent docs and the work orders; this skill adds none and
+  skips none.

--- a/skills/drivers/epic/agents/openai.yaml
+++ b/skills/drivers/epic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Epic"
+  short_description: "Ship a triaged ticket batch as one integration branch and one PR"
+  default_prompt: "Use $epic to coordinate this ticket batch into one integration branch ending in one pull request."


### PR DESCRIPTION
Codifies the integration-batch coordination pattern proven by harmonic PR harmonichq/harmonic#160: an ordered list of work-ordered tickets shipped as one integration branch, ending in one human-merged pull request.

## What's in

- `skills/drivers/epic/SKILL.md` — the driver. Composes `/orchestrate` (coordinator-only session, routing table untouched) and `/ticket` (work orders are verbatim briefs, no re-triage). Loop per ticket: rebase onto the current integration tip → `/ticket start` → sub-PR into the integration branch → coordinator merge (integration branch only) → full repo gate → next. Claims are re-measured on the current tip, never copied from orders. Sub-coordinators allowed for genuinely independent slices, two levels max, sequential by default. One final PR to main; a human merges.
- `skills/drivers/epic/agents/openai.yaml` — interface stub, matching orchestrate's.
- `scripts/validate.py` — `drivers/epic` added to the expected skill set.
- `docs/scope/epic-manager.md` — the scope ledger behind this design, including the shelved parallel-architect variant and why it stays shelved.

## Deliberately not codified

- Model restrictions (the #160 Codex-only force was a per-run budget instruction).
- Repo-specific hazards (ports, publish guards, ledger append rules) — those stay in each repo's agent docs and work orders.

## Validation

`python3 scripts/validate.py` passes (28 skills, 279 files). The unittest gate shows 4 failures that are pre-existing on a clean tree in this container (permission-denial tests running as root).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9cSsV4TV9vHBADhDtVYZD)_