### PR TITLE
docs(epic-rework): open the epic — proposal and risk contract

### DIFF
--- a/openspec/changes/epic-rework/design.md
+++ b/openspec/changes/epic-rework/design.md
@@ -1,0 +1,6 @@
+# Design
+
+Destination rationale lives in the proposal's Settled decisions; lasting
+rulings go to `docs/adr/` per the charter's ADR-home rule, not here. This epic
+change folder substitutes tracker child issues for `tasks.md` and carries
+`ledger.md` on the standing draft PR.

--- a/openspec/changes/epic-rework/proposal.md
+++ b/openspec/changes/epic-rework/proposal.md
@@ -497,3 +497,30 @@ serial build tickets, per the conjunctive promotion rule.
 * Store paths `~/.config/agent-calibration/{models,assessments}.jsonl`.
 * Nudge threshold 5 tickets; edit threshold 3 supporting rows, both streams.
 * Renderer script name `epic_status.py`; Mermaid + text output.
+
+## Risk contract
+
+- **Must prevent:** secret exposure; irreversible loss of authoritative data —
+  in this epic, tracker state: no label carrying claim or disposition state is
+  deleted without its issues surfaced and acknowledged first; silent incorrect
+  success — a calibration row or telemetry record that misattributes work;
+  breaking agentflow's per-file pins unknowingly (the pin check gate runs
+  before the rename merges).
+- **Must recover:** nothing automatically. Every failure stops visibly for the
+  operator; the migration script is idempotent so a half-applied run re-runs.
+- **Accepted failure:** a build session dying mid-run (recover from the work
+  order and worktree); ledger staleness against the tracker (renderer marks
+  it; manual sync); a missed nudge if the calibration store write is denied
+  (reported in one line, never blocking).
+- **Unsupported:** repos outside the spike's approved list; concurrent epics
+  sharing one change directory; trackers other than GitHub issues.
+- **Evidence owed:** validator, full suite, and post-install check green on
+  the renamed tree; migration acceptance quantified over the approved list;
+  the purge gate shown red before and green after each enumerated target; the
+  renderer's completion gate against the pinned fixture; a finalize staging
+  rows without prompting.
+
+**Why:** process machinery for one operator; the worst credible losses are
+tracker label state and pinned-consumer breakage, and both sit behind gates.
+**Disposition:** admitted; children copy the relevant lines into their work
+orders at stamping time.


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

The epic-rework plan is now the epic's proposal: the reviewed spec moves from
`docs/` into the change folder, gains the epic-level risk contract children
copy from at stamping time, and picks up a design stub pointing rulings at the
ADR tree. The epic issue is open and links here as its authority.

* The risk contract's must-prevent lines are tracker state (no state-carrying
  label deleted without its issues surfaced first), calibration
  misattribution, and agentflow's per-file pins; recovery is always a visible
  stop, never automatic.
* The move is content-identical apart from the two appended sections; the
  document itself merged already reviewed.

Fixes nothing; the epic closes when its children do.
