### PR TITLE
docs: adopt OpenSpec — baseline specs

### DIFF
--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -1,0 +1,12 @@
+# OpenSpec in this repo
+
+* `specs/` holds the behavioral baseline: what the pack does today, grounded
+  in code that was read. Correct it when it drifts; do not let it guess.
+* `changes/<slug>/` holds one in-flight change: `proposal.md` (what and why,
+  with the risk contract), `design.md` (rationale; ADRs live in `docs/adr/`
+  per the charter's ADR-home rule, not here), and any change-specific state.
+* A change is archived to `changes/archive/` in the pull request that
+  finishes it, before that PR is marked ready — never in a follow-up commit
+  after merge, never as a push onto an approved PR.
+* An epic's change folder substitutes tracker child issues for `tasks.md` and
+  carries `ledger.md`; see the epic driver skill once adopted.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,33 @@
+# Project
+
+Connor Griffin's public, portable skill pack for coding agents. Skills live
+under `skills/<category>/<name>/` (categories: `drivers`, `tools`,
+`workflows`), one directory each, consumed by the standard `skills` CLI.
+`profile/`, `output-styles/`, `hooks/`, and `docs/` sit alongside.
+
+## Stack and constraints
+
+* Python 3 standard library and Node 20 only; no third-party dependency may
+  enter the pack (the browser driver under `skills/tools/drive-local-webapp`
+  installs its own deps and is the sanctioned exception).
+* `scripts/validate.py` is the structural gate, not a lint: it pins the
+  expected skill set, requires `SKILL.md` plus `agents/openai.yaml` per
+  skill, checks every relative markdown link, runs a forbidden-pattern scan,
+  and verifies `docs/evidence/contract-v2.json` against a pinned SHA-256.
+* Tests live in `tests/`; CI (`.github/workflows/validate.yml`) runs the
+  validator, an enumerated unittest module list, an enumerated `py_compile`
+  list, a fresh-install smoke check of a named skill subset, and
+  `scripts/check_dco.py`.
+
+## Conventions
+
+* Every commit carries `Signed-off-by` (DCO); CI fails without it and history
+  cannot be fixed after merge.
+* Nothing merges without a pull request. PR bodies are written for the human
+  who merges, in domain terms, and pass the `pr-body` skill's scorer.
+* Release tags are never moved, retagged, or deleted: the agentflow repo pins
+  this pack by tag, commit, and per-file SHA-256.
+* `.claude/skills/` and `.agents/skills/` are vendored, pinned copies of this
+  repo's own skills; the source under `skills/` is edited and the pin bumped
+  deliberately, never the copies.
+* Engineering standards live in `profile/CHARTER.md` and bind review.

--- a/openspec/specs/pack-integrity/spec.md
+++ b/openspec/specs/pack-integrity/spec.md
@@ -1,0 +1,36 @@
+# Pack integrity
+
+How the pack guarantees a consumer installs exactly what was reviewed.
+
+## Behavior
+
+* `scripts/validate.py` discovers every `skills/<category>/<name>/` directory
+  and fails unless the discovered set equals its hardcoded `EXPECTED` list
+  (27 skills at baseline). Adding, renaming, or removing a skill is therefore
+  always a deliberate two-place change.
+* Each skill must carry `SKILL.md` with valid frontmatter and
+  `agents/openai.yaml`. Every relative markdown link in the pack must
+  resolve. A forbidden-pattern scan runs over tracked files.
+* `docs/evidence/contract-v2.json` is verified byte-for-byte against a
+  SHA-256 recorded in the validator, pinned to a commit of the upstream
+  `ConnorGriffin/agentflow` repo. Any edit to that file fails validation
+  here; changing it is upstream work.
+* CI (`.github/workflows/validate.yml`) additionally runs an enumerated
+  unittest module list, an enumerated `py_compile` script list, a fresh
+  `npx skills add` install asserting a named subset of skills lands, and the
+  DCO check. The unittest and `py_compile` lists are exhaustive: a new test
+  module or skill script that is not added to them silently never runs.
+* A pre-push hook mirrors validation and DCO locally.
+
+## Invariants
+
+* Stock Python 3 and Node 20 suffice to install and run the pack.
+* Release tags are immutable; agentflow pins this repo by tag, commit, and
+  per-file SHA-256 (`agentflow/capabilities.toml`, `skills-lock.json`).
+* `.claude/skills/` and `.agents/skills/` are pinned vendored copies of the
+  pack's own skills and are never edited directly.
+
+## Dependents
+
+The `skills` CLI installs from this layout; agentflow's pins name individual
+file paths, so path renames under `skills/` are breaking changes for it.

--- a/openspec/specs/planning-and-review/spec.md
+++ b/openspec/specs/planning-and-review/spec.md
@@ -1,0 +1,37 @@
+# Planning and review routing
+
+How ambiguous work becomes buildable, and how finished work gets reviewed.
+
+## Behavior
+
+* `/scope` is the triage front door for work that is not ready to build: it
+  classifies the dominant uncertainty and routes to exactly one specialist
+  skill, keeping a per-effort ledger under `docs/scope/` with decisions, open
+  questions, and spawned tasks. Bounded work is admitted to build only with a
+  risk contract copied into the authoritative artifact.
+* `wayfinder` charts a large, foggy effort as a GitHub map issue with native
+  child decision tickets, resolving one decision per session and filing
+  build issues only when no open decision can invalidate them. Its map body,
+  candidate-disposition protocol, and six persistent `wayfinder:*` labels are
+  pinned by tests. (The pending epic-rework change supersedes this model.)
+* `/review` is the review front door: it classifies the subject and routes to
+  exactly one review skill — code review on two axes (repo standards, spec
+  conformance), plan review as adversarial pre-build objection cycles capped
+  at three panels, or a persona panel whose reviewer memory lives in a
+  private data repo and never enters this one.
+* `/orchestrate` flips a session into coordinator mode: the parent plans and
+  reviews but delegates implementation to sub-agents routed by a benchmarked,
+  provenance-stamped model routing table; stamped rows change only via a
+  benchmark replay.
+
+## Invariants
+
+* Planning artifacts record decisions once, in one home: resolutions in their
+  ticket, lasting rulings as ADRs in `docs/adr/`, work orders on the tracker.
+* Review verdicts are grounded in files read or commands run, never in the
+  plan's own claims about the system.
+
+## Dependents
+
+The ticket workflow's triage verb calls into `/scope`; persona review's
+containment rule binds every calling skill's committed artifacts.

--- a/openspec/specs/ticket-workflow/spec.md
+++ b/openspec/specs/ticket-workflow/spec.md
@@ -1,0 +1,42 @@
+# Ticket workflow
+
+How one tracked ticket moves from arrival to resolution.
+
+## Behavior
+
+* Four verbs, one at a time: `triage` reads the ticket and repo and posts a
+  locked work order as a ticket comment (interviewing through `/scope` when
+  scope is thin); `start` executes the order in a fresh session on an
+  isolated worktree and opens the PR; `revise` actions one review round;
+  `finalize` runs after a human merges — closes the ticket, tears the
+  worktree down, and records what the ticket cost.
+* Work orders too big for one context are sliced at triage into sub-orders in
+  the same comment. Chunks are never issues. The slicing rubric targets a
+  projected peak under 180k tokens per chunk, folds chunks that would peak
+  under 120k into a neighbour, and treats more than four chunks as a sign the
+  ticket is really a larger effort. On a chunked order, `start` coordinates
+  one agent per chunk per the coordinator-mode reference, which binds
+  `/orchestrate`'s delegation rules.
+* Status moves through `ticket:<state>` labels via the GitHub issues binding;
+  agents never merge.
+* Telemetry: sessions claim tickets as they work (`ticket.py claim`), and
+  `finalize` runs `ticket.py record`, appending verdict, role-tagged peaks,
+  chunk count, rubric traits, and repo to `~/.config/ticket/telemetry.jsonl`.
+  Every record carries counts and labels supplied on the command line, never
+  prose from a session. A `no-data` verdict appends nothing. A denied write
+  is reported in one visible line and never blocks the verb.
+* On a misprediction verdict, `finalize` drafts an amendment against the
+  slicing rubric and shows it to the user; prose and the helper's constants
+  move together.
+
+## Invariants
+
+* No work order, no `start`: the verb refuses rather than inventing scope.
+* A session never runs an order stamped for a stronger model tier than its
+  own, and never re-slices in flight.
+
+## Dependents
+
+The review workflow's depth stamps and the slicing rubric's calibration both
+read this telemetry; the pending epic-rework change re-homes the amendment
+path.


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

The repo now carries an OpenSpec baseline: project context plus three
behavioral specs (pack integrity, ticket workflow, planning and review
routing) describing what the pack does today, so future change proposals have
something checked in to amend. Documentation only; no skill changes.

* Every claim is grounded in files read this session: the validator's pinned
  skill set and SHA-checked evidence contract, the enumerated CI lists, the
  ticket verbs and their telemetry store, and the routing front doors.
* The archiving rule is the strict one: a change archives in the PR that
  finishes it, before that PR is marked ready.
* The baseline is a starting point; corrections from whoever knows the system
  better are the point of reviewing it.
* The pending epic-rework plan names OpenSpec adoption as its first child;
  merging this completes that child.
