### PR TITLE
feat(epic): define ledger planning protocol

### DIFF
--- a/docs/scope/142-epic-skill-content.md
+++ b/docs/scope/142-epic-skill-content.md
@@ -13,6 +13,15 @@
   spike resolved. GitHub remains authoritative; the epic ledger records only the
   derived one-line state and never the comment URL. This standardizes the
   convention after issue #140 used `## Spike findings`. — `inline`
+- Durable close ordering follows tracker truth. For a research spike: the
+  `## Findings` comment lands; the home session verifies it; the spike issue
+  closes; then the home session derives its `Spikes` and `Decisions` ledger
+  lines, updates Status, commits with DCO sign-off, and pushes the standing
+  planning branch. For the epic: the direct tracker completion checks pass;
+  the home session syncs the final ledger and archives the OpenSpec change in a
+  signed, pushed commit; only then does the planning pull request leave draft;
+  a human merges it; the home session verifies the merge, closes the epic issue,
+  and tears down the planning worktree. — `inline`
 
 ### Risk contract
 
@@ -30,9 +39,9 @@
 - **Evidence owed:** validator and the full enumerated suite green; behavior pins
   for the normative epic ledger, planning-PR lifecycle, bounded filing rules,
   exact `## Findings` verification, deferred close-out mutations, four-label
-  bootstrap, native child issues, native blocked-by edges, and direct tracker
-  completion checks; bounded zero-hit checks for the three gate terms and the
-  enumerated superseded protocol identifiers.
+  bootstrap, native child issues, native blocked-by edges, direct tracker
+  completion checks, and both durable close sequences; bounded zero-hit checks
+  for the three gate terms and the enumerated superseded protocol identifiers.
 
 Why: this skill is inherited process machinery whose tracker instructions can
 mutate durable issue state.

--- a/docs/scope/142-epic-skill-content.md
+++ b/docs/scope/142-epic-skill-content.md
@@ -1,0 +1,48 @@
+# Scope ledger — issue 142 epic skill content
+
+## Decisions
+
+- A deferred child receives its `spike` or `build` type label when it is filed,
+  then also receives `deferred`. The parent proposal's orphan-control section
+  already requires "a type label plus `deferred`"; this is clarification of the
+  existing rule, not a proposal amendment. — `inline`
+- A research spike's terminal result comment starts with the exact heading
+  `## Findings`. The home session verifies that mechanically before marking the
+  spike resolved. GitHub remains authoritative; the epic ledger records only the
+  derived one-line state and never the comment URL. This standardizes the
+  convention after issue #140 used `## Spike findings`. — `inline`
+
+### Risk contract
+
+- **Must prevent:** secret exposure; irreversible loss of authoritative tracker
+  data; silent incorrect success from instructions that appear to complete an
+  epic while tracker state or the epic ledger still shows unresolved work.
+- **Must recover:** nothing automatically. Tracker or Git failures stop visibly
+  for the operator; the epic ledger and live GitHub state provide manual recovery
+  points.
+- **Accepted failure:** a build session may die mid-run and resume from its work
+  order and worktree; epic-ledger staleness is visible and corrected manually
+  from tracker state.
+- **Unsupported:** trackers other than GitHub Issues; concurrent epics sharing
+  one OpenSpec change directory.
+- **Evidence owed:** validator and the full enumerated suite green; behavior pins
+  for the normative epic ledger, planning-PR lifecycle, bounded filing rules,
+  exact `## Findings` verification, deferred close-out mutations, four-label
+  bootstrap, native child issues, native blocked-by edges, and direct tracker
+  completion checks; bounded zero-hit checks for the three gate terms and the
+  enumerated superseded protocol identifiers.
+
+Why: this skill is inherited process machinery whose tracker instructions can
+mutate durable issue state.
+
+Disposition: admitted into issue #142's work order.
+
+## Open questions
+
+- None.
+
+## Spawned tasks
+
+- Cold executor, rule-corpus, and ceremony-skeptic review passes completed in
+  this triage session; their verified blocking conditions are folded into the
+  revised work order.

--- a/docs/scope/142-epic-skill-content.md
+++ b/docs/scope/142-epic-skill-content.md
@@ -50,10 +50,25 @@ Disposition: admitted into issue #142's work order.
 
 ## Open questions
 
-- None.
+- When a deferred `build` child is closed as won't-do, must it also leave the
+  closing epic's native child set, or does the completion predicate admit a
+  closed won't-do build without a merged pull request?
+- How does a research spike produce the authoritative `## Findings` GitHub
+  comment while the existing `$research` interface requires a Markdown file in
+  the repository and only the epic ledger may ride the standing planning pull
+  request?
+- Must the first epic normalize its declared child relationships and standing
+  ledger before issue #142 executes? Live grounding found issues #143 through
+  #147 declare themselves children of #133 but have no native parent; the
+  standing ledger uses non-normative Build states and puts instructions in
+  Notes.
 
 ## Spawned tasks
 
 - Cold executor, rule-corpus, and ceremony-skeptic review passes completed in
   this triage session; their verified blocking conditions are folded into the
   revised work order.
+- Three review panels reached the mandatory cap. The final panel's remaining
+  blockers are the three decisions above plus an executable spike for the
+  direct GitHub completion predicates; drafting is stopped until `/scope`
+  resolves them.

--- a/docs/scope/142-epic-skill-content.md
+++ b/docs/scope/142-epic-skill-content.md
@@ -3,9 +3,11 @@
 ## Decisions
 
 - A deferred child receives its `spike` or `build` type label when it is filed,
-  then also receives `deferred`. The parent proposal's orphan-control section
-  already requires "a type label plus `deferred`"; this is clarification of the
-  existing rule, not a proposal amendment. — `inline`
+  then also receives `deferred`. This is the narrow exception for a deferred
+  child the epic files: ordinary build tickets still receive `build` from ticket
+  triage. The parent proposal's orphan-control section already requires "a type
+  label plus `deferred`"; this is clarification of the existing rule, not a
+  proposal amendment. — `inline`
 - A research spike's terminal result comment starts with the exact heading
   `## Findings`. The home session verifies that mechanically before marking the
   spike resolved. GitHub remains authoritative; the epic ledger records only the

--- a/docs/scope/142-epic-skill-content.md
+++ b/docs/scope/142-epic-skill-content.md
@@ -22,6 +22,28 @@
   signed, pushed commit; only then does the planning pull request leave draft;
   a human merges it; the home session verifies the merge, closes the epic issue,
   and tears down the planning worktree. — `inline`
+- A deferred build closed as won't-do stays a native child of its epic and
+  keeps its `build` type so the epic retains the history of work it declined.
+  The closing session posts the specific reason, closes the issue with GitHub's
+  `NOT_PLANNED` state reason, and removes `deferred`. The build completion
+  predicate therefore accepts either a merged closing pull request or a closed
+  `NOT_PLANNED` build. — `inline`
+- A research worker uses `$research` unchanged in a temporary per-spike
+  worktree and returns its Markdown findings file. The home session posts that
+  content to the spike under the exact `## Findings` heading, verifies the
+  comment, then removes the temporary worktree and its unshipped file. The
+  standing planning pull request still carries only the epic ledger. — `inline`
+- The first epic adopts the native tracker and normative-ledger contract before
+  issue #142 executes. Live verification on 2026-08-24 found every declared
+  child attached to #133 and PR #136 at `43cad55`, with pointer-only Notes and
+  the closed Builds grammar. — `inline`
+- The direct completion-read spike is grounded in GitHub CLI 2.97.0's actual
+  shapes: `subIssues.nodes` enumerates children; each child's labels, state,
+  state reason, and closing pull-request references determine its branch; each
+  referenced pull request's `mergedAt` determines merge truth. Its fixtures pass
+  merged and `NOT_PLANNED` builds and reject open spikes, incomplete builds, and
+  open deferred children. Against live #133 it correctly fails on #140, builds
+  #139/#142–#147, and deferred #147. — `inline`
 
 ### Risk contract
 
@@ -50,18 +72,7 @@ Disposition: admitted into issue #142's work order.
 
 ## Open questions
 
-- When a deferred `build` child is closed as won't-do, must it also leave the
-  closing epic's native child set, or does the completion predicate admit a
-  closed won't-do build without a merged pull request?
-- How does a research spike produce the authoritative `## Findings` GitHub
-  comment while the existing `$research` interface requires a Markdown file in
-  the repository and only the epic ledger may ride the standing planning pull
-  request?
-- Must the first epic normalize its declared child relationships and standing
-  ledger before issue #142 executes? Live grounding found issues #143 through
-  #147 declare themselves children of #133 but have no native parent; the
-  standing ledger uses non-normative Build states and puts instructions in
-  Notes.
+- None.
 
 ## Spawned tasks
 
@@ -69,6 +80,7 @@ Disposition: admitted into issue #142's work order.
   this triage session; their verified blocking conditions are folded into the
   revised work order.
 - Three review panels reached the mandatory cap. The final panel's remaining
-  blockers are the three decisions above plus an executable spike for the
-  direct GitHub completion predicates; drafting is stopped until `/scope`
-  resolves them.
+  blockers were routed through `/scope`. The user settled all three decisions,
+  the epic home session normalized live tracker and ledger state, and the direct
+  GitHub completion predicates passed their fixture spike and failed on the
+  expected live open work.

--- a/skills/drivers/epic/SKILL.md
+++ b/skills/drivers/epic/SKILL.md
@@ -1,325 +1,92 @@
 ---
 name: epic
-description: Chart and resolve a large, foggy effort as a GitHub map of decision tickets, then hand clear independent subtrees to your implementation workflow as ordinary build issues. Use when an idea is too large or uncertain for one session, when the user invokes wayfinder or supplies a wayfinder map, or when planning must settle research, UI, domain, and scope decisions before implementation begins.
+description: "Maintain an epic ledger and work clear child tickets through a GitHub-backed planning lifecycle. Use when an effort needs multiple attended sessions, recorded decisions, spikes, or independently shippable builds."
 ---
 
-# Wayfinder
+# Epic
 
-Find the way to a destination across multiple sessions. Maintain one `wayfinder:map`
-issue with child decision tickets, resolve one decision per session, and file build
-issues only when no open decision can invalidate their subtree.
+`$epic` maintains one OpenSpec-backed epic from its first uncertainty through human-verified close-out. It plans and coordinates; clear implementation belongs in ordinary child tickets and runs through `$ticket`.
 
-## Operating rules
+## Authority and boundaries
 
-- **Plan, do not build.** Resolve decisions and create planning artifacts. The pull to
-  implement is normally the signal to hand a clear subtree to whatever process builds
-  your work.
-- **Refer by name.** In human-facing text, wrap issue links in their titles. Never make
-  people decode a wall of bare issue numbers.
-- **Keep one source for each answer.** The resolution lives in its ticket comment. The map
-  keeps only a one-line gist and link. An ADR keeps only the lasting ruling.
-- **Work one decision per session.** Parallel AFK research tickets are the sole exception.
-- **Ground structural decisions in the project's standards.** When a decision ticket
-  settles module or interface shape, judge it by the project's engineering standards
-  document (charter, architecture guide) when one exists, and load `/codebase-design`
-  for the vocabulary when it is available. Interface shape is a decision the map
-  resolves, never one left implicit for the build session.
-- **Use GitHub's native structure.** Read
-  [references/github-tracker.md](references/github-tracker.md) before any tracker action.
-  Do not replace child issues, blocking relationships, or label claims with body text.
+An epic lives at `openspec/changes/<epic-slug>/`. Its `proposal.md` and `design.md` are authoritative for destination, scope, risk, and durable decisions. The epic ledger is a derived index, not another source of truth. Live GitHub is truth whenever it disagrees with the ledger.
 
-## Evidence v2
+Use GitHub Issues only. Read [the tracker reference](references/github-tracker.md) before the first tracker action. A tracker, authentication, or Git failure stops the current operation visibly; do not guess or repair authoritative state from the ledger.
 
-Use [the shared envelope reference](../../../docs/evidence/envelope-v2.md) for a grounded
-claim, criterion, decision, or disposition only after its GitHub issue/comment or ADR
-has a stable locator and normalized immutable content digest. The map and scratchpad
-are planning state, not evidence authority. Record the decision in its existing ticket
-protocol first; emit only normalized authority facts and lineage, never the research
-body, candidate list, proposal, or worker transcript.
+The home session owns the epic. It stays at planning altitude, files and reads issues, and is the only epic-ledger writer. Build and triage sessions report in their ticket comments and pull requests; the home session syncs the ledger after they return. Coordinators do not nest.
 
-## The map
+## The epic ledger
 
-The map is a GitHub issue labelled `wayfinder:map`. Its decision tickets are native child
-issues. The map body is the low-resolution view loaded at the start of every session:
+Keep `ledger.md` on one standing draft planning pull request, in a dedicated planning worktree. Every planning commit is signed-off, pushed as work proceeds, and the branch merges from main only when necessary. The close-out commit moves the OpenSpec change to the archive in that same pull request. After human merge verification, tear down the planning worktree.
+
+This template and grammar are normative:
 
 ```markdown
-## Destination
+# Ledger — <epic title>
 
-<One or two lines describing what this effort is finding its way to.>
+## Status
+next: <the single next action, one line>
+updated: <YYYY-MM-DD>
 
 ## Notes
+- <pointer only: a skill to invoke, or the location of an existing rule>
 
-<Domain, standing preferences, and skills every session must consult.>
+## Fog
+- <something not yet precise enough to ticket>
 
-## Decisions so far
+## Decisions
+- #<n> <title> — <one-line gist of the resolved spike's ruling>
 
-- [<closed ticket title>](https://github.com/<org>/<repo>/issues/<n>) — <one-line gist>
+## Spikes
+- #<n> <title> — open | dispatched | resolved — <one-line gist>
 
-## Awaiting disposition
+## Builds
+- #<n> <title> — filed | triaged | in-progress | pr:#<n> | merged
 
-- [<open research ticket title>](https://github.com/<org>/<repo>/issues/<n>) — <findings are complete; build candidates need rulings>
+## Deferred
+- #<n> <title> — <one-line reason it can wait>
 
-## Not yet specified
-
-<In-scope fog that cannot yet be phrased as a precise question.>
-
-## Handoffs
-
-- [<build issue title>](https://github.com/<org>/<repo>/issues/<n>) — <independent subtree handed off>
-
-## Out of scope
-
-<Work consciously ruled beyond the destination, with reasons.>
+## Rounds
+- <YYYY-MM-DD> #<n> — <sessions used, outcome, one line>
 ```
 
-The map is an index, not a duplicate store. Discover live work from its open child issues,
-not by maintaining another ticket list in the body.
+Titles never contain ` — `. `Spikes` and `Builds` split at the first delimiter whose next field is a listed state token; free text follows a second delimiter. `Decisions` and `Deferred` have only free text after their first delimiter. `Rounds` lead with date, issue reference, and free text. `Notes` and `Fog` are plain lines.
 
-## Decision tickets
+`Notes` contains pointers and never rules; new standing instructions belong in the repository's ADR home. `Decisions` is derived from resolved spikes, one line for each ruling that still stands. GitHub state, including the `deferred` label, wins over every ledger line.
 
-Each ticket is sized to one agent session and has this body:
+## Start and maintain an epic
 
-```markdown
-## Question
+1. Confirm the target repository already has OpenSpec. Otherwise run `$openspec-adopt` as a separate documentation-only pull request.
+2. Land the proposal and design on main before opening child work. Create the epic issue with the `epic` label, its native child issues, and the standing draft planning pull request carrying the ledger.
+3. Re-read relevant live GitHub state before each mutation. Sync derived ledger lines and `Status`, commit with DCO sign-off, and push. If that ledger push fails, report visible ledger staleness and recover its derived state from live GitHub before continuing.
+4. Keep Fog as the operator's prompt. Remove a Fog line only through a `Decisions` line or a spike; never silently delete it.
 
-<The precise decision or investigation this ticket resolves.>
-```
+## Admit work deliberately
 
-Apply exactly one ticket-type label:
+File a spike when a question is precise but not yet resolved. A spike can be research, interview, mockup, or a human prerequisite. File a build only as a bounded refusal: refuse to file a build while an open spike or standing Fog line can invalidate its outcome, constraints, or acceptance criteria.
 
-- **`wayfinder:research` (AFK-able):** Any investigation an unattended agent session can
-  finish alone — an internal repository audit as much as an outward read. Invoke `/research`
-  when the answer depends on documentation, third-party systems, or sources outside the
-  repository; ground directly in the repo when it doesn't. Record findings, sources, and
-  the decision they support. Treat `/research` as a required dependency for outward reads:
-  if it is unavailable, leave the ticket unclaimed and tell the human rather than
-  substituting a generic search pass. The label is a promise of AFK-ability — an unattended
-  session may be dispatched for an unclaimed research ticket, so apply it honestly.
-- **`wayfinder:prototype` (HITL):** Invoke `/ui-craft`. Produce repository-grounded
-  variants, iterate with the human, and finish with a locked visual spec linked from the
-  ticket. That artifact also satisfies any later review gate that demands a locked design.
-- **`wayfinder:interview` (HITL):** Invoke `/scope`'s interview mode, plus a
-  domain-modelling skill when one is available. Follow interview mode's design-tree
-  cadence: ask the whole currently answerable frontier in one numbered round, then
-  wait. Never answer the human's side of the exchange.
-- **`wayfinder:task` (HITL):** A prerequisite that genuinely needs the human in the loop.
-  It earns a place only by unblocking a decision, not by delivering the destination — and
-  it is never an execution errand: a prerequisite that must *change the world* before a
-  decision can be made is handed off as an ordinary build issue, and its landed result
-  feeds back into the map as a decision input.
+Before filing a build, require every relevant load-bearing ruling in the repository's ADR home. User-facing work also requires a locked `/ui-craft` spec. The build issue must stand alone and receive the normal `$ticket` triage flow; the epic does not manufacture a work order.
 
-`wayfinder:awaiting-disposition` is durable state, not a ticket type or a claim. A research
-ticket in that state remains open, keeps its one `wayfinder:research` ticket-type label, and
-may temporarily also carry the distinct `wayfinder:resolving` claim while a human reconciles
-its findings.
+Use native `blocked-by` edges for actual dependencies. A follow-up required to reach the epic destination is an in-scope native child. A follow-up outside that destination is also filed as a native child, receives its `spike` or `build` type plus `deferred`, and is reported on the originating ticket. Ordinary builds still receive `build` from ticket triage.
 
-The claim is the `wayfinder:resolving` label, shared by human sessions and unattended
-workers. Assignment is not the claim: an unattended worker may run under the operator's own
-GitHub identity, so assignment cannot tell the two apart. Set the label before work, remove
-it on completion or when giving up, and skip open tickets already claimed. Native issue
-dependencies define order. The **frontier** is the map's child tickets that are open,
-unblocked, unclaimed, and not carrying `wayfinder:awaiting-disposition`.
+## Resolve spikes
 
-The session that launches a worker owns claim recovery. A successful spawn is not a
-durable outcome: supervise the worker until the ticket is resolved or the worker fails. On
-failure or interruption, remove its `wayfinder:resolving` claim before reporting the ticket
-available again. Never leave a claimed ticket behind with no live worker. If your
-environment has its own dispatcher that runs unclaimed research tickets unattended, that
-dispatcher owns them instead and charting does not spawn workers itself.
+For a research spike, run `$research` in a temporary per-spike worktree. The worker writes the Markdown file required by its public interface and returns it to the home session. The home session posts that returned content under the exact heading `## Findings`, verifies the `## Findings` comment, removes the temporary worktree and its unshipped file, and only then closes the spike.
 
-## Fog and scope
+Close the spike issue only after that verification. Only then derive its `Spikes` and `Decisions` ledger lines, update `Status`, commit with DCO sign-off, and push the standing planning branch. A failed worker leaves the spike `dispatched`; it is not resolved by inference. Interview and mockup spikes run as fresh attended sessions.
 
-Put a question in a ticket when it can be stated precisely now, even if blocked. Keep it in
-`Not yet specified` when the question itself is still vague. Do not pre-slice fog: one patch
-may later become several tickets or none.
+## Deferred child close-out
 
-Keep decided work, live tickets, and out-of-scope work out of the fog. When a ticket proves
-to be beyond the destination, close it, link it under `Out of scope` with the reason, and do
-not add it to `Decisions so far`.
+Before archive, sweep each deferred child from live GitHub state. A human must choose exactly one disposition:
 
-## Chart a map
+- Promote it outside the closing epic as a spike or build, and remove `deferred`.
+- Reparent it to a future epic while retaining `deferred`; it is no longer this epic's child.
+- Post the won't-do reason, close it with state reason `NOT_PLANNED`, keep its type label, and remove `deferred`.
 
-When the user brings a loose idea:
+Refuse to archive while an open child carries `deferred`.
 
-1. Run `/scope`'s interview mode, and a domain-modelling skill when one is available, to
-   name the destination. The destination fixes scope, so settle it first.
-2. Grill breadth-first across the effort. Surface precise decisions, dependency order, and
-   coarse fog without resolving any ticket.
-3. If the route is already clear and fits one session, stop and tell the user a map would
-   add no leverage.
-4. Ensure the six persistent `wayfinder:*` labels exist, then create the map with its destination,
-   notes, fog, and scope boundary.
-5. Create every currently precise decision ticket as a child of the map. Create all issues
-   first, then add native blocking relationships in a second pass.
-6. Verify `/research` is available and the environment can both launch and supervise
-   background workers. If either capability is unavailable, leave research tickets
-   unclaimed and report the missing prerequisite.
-7. For each research ticket already on the frontier, launch one separate AFK worker with
-   `/research` and the complete ticket-resolution task attached. Tell it explicitly that it
-   is already the background worker: it must research directly, never delegate again. Each
-   worker verifies eligibility, claims, researches, comments, and updates only its ticket
-   and the map. Its terminal findings comment must end with the structured candidate list
-   defined under **Reconcile completed research**. If that list contains any
-   `handoff_required` candidates, it adds `wayfinder:awaiting-disposition`, adds the ticket
-   under `Awaiting disposition`, releases its claim, and leaves the ticket open. Otherwise it
-   records the final gist under `Decisions so far`, closes the ticket, and releases its claim.
-8. Record every worker ID and supervise all workers to terminal completion. Spawn success
-   alone does not mean "research running." Before reporting success, verify the findings
-   comment and map update, then verify either an open, unclaimed awaiting-disposition ticket
-   or a closed ticket with no undisposed candidates. If a worker fails or is interrupted,
-   release its `wayfinder:resolving` claim and report the failure. If the user replaces the
-   task, reconcile or cancel every worker and release failed claims before switching work.
-9. Stop after every launch has reached a durable outcome. Charting creates the map; the
-   root session does not hand-resolve a research ticket while its worker runs.
+## Completion and close-out
 
-## Work through a map
+Read the three completion predicates directly from GitHub: no open spike child; every build child has a merged closing pull request or is closed `NOT_PLANNED`; and no open deferred child remains. Do not infer any predicate from a ledger line.
 
-When the user supplies a map, optionally with a ticket:
-
-1. Load the map body, not every child body.
-2. Before selecting ordinary frontier work, inspect the map's open research children and
-   reconcile every one carrying `wayfinder:awaiting-disposition` by following **Reconcile
-   completed research** below. Restore a missing `Awaiting disposition` entry before
-   reconciling. Skip an awaiting child another session already claims with
-   `wayfinder:resolving`; that session owns finishing it. Re-read the map after each ticket;
-   do not begin frontier work while any unclaimed awaiting child or entry remains.
-3. If the user named a ticket, verify it is open and unblocked. Otherwise choose the first
-   frontier ticket in tracker order. Claim it before reading deeply or invoking another
-   skill.
-4. Resolve that one question. Load related tickets only as needed and invoke every skill in
-   the map's `Notes`.
-5. Post a resolution comment with the answer, supporting evidence or artifact links, and
-   the important alternatives rejected. Keep the full reasoning here.
-6. Decide whether the ruling is load-bearing. Create or update an ADR before closing when
-   the decision constrains multiple builds, is costly to reverse, settles architecture or
-   domain language, or must be enforced downstream. Follow the repository's ADR format and
-   index. Link the ADR from the resolution; keep reasoning in the ticket and the concise
-   ruling plus consequences in the ADR.
-7. Close the ticket and append its titled link plus one-line gist to `Decisions so far`.
-8. Create and wire newly precise tickets, graduate cleared fog, and remove invalidated or
-   out-of-scope tickets. Expect concurrent sessions and re-read tracker state before edits.
-9. Evaluate handoff eligibility for every affected independent subtree.
-
-## Reconcile completed research
-
-Completed unattended research with structured `handoff_required` candidates is not resolved
-until a human disposes every candidate. Keep the research ticket open, keep
-`wayfinder:awaiting-disposition`, and keep its titled link under the map's
-`Awaiting disposition` section throughout reconciliation.
-
-Claim the research ticket with `wayfinder:resolving`, then read its terminal findings comment.
-The worker writes every candidate in a final fenced YAML block using this envelope; an empty
-`candidates` list explicitly proves that no build disposition is pending:
-
-```yaml
-wayfinder_findings:
-  candidates:
-    - id: <stable identity unique within this research ticket>
-      disposition: handoff_required
-      title: <independently shippable outcome>
-      outcome: <observable result the build must produce>
-```
-
-Keep `id` byte-for-byte unchanged in every build issue or disposition comment. Candidate IDs,
-not titles or list position, are the replay identity. A missing or malformed envelope is not a
-completed research result: repair the findings comment before closing or reconciling the ticket.
-The operator may select zero or more candidates. For each independently shippable selected
-candidate, file one ordinary standalone build issue using **Hand clear work to implementation**;
-never combine independent candidates into an umbrella issue. Copy the candidate's exact
-structured identity into that issue's `Wayfinder candidate:` marker so replay can match the
-issue back to one candidate. For every unselected candidate, record that same identity in a
-disposition comment on the research ticket:
-
-- **No-build:** name the reason, the observable trigger that would invalidate the ruling, and
-  the condition that verifies no build is needed.
-- **Deferred:** name the observable trigger that reopens consideration and the condition that
-  will verify the later build is complete.
-
-A selected candidate is durably disposed only when all three handoff facts agree:
-
-1. the map's `Handoffs` entry links the build issue;
-2. the build issue body contains the exact marker `Wayfinder handoff: #<map>`; and
-3. the build issue has a native `blockedBy` edge to this terminal research child.
-
-A map link alone never counts as a handoff. Before filing anything, and again after every
-GitHub mutation, re-read the map, research comments and labels, candidate build issue bodies,
-and native dependencies. Derive completed work from GitHub: match existing map entries and
-ordinary issues carrying the exact marker and research dependency back to each structured
-candidate by its copied identity. Repair a partial three-fact handoff in place; never create a
-duplicate build issue, map line, or disposition comment. The tracker reference gives the
-mutation order and replay procedure.
-
-After every candidate has exactly one durable selected, no-build, or deferred disposition,
-finalize in order: remove the ticket's `Awaiting disposition` map entry, remove
-`wayfinder:awaiting-disposition`, append its titled link and explicit final gist under
-`Decisions so far`, then close the research ticket and release its claim.
-Close research only after every candidate has a durable disposition; never close it with an
-undisposed candidate.
-
-Maintainer invariant: closed research always has a durable disposition. No hidden
-issues-to-file list exists outside GitHub.
-
-## Hand clear work to implementation
-
-Hand off a subtree as soon as all of these are true:
-
-- its fog is empty;
-- no open decision anywhere on the map could invalidate its outcome, constraints, or
-  acceptance criteria;
-- every relevant load-bearing ruling is in an ADR;
-- any user-facing surface has a locked `/ui-craft` spec.
-
-File a new ordinary GitHub issue in the repository that will build it. Do **not** make it a
-child decision ticket, and do **not** add any `wayfinder:*` label. Whatever intake your
-implementation workflow uses owns its own routing labels, briefs, and effort dials —
-wayfinder never sets them.
-
-Make the issue stand alone. Whoever picks it up grounds from the repository and will not
-chase the map's links to reconstruct context. Use the repository's domain terms and inline
-every relevant ruling:
-
-```markdown
-## Outcome
-
-<Observable result this build should deliver.>
-
-## Decided constraints
-
-- <Decision title>: <ruling stated inline, with ADR link when one exists>
-
-## Scope
-
-<What this ticket includes.>
-
-## Acceptance criteria
-
-- <Observable criterion>
-
-## Evidence and locked artifacts
-
-- <Research evidence or locked visual spec, with the operative conclusion repeated here>
-
-## Not part of this ticket
-
-- <Nearby work deliberately excluded>
-
-Wayfinder handoff: #<map>
-Wayfinder candidate: <candidate id — only when this issue came from a research disposition>
-```
-
-Before filing, run `/plan-review` on the brief above — a finding can still change the issue
-body before the marker/dependency triad below is written.
-
-Before filing, reconcile existing handoff facts in GitHub. The two trailing marker lines are
-the issue's durable identity: keep `Wayfinder handoff: #<map>` byte-for-byte, and carry
-`Wayfinder candidate:` only when a research disposition produced this issue, repeating that
-candidate's `id` unchanged. Then add a native `blockedBy` edge from the build issue to at
-least one terminal decision child that cleared the work, and link the filed issue under the
-map's `Handoffs`. During research disposition, that dependency is the terminal research
-child. All three facts must agree before the handoff counts. If intake sends the issue back
-for more scoping or clarification, treat that as evidence the map was incomplete: create a
-new decision ticket for the gap, link the held build issue, and stop handing off dependent
-work until the gap is resolved.
-
-The map is complete when nothing remains in fog, no decision ticket is open, and every
-buildable subtree has been handed off (or the destination explicitly requires no build).
+Only after all predicates pass, make the final ledger-and-archive commit and push it. Take the planning pull request out of draft, wait for the planning pull request to be human-merged, and verify that merge. Then close the epic issue and tear down the planning worktree. Report the issue and planning pull request URLs, the three direct checks, and any visible ledger staleness.

--- a/skills/drivers/epic/agents/openai.yaml
+++ b/skills/drivers/epic/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Wayfinder"
-  short_description: "Map a foggy effort as decision tickets"
-  default_prompt: "Use $epic to chart this large effort as decision tickets and work the next clear decision."
+  display_name: "Epic"
+  short_description: "Maintain an epic ledger and work clear child tickets"
+  default_prompt: "Use $epic to maintain this effort's ledger, resolve its open spikes, and file clear child tickets."

--- a/skills/drivers/epic/references/github-tracker.md
+++ b/skills/drivers/epic/references/github-tracker.md
@@ -1,216 +1,77 @@
 # GitHub tracker operations
 
-Wayfinder uses GitHub's native child issues, dependencies, and labels. The
-commands below require a current GitHub CLI with `--add-sub-issue`, `--add-blocked-by`, and
-the `subIssues` / `blockedBy` JSON fields. Run `gh version` and `gh auth status` before the
-first mutation. Pass `--repo OWNER/REPO` explicitly when the working directory is ambiguous.
+Epic planning uses authenticated GitHub Issues. Before a mutation, run `gh version` and `gh auth status`; pass `--repo OWNER/REPO` explicitly. The current GitHub CLI must support native sub-issues and dependencies. Live tracker state is truth; re-read it after every mutation that changes relationships or labels.
 
-## Labels
+## Bootstrap labels
 
-Create the vocabulary once per repository. `--force` makes this idempotent without changing
-the state of any issue:
+Create exactly the four protocol labels idempotently. The `ticket:*` status axis is independent and this skill must not remove, rename, or reconcile it.
 
 ```sh
-gh label create wayfinder:map       --color 5319e7 --description "Map of decisions for a multi-session effort" --force
-gh label create wayfinder:research  --color 0e8a16 --description "AFK research decision" --force
-gh label create wayfinder:prototype --color 1d76db --description "HITL locked UI mockup decision" --force
-gh label create wayfinder:interview --color fbca04 --description "HITL interview or domain decision" --force
-gh label create wayfinder:task      --color c5def5 --description "Prerequisite action that unblocks a decision" --force
-gh label create wayfinder:awaiting-disposition --color bfdadc --description "Completed research awaiting human disposition" --force
+gh label create epic     --repo OWNER/REPO --color 5319e7 --description "OpenSpec planning container" --force
+gh label create spike    --repo OWNER/REPO --color 0e8a16 --description "Question that resolves planning uncertainty" --force
+gh label create build    --repo OWNER/REPO --color 1d76db --description "Implementable ticket" --force
+gh label create deferred --repo OWNER/REPO --color bfdadc --description "Outside this epic's current scope" --force
 ```
 
-Every map and decision ticket carries exactly one of the first five ticket-type labels.
-`wayfinder:awaiting-disposition` is additional state compatible with exactly one ticket-type
-label; it is not a second ticket type and is distinct from the transient
-`wayfinder:resolving` claim. Keep the `wayfinder:` namespace reserved for planning: whatever
-labels your implementation workflow uses live outside it, and nothing in that namespace
-belongs on a build issue.
+An epic has `epic`; each child has one of `spike` or `build`; a deferred child also has `deferred`. Ticket triage applies `build` to ordinary build tickets.
 
-## Create the map and tickets
+## Native structure
 
-Create issue bodies in a temporary file and use `--body-file` so Markdown is not damaged by
-shell quoting:
+Create issue bodies in temporary files and use `--body-file`. Capture returned URLs rather than guessing numbers. Attach every spike, build, and deferred follow-up to the epic through native child issues:
 
 ```sh
-gh issue create --repo OWNER/REPO --title "Map: <destination>" \
-  --body-file /path/to/map-body.md --label wayfinder:map
-
-gh issue create --repo OWNER/REPO --title "Decide <question>" \
-  --body-file /path/to/ticket-body.md --label wayfinder:interview
+gh issue edit EPIC_NUMBER --repo OWNER/REPO --add-sub-issue CHILD_NUMBER
 ```
 
-Capture the returned URLs or resolve titles immediately; never guess issue numbers.
-
-Add each decision ticket as a native child after both issues exist:
-
-```sh
-gh issue edit MAP_NUMBER --repo OWNER/REPO --add-sub-issue TICKET_NUMBER
-```
-
-Build issues filed at handoff are not children of the map. The child set remains the exact
-decision-ticket set used to calculate the frontier.
-
-## Wire dependencies
-
-If `BLOCKED_NUMBER` cannot be worked until `BLOCKER_NUMBER` closes:
+Express a real prerequisite with a native blocked-by edge:
 
 ```sh
 gh issue edit BLOCKED_NUMBER --repo OWNER/REPO --add-blocked-by BLOCKER_NUMBER
 ```
 
-Use `--remove-blocked-by`, `--add-blocking`, or `--remove-blocking` to correct edges. Never
-encode a dependency only as `Blocked by #N` prose; body prose is not queryable, and other
-tools may already read that convention for their own purposes. Wayfinder uses GitHub's
-native planning relationship.
+Use `--remove-blocked-by`, `--add-blocking`, `--remove-blocking`, `--parent`, or `--remove-parent` to correct a live relationship. Never substitute prose for native structure.
 
-## Read the map and frontier
+## Read an epic and its children
 
-Load the map at low resolution:
+Read the epic's child nodes directly; `subIssues.nodes` is the child list. Then read every child's labels, state, state reason, and closing-pull-request references. Finally read each referenced pull request's `mergedAt` value.
 
 ```sh
-gh issue view MAP_NUMBER --repo OWNER/REPO \
-  --json number,title,url,body,state,subIssues,subIssuesSummary
+gh api graphql -f query='query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    issue(number:$number) {
+      subIssues(first:100) { nodes {
+        number title state labels(first:20) { nodes { name } }
+        stateReason
+        closedByPullRequestsReferences(first:20) { nodes { number mergedAt } }
+      } }
+    }
+  }
+}' -F owner=OWNER -F repo=REPO -F number=EPIC_NUMBER
 ```
 
-List child numbers, then inspect only the open candidates:
+If a closing reference needs fresh confirmation, read that pull request directly:
 
 ```sh
-gh issue view MAP_NUMBER --repo OWNER/REPO --json subIssues --jq '.subIssues[].number'
-
-gh issue view TICKET_NUMBER --repo OWNER/REPO \
-  --json number,title,url,state,labels,assignees,blockedBy
+gh pr view PR_NUMBER --repo OWNER/REPO --json number,state,mergedAt,url
 ```
 
-A ticket is on the frontier only when `state` is `OPEN`, it does not carry either the
-`wayfinder:resolving` or `wayfinder:awaiting-disposition` label, and every issue in
-`blockedBy` is closed. Preserve GitHub's returned child order when choosing the first
-frontier ticket. Tickets carrying `wayfinder:awaiting-disposition` are excluded from the frontier.
+## Completion checks
 
-## Claim and resolve
+Perform these direct reads before close-out, and report each as pass or fail:
 
-The claim is the `wayfinder:resolving` label, shared by human sessions and unattended
-workers. Assignment cannot distinguish the two, since an unattended worker may run under the
-operator's own GitHub identity. Claim before doing work:
+1. **No open spike child:** every child with label `spike` is closed.
+2. **Build completion:** every child with label `build` either has a closing pull request whose `mergedAt` is non-null, or is closed with `stateReason` `NOT_PLANNED`.
+3. **No open deferred child:** no open child carries `deferred`.
+
+Only these live reads decide whether the epic may close. A ledger mismatch is visible staleness for the home session to correct, never a completion pass.
+
+## Deferred dispositions
+
+At close-out, first re-read the child and parent relationship. Promotion removes `deferred` and files the child outside the closing epic. Reparenting uses the new parent's native relationship while keeping `deferred`. A won't-do outcome posts the reason, closes with `--reason not planned`, retains the type label, and removes `deferred`:
 
 ```sh
-gh label create wayfinder:resolving --repo OWNER/REPO --color d4c5f9 \
-  --description "A session is resolving this decision ticket" --force
-gh issue edit TICKET_NUMBER --repo OWNER/REPO --add-label wayfinder:resolving
+gh issue close CHILD_NUMBER --repo OWNER/REPO --reason "not planned"
+gh issue edit CHILD_NUMBER --repo OWNER/REPO --remove-label deferred
 ```
 
-Re-read the issue after claiming. If another session won the race, choose another frontier
-ticket. Release the claim on completion or when giving up:
-
-```sh
-gh issue edit TICKET_NUMBER --repo OWNER/REPO --remove-label wayfinder:resolving
-```
-
-Post the full answer as a comment, then close only after its ADR and map update are durable:
-
-```sh
-gh issue comment TICKET_NUMBER --repo OWNER/REPO --body-file /path/to/resolution.md
-gh issue close TICKET_NUMBER --repo OWNER/REPO --reason completed
-```
-
-Update the map with `gh issue edit MAP_NUMBER --body-file ...`. Before every mutation,
-re-fetch the current body and child/dependency state so concurrent sessions do not overwrite
-one another.
-
-## Reconcile awaiting dispositions
-
-Human map sessions inspect every open research child and reconcile each one carrying
-`wayfinder:awaiting-disposition` before reading the ordinary frontier. The state label is the
-durable queue; `Awaiting disposition` is its map index. If either side is missing, restore the
-map entry for every labeled child before reconciling and do not treat an unlabeled map entry as
-disposed without checking its research ticket. For each pending child, load its labels and
-terminal findings comment. Skip it when another session already holds `wayfinder:resolving`;
-otherwise claim it and re-read to confirm the claim. Keep the ticket open, keep
-`wayfinder:awaiting-disposition`, and keep the map entry until every structured
-`handoff_required` candidate has a durable ruling.
-
-Treat GitHub as the recovery log. Before the first mutation and after every mutation:
-
-1. Re-fetch the map body, all open research children and their labels, research ticket
-   comments, and native relationships. Repair any mismatch between labeled children and the
-   map's `Awaiting disposition` index before continuing.
-2. Enumerate the map's `Handoffs` links and ordinary issues whose bodies contain the exact
-   `Wayfinder handoff: #<map>` marker, then inspect each issue's `blockedBy` relationships:
-
-   ```sh
-   gh search issues --repo OWNER/REPO --match body "Wayfinder handoff: #MAP_NUMBER" \
-     --json number,title,url,state,body --limit 100
-
-   gh issue view BUILD_NUMBER --repo OWNER/REPO --json number,title,url,state,body,blockedBy
-   ```
-
-   GitHub's search tokenizes text, so treat every hit as a candidate only: confirm the exact
-   marker line in the fetched body before matching, and never conclude an issue is absent from
-   an empty search result alone — the map's `Handoffs` links are the second read.
-3. Match records by the exact candidate identity copied into each build issue or disposition
-   comment: the build issue repeats it in its `Wayfinder candidate:` marker, and the
-   disposition comment repeats it verbatim. A selected candidate is complete only when one map
-   entry, one exact marker, and one native `blockedBy` edge to this terminal research child all
-   name the same build issue.
-4. If only one or two facts exist, repair that same build issue. If all three exist, record no
-   new mutation. Create a build issue only when no existing or partial record matches.
-5. Treat an existing disposition comment as complete only when it matches the candidate
-   identity and contains `no-build` or `deferred`, its required observable trigger, and its
-   verification condition. A no-build ruling must also contain its reason. Repair an incomplete
-   comment in place; never append a duplicate disposition.
-
-Read the findings and disposition comments, and repair one in place, by its comment URL:
-
-```sh
-gh issue view RESEARCH_NUMBER --repo OWNER/REPO --json comments \
-  --jq '.comments[] | {url, body}'
-
-# COMMENT_ID is the number after `#issuecomment-` in that comment's URL.
-gh api --method PATCH /repos/OWNER/REPO/issues/comments/COMMENT_ID \
-  --field body=@/path/to/disposition.md
-```
-
-Posting a second comment for a candidate that already has one is a duplicate disposition, not
-a repair.
-
-For each selected candidate, create its standalone build issue first, carrying both the
-`Wayfinder handoff: #<map>` and `Wayfinder candidate:` markers in its body, then add the
-truthful dependency, then add its titled map line:
-
-```sh
-gh issue edit BUILD_NUMBER --repo OWNER/REPO --add-blocked-by RESEARCH_NUMBER
-```
-
-Never make build issues map children or add `wayfinder:*` labels to them. Every unselected
-candidate must instead have a research-ticket disposition comment that says `no-build` or
-`deferred`; include its exact candidate identity, an observable trigger, and a verification
-condition. Selecting zero candidates is valid only when every candidate has one of those
-explicit rulings.
-
-Once replay proves that every candidate is disposed, re-fetch the map and finalize in this
-order: remove its `Awaiting disposition` line, remove the state label, append the research
-ticket's explicit final gist under `Decisions so far`, close the ticket, and release the claim.
-
-```sh
-gh issue edit RESEARCH_NUMBER --repo OWNER/REPO --remove-label wayfinder:awaiting-disposition
-gh issue close RESEARCH_NUMBER --repo OWNER/REPO --reason completed
-gh issue edit RESEARCH_NUMBER --repo OWNER/REPO --remove-label wayfinder:resolving
-```
-
-Replay the full read-and-match procedure after an interruption. Closed research always has a
-durable disposition; no hidden issues-to-file list exists outside GitHub.
-
-## Correct structure
-
-```sh
-# Move a ticket to another map.
-gh issue edit TICKET_NUMBER --repo OWNER/REPO --parent NEW_MAP_NUMBER
-
-# Remove it from the current parent.
-gh issue edit TICKET_NUMBER --repo OWNER/REPO --remove-parent
-
-# Remove a child from a known map.
-gh issue edit MAP_NUMBER --repo OWNER/REPO --remove-sub-issue TICKET_NUMBER
-```
-
-Closing an out-of-scope ticket removes it from the frontier; keep it as a child so the map
-retains its planning history.
+Never archive while the completion read finds an open deferred child.

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3157,7 +3157,7 @@ export const chromium = {
         self.assertNotIn("HEADLESS-SANDBOX-BLOCKED", result.stdout + result.stderr)
 
 
-class EpicResearchDispatchHandshakeTests(unittest.TestCase):
+class EpicProtocolContractTests(unittest.TestCase):
     RESEARCH = (ROOT / "skills" / "tools" / "research" / "SKILL.md").read_text(encoding="utf-8")
     EPIC = (ROOT / "skills" / "drivers" / "epic" / "SKILL.md").read_text(
         encoding="utf-8"
@@ -3178,84 +3178,76 @@ class EpicResearchDispatchHandshakeTests(unittest.TestCase):
             r"(never|do not) spawn (a |another )?(nested|background )?(agent|worker)",
         )
 
-    def test_epic_supervises_launched_workers_to_a_terminal_outcome(self):
-        self.require(
-            self.EPIC, r"(supervise|wait for).*(terminal|completion|complete)"
-        )
+    def test_epic_names_proposal_and_design_as_authority(self):
+        self.require(self.EPIC, r"proposal\.md.*design\.md.*authoritative")
 
-    def test_epic_releases_a_failed_workers_claim(self):
-        self.require(
-            self.EPIC,
-            r"if a worker fails or is interrupted,\s+release its `wayfinder:resolving` claim",
-        )
+    def test_epic_ledger_template_has_all_normative_sections(self):
+        for heading in ("Status", "Notes", "Fog", "Decisions", "Spikes", "Builds", "Deferred", "Rounds"):
+            self.assertIn(f"## {heading}", self.EPIC)
 
-    def test_tracker_excludes_awaiting_disposition_from_the_frontier(self):
-        self.require(
-            self.TRACKER,
-            r"wayfinder:awaiting-disposition.*excluded from the frontier",
-        )
+    def test_epic_ledger_preserves_pointer_only_notes_and_derived_decisions(self):
+        self.require(self.EPIC, r"Notes.*pointers?.*never.*rules")
+        self.require(self.EPIC, r"Decisions.*derived")
 
-    def test_epic_reconciles_every_awaiting_disposition_child(self):
-        self.require(
-            self.EPIC,
-            r"reconcile every one carrying `wayfinder:awaiting-disposition`",
-        )
+    def test_home_session_is_the_sole_ledger_writer_and_tracker_wins(self):
+        self.require(self.EPIC, r"home session.*only.*ledger writer")
+        self.require(self.EPIC, r"live GitHub.*truth.*ledger")
 
-    def test_tracker_map_index_is_not_the_authoritative_pending_queue(self):
-        self.require(
-            self.TRACKER,
-            r"durable queue; `Awaiting disposition` is its map index",
-        )
+    def test_epic_uses_one_draft_planning_pr_and_signed_off_pushes(self):
+        self.require(self.EPIC, r"one standing draft planning pull request")
+        self.require(self.EPIC, r"signed-off.*push")
 
-    def test_epic_defines_structured_candidate_envelope(self):
-        self.require(self.EPIC, r"wayfinder_findings:")
+    def test_build_admission_refuses_open_spikes_or_fog(self):
+        self.require(self.EPIC, r"refuse.*build.*open spike.*Fog")
+        self.require(self.EPIC, r"Fog.*Decisions.*spike")
 
-    def test_epic_candidate_identity_is_stable_replay_identity(self):
-        self.require(
-            self.EPIC, r"not titles or list position, are the replay identity"
-        )
+    def test_build_admission_requires_adrs_and_locked_surface_spec(self):
+        self.require(self.EPIC, r"load-bearing.*ADR")
+        self.require(self.EPIC, r"user-facing.*locked.*ui-craft")
 
-    def test_epic_map_only_link_does_not_count_as_durable_handoff(self):
-        self.require(
-            self.EPIC,
-            r"map (link|Handoffs entry) alone.*(never|does not).*count",
-        )
+    def test_research_handoff_uses_exact_findings_heading_and_temporary_worktree(self):
+        self.assertIn("## Findings", self.EPIC)
+        self.require(self.EPIC, r"temporary per-spike worktree")
+        self.require(self.EPIC, r"verif.*Findings.*close")
+        self.require(self.EPIC, r"removes.*temporary.*unshipped.*only then closes")
 
-    def test_epic_must_not_close_with_undisposed_candidates(self):
-        self.require(
-            self.EPIC,
-            r"close.*only after every.*candidate.*(disposed|disposition)",
-        )
+    def test_failed_ledger_push_reports_staleness_and_recovers_from_tracker_truth(self):
+        self.require(self.EPIC, r"ledger push fails.*visible ledger staleness.*recover.*live GitHub")
 
-    def test_epic_build_issue_carries_candidate_identity_marker(self):
-        self.require(self.EPIC, r"Wayfinder candidate:")
+    def test_research_close_updates_tracker_before_derived_ledger(self):
+        self.require(self.EPIC, r"close.*spike.*only after.*verification")
+        self.require(self.EPIC, r"Only then derive.*Spikes.*Decisions.*Status.*DCO sign-off.*push")
 
-    def test_tracker_candidate_identity_is_copied_into_handoff_or_disposition(self):
-        self.require(
-            self.TRACKER,
-            r"exact candidate identity copied into each Build Issue or disposition",
-        )
+    def test_deferred_children_have_explicit_close_out_dispositions(self):
+        self.require(self.EPIC, r"promote.*remove.*deferred")
+        self.require(self.EPIC, r"reparent.*future epic.*retaining.*deferred")
+        self.require(self.EPIC, r"NOT_PLANNED.*remove.*deferred")
+        self.require(self.EPIC, r"refuse.*archive.*open.*deferred")
 
-    def test_tracker_validates_a_disposition_before_treating_it_complete(self):
-        self.require(
-            self.TRACKER,
-            r"disposition comment as complete only when.*candidate",
-        )
+    def test_tracker_bootstraps_the_four_protocol_labels_without_touching_ticket_axis(self):
+        self.require(self.TRACKER, r"epic.*spike.*build.*deferred")
+        self.require(self.TRACKER, r"ticket:\*.*independent")
 
-    def test_tracker_complete_disposition_retains_its_trigger(self):
-        self.require(self.TRACKER, r"required observable trigger")
+    def test_tracker_uses_native_children_and_blocked_by_edges(self):
+        self.require(self.TRACKER, r"--add-sub-issue")
+        self.require(self.TRACKER, r"--add-blocked-by")
 
-    def test_tracker_complete_disposition_retains_its_verification_condition(self):
-        self.require(self.TRACKER, r"verification condition")
+    def test_tracker_reads_child_completion_fields_and_merged_at(self):
+        self.require(self.TRACKER, r"subIssues\.nodes")
+        self.require(self.TRACKER, r"stateReason")
+        self.require(self.TRACKER, r"closedByPullRequestsReferences")
+        self.require(self.TRACKER, r"mergedAt")
 
-    def test_tracker_documents_in_place_repair_edit(self):
-        self.require(self.TRACKER, r"issues/comments/COMMENT_ID")
+    def test_completion_checks_are_direct_and_merged_or_not_planned(self):
+        self.require(self.TRACKER, r"no open spike child")
+        self.require(self.TRACKER, r"merged.*NOT_PLANNED")
+        self.require(self.TRACKER, r"no open deferred child")
 
-    def test_epic_workers_must_not_unconditionally_close_tickets(self):
-        self.assertNotRegex(
-            self.EPIC,
-            re.compile(r"claims, researches, comments, closes", re.IGNORECASE),
-        )
+    def test_epic_close_waits_for_final_push_human_merge_and_verification(self):
+        self.require(self.EPIC, r"final ledger.*archive.*push")
+        self.require(self.EPIC, r"planning pull request.*human-merged")
+        self.require(self.EPIC, r"verify.*merge")
+        self.require(self.EPIC, r"then close.*epic.*tear down")
 
 
 class ReviewRouteResolverTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Rewrites `$epic` from the retired map/candidate workflow to the OpenSpec-led epic ledger protocol.

- Defines ledger authority, grammar, planning-PR lifecycle, spike handoff, deferred-child close-out, and direct GitHub completion checks.
- Replaces tracker instructions with the four-label taxonomy, native child/dependency structure, and merged-or-NOT_PLANNED reads.
- Updates Epic metadata and behavioral contract pins.

Closes #142.

## Verification

```
/opt/homebrew/bin/python3.14 scripts/validate.py && /opt/homebrew/bin/python3.14 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco && PYTHONPYCACHEPREFIX=/tmp/ticket-142-pycache /opt/homebrew/bin/python3.14 -m py_compile skills/tools/codebase-memory/scripts/install.py
```

Passed locally before the final review fixes; focused `EpicProtocolContractTests` passes after them (18 tests), as do diff checks and the required zero-hit protocol checks.
