### PR TITLE
feat(ticket): align epic child lifecycle and CI gates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,7 @@ jobs:
           tests.test_ticket
           tests.test_codebase_memory_install
           tests.test_check_dco
+          tests.test_ci_changed_paths
       - name: Check DCO
         if: github.event_name == 'pull_request'
         run: >-
@@ -43,16 +44,28 @@ jobs:
           python3 -m py_compile skills/drivers/ticket/scripts/ticket.py
           python3 -m py_compile skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
           python3 -m py_compile skills/tools/codebase-memory/scripts/install.py
+          python3 -m py_compile scripts/ci_changed_paths.py
           node --check skills/tools/drive-local-webapp/scripts/driver.mjs
           node --check skills/tools/drive-local-webapp/scripts/self-check.mjs
           sh -n skills/tools/cbm-onboard/scripts/cbm-onboard.sh
           sh -n skills/tools/cbm-onboard/scripts/cbm-reindex.sh
           sh -n skills/tools/cbm-onboard/scripts/cbm-teardown.sh
+      - name: Classify changed paths
+        id: changed-paths
+        run: >-
+          python3 scripts/ci_changed_paths.py
+          --repo .
+          --event "${{ github.event_name }}"
+          --base "${{ github.event.pull_request.base.sha }}"
+          --head "${{ github.event.pull_request.head.sha }}"
+          --github-output "$GITHUB_OUTPUT"
       - name: Fresh-install through the standard skills CLI
+        if: steps.changed-paths.outputs.run_expensive != 'false'
         run: >-
           npx --yes skills@1.5.20 add . --skill '*'
           --agent codex --copy --yes
       - name: Verify installed skills
+        if: steps.changed-paths.outputs.run_expensive != 'false'
         run: |
           for skill in drive-local-webapp cbm-onboard spin-worktree research \
             codebase-memory implement tdd review prototype scope epic plan-review \
@@ -65,10 +78,12 @@ jobs:
               ".agents/skills/codebase-memory/$file"
           done
       - name: Install pinned browser driver dependencies
+        if: steps.changed-paths.outputs.run_expensive != 'false'
         working-directory: skills/tools/drive-local-webapp
         run: |
           npm ci
           npx playwright install chromium
       - name: Run browser driver self-check
+        if: steps.changed-paths.outputs.run_expensive != 'false'
         working-directory: skills/tools/drive-local-webapp
         run: npm run self-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,9 @@ ui-surfaces: none
   plus `npx playwright install chromium`).
 - Test: `python3 scripts/validate.py && python3 -m unittest tests.test_behavior
   tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench
-  tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco &&
-  python3 -m py_compile skills/tools/codebase-memory/scripts/install.py`
+  tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco
+  tests.test_ci_changed_paths && python3 -m py_compile
+  skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py`
 - Dev: no app to run. To exercise a skill, install the pack into a scratch
   directory with `npx skills add . --skill '<name>' --copy --yes`.
 - Source: `skills/<category>/<name>/` (SKILL.md plus its own `references/`,

--- a/docs/adr/adr-143-epic-child-behavior-after-mechanical-rename.md
+++ b/docs/adr/adr-143-epic-child-behavior-after-mechanical-rename.md
@@ -1,0 +1,20 @@
+# ADR 143 — Epic-child behavior after the mechanical rename
+
+## Context
+
+ADR 51 records the legacy `wayfinder` taxonomy and its mechanical path move. The
+epic proposal evolved that driver into `epic`, while deliberately keeping the move
+separate from the lifecycle behavior that its child tickets need.
+
+## Decision
+
+`epic` is the evolved driver. Shared epic-child behavior follows the mechanical path
+move in separate children, so the rename and lifecycle contract remain independently
+reviewable. This record amends ADR 51 without renaming or rewriting that legacy
+record.
+
+## Consequences
+
+Epic-child triage, execution, follow-up handling, and close-out use the evolved
+driver's settled lifecycle contract. This ADR does not amend the parent epic's
+close-out or baseline decisions.

--- a/scripts/ci_changed_paths.py
+++ b/scripts/ci_changed_paths.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Classify a change set for the required GitHub Actions skills job."""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+SAFE_ROOT_FILES = {"README.md", "CONTRIBUTING.md", "SECURITY.md", "LICENSE", "NOTICE"}
+
+
+def git(repository, *arguments):
+    return subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout
+
+
+def is_safe_path(path):
+    if path in SAFE_ROOT_FILES:
+        return True
+    return (
+        (path.startswith("docs/") or path.startswith("openspec/"))
+        and path.endswith(".md")
+    )
+
+
+def classify(repository, event, base, head):
+    if event != "pull_request":
+        return True
+    try:
+        git(repository, "rev-parse", "--show-toplevel")
+        merge_base = git(repository, "merge-base", base, head).strip()
+        paths = git(repository, "diff", "--name-only", "-z", "--no-renames", merge_base, head)
+    except (OSError, subprocess.CalledProcessError):
+        return True
+    try:
+        changed_paths = [path.decode("utf-8") for path in paths.split(b"\0") if path]
+    except UnicodeDecodeError:
+        return True
+    return not changed_paths or not all(is_safe_path(path) for path in changed_paths)
+
+
+def write_output(output, run_expensive):
+    try:
+        Path(output).write_text(
+            f"run_expensive={'true' if run_expensive else 'false'}\n", encoding="utf-8"
+        )
+    except OSError as error:
+        print(f"ci-changed-paths: cannot write GitHub output: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--github-output", required=True)
+    arguments = parser.parse_args()
+    return write_output(
+        arguments.github_output,
+        classify(arguments.repo, arguments.event, arguments.base, arguments.head),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_changed_paths.py
+++ b/scripts/ci_changed_paths.py
@@ -56,9 +56,11 @@ def write_output(output, run_expensive):
 
 
 def github_output_argument(arguments):
-    for index, argument in enumerate(arguments[:-1]):
+    for index, argument in enumerate(arguments):
         if argument == "--github-output":
-            return arguments[index + 1]
+            return arguments[index + 1] if index + 1 < len(arguments) else None
+        if argument.startswith("--github-output="):
+            return argument.partition("=")[2] or None
     return None
 
 

--- a/scripts/ci_changed_paths.py
+++ b/scripts/ci_changed_paths.py
@@ -55,14 +55,31 @@ def write_output(output, run_expensive):
     return 0
 
 
+def github_output_argument(arguments):
+    for index, argument in enumerate(arguments[:-1]):
+        if argument == "--github-output":
+            return arguments[index + 1]
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--repo", required=True)
-    parser.add_argument("--event", required=True)
-    parser.add_argument("--base", required=True)
-    parser.add_argument("--head", required=True)
-    parser.add_argument("--github-output", required=True)
-    arguments = parser.parse_args()
+    parser.add_argument("--repo")
+    parser.add_argument("--event")
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--github-output")
+    try:
+        arguments = parser.parse_args()
+    except SystemExit as error:
+        output = github_output_argument(sys.argv[1:])
+        if output:
+            return write_output(output, True)
+        return error.code
+    if not arguments.github_output:
+        parser.error("the following arguments are required: --github-output")
+    if not all((arguments.repo, arguments.event, arguments.base, arguments.head)):
+        return write_output(arguments.github_output, True)
     return write_output(
         arguments.github_output,
         classify(arguments.repo, arguments.event, arguments.base, arguments.head),

--- a/skills/drivers/epic/SKILL.md
+++ b/skills/drivers/epic/SKILL.md
@@ -9,7 +9,7 @@ description: "Maintain an epic ledger and work clear child tickets through a Git
 
 ## Authority and boundaries
 
-An epic lives at `openspec/changes/<epic-slug>/`. Its `proposal.md` and `design.md` are authoritative for destination, scope, risk, and durable decisions. The epic ledger is a derived index, not another source of truth. Live GitHub is truth whenever it disagrees with the ledger.
+An epic lives at `openspec/changes/<epic-slug>/`. Its `proposal.md` and `design.md` are authoritative for destination, scope, risk, and durable decisions. Tracker children substitute for `tasks.md`; `ledger.md` rides the standing planning pull request. The epic ledger is a derived index, not another source of truth. Live GitHub is truth whenever it disagrees with the ledger.
 
 Use GitHub Issues only. Read [the tracker reference](references/github-tracker.md) before the first tracker action. A tracker, authentication, or Git failure stops the current operation visibly; do not guess or repair authoritative state from the ledger.
 

--- a/skills/drivers/epic/references/github-tracker.md
+++ b/skills/drivers/epic/references/github-tracker.md
@@ -17,7 +17,21 @@ An epic has `epic`; each child has one of `spike` or `build`; a deferred child a
 
 ## Native structure
 
-Create issue bodies in temporary files and use `--body-file`. Capture returned URLs rather than guessing numbers. Attach every spike, build, and deferred follow-up to the epic through native child issues:
+Create issue bodies in temporary files and use `--body-file`. Capture returned URLs rather than guessing numbers. Attach every spike, build, and deferred follow-up to the epic through native child issues. For the ticket workflow's already-qualified necessary follow-up, create the native child in one command from its temporary body file, capture its returned URL, and report it on the originating ticket. Use `spike` or `build`; add `deferred` only when the epic destination does not require it:
+
+The installed CLI's `gh issue create --help` verifies that `--repo`, `--title`, `--body-file`, repeatable `--label`, and `--parent` are available together.
+
+```sh
+gh issue create --repo OWNER/REPO --title "TITLE" --body-file BODY_FILE --label build --parent EPIC_NUMBER
+```
+
+```sh
+gh issue create --repo OWNER/REPO --title "TITLE" --body-file BODY_FILE --label spike --label deferred --parent EPIC_NUMBER
+```
+
+Do not use this path for preferences or unresolved choices: those retain the ticket workflow's existing dispositions. The ticket tracker's four-operation contract does not expand.
+
+Other native relationship repair may use:
 
 ```sh
 gh issue edit EPIC_NUMBER --repo OWNER/REPO --add-sub-issue CHILD_NUMBER

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -22,7 +22,8 @@ four.
   ticket comment. Work too big for one agent's context is sliced into sub-orders
   in that same comment ([references/slicing.md](references/slicing.md)). It
   writes nothing to the repo except scope and spec documents committed in the
-  ticket's worktree.
+  ticket's worktree. An epic child writes only its work order; a required epic
+  spec amendment is a separate docs-only pull request merged before stamping.
 * `start` runs in a fresh session, fetches the work order, refuses if there is
   none, implements it on a branch in an isolated worktree (or, on a sliced order,
   coordinates one agent per chunk), iterates the verification step until the
@@ -105,8 +106,9 @@ exception instead.
    cuts the branch and worktree through `spin-worktree`; `start` and `revise`
    reuse them; `finalize` tears them down. The first repository action after the
    summary-and-claim opening, before grounding or any repo read, is to cut or
-   reuse the ticket's worktree. Grounding, scope ledgers, and change records all
-   happen and get committed there. The control checkout may be dirty, stale, or
+   reuse the ticket's worktree. Outside an epic child, grounding, scope ledgers, and
+   change records all happen and get committed there; an epic child keeps its
+   instrumentation in session scratch and relies on its parent record. The control checkout may be dirty, stale, or
    on another branch: its working tree is never read or written, and it never
    switches branches. Never commit, stash, move, or clean its files, and never
    substitute another task's worktree as the control checkout. It holds the
@@ -119,8 +121,9 @@ exception instead.
    pull request ([references/coordinator-mode.md](references/coordinator-mode.md)).
 
 6. **Working state lives on the ticket.** No plan files and no scratch
-   directories on the branch. The branch carries shipping code plus the repo's own
-   change record, nothing else.
+   directories on the branch. Outside an epic, the branch carries shipping code plus
+   the repo's own change record; an epic child carries shipping code only and its
+   parent epic owns the record.
 
 7. **Ground in what the repo already says.** Read the repo's own decision and
    change records, `docs/`, and recent `git log` before forming opinions. Read the
@@ -219,6 +222,13 @@ want of it.
 ## The change record
 
 The skill records the change where the target repo already records changes.
+
+An **epic child** neither creates, folds, revises, records, nor incurs sweep debt
+for a per-child change record. Its parent epic's existing change/archive flow is
+the record, including its already-settled baseline timing and standing planning
+pull-request contents.
+
+Outside an epic, follow this per-ticket rule:
 
 1. The repo has an OpenSpec layout (`openspec/`): write the change folder on the
    ticket branch (`proposal.md`, `tasks.md`, and `design.md` when the work

--- a/skills/drivers/ticket/bindings/github-issues.md
+++ b/skills/drivers/ticket/bindings/github-issues.md
@@ -20,11 +20,12 @@ another tracker, or a guess at the ticket's contents.
 ## 1. Read a ticket
 
 ```sh
-gh issue view <id> --repo <org/repo> --json number,title,body,state,comments
+gh issue view <id> --repo <org/repo> --json number,title,body,state,parent,comments
 ```
 
-`comments` arrives oldest-first, each with `body` and `createdAt`. Sort by
-`createdAt` when a verb wants newest-first.
+`parent` lets triage select the epic-child lifecycle. `comments` arrives
+oldest-first, each with `body` and `createdAt`. Sort by `createdAt` when a verb
+wants newest-first.
 
 A missing issue exits non-zero with `Could not resolve to an issue`. That is the
 absent-ticket failure: stop, naming the id.

--- a/skills/drivers/ticket/bindings/github-issues.md
+++ b/skills/drivers/ticket/bindings/github-issues.md
@@ -46,15 +46,27 @@ labels plus the issue's own open or closed state:
 
 | State | What the binding does |
 |---|---|
-| triaged | `gh issue edit <id> --repo <org/repo> --add-label ticket:triaged` |
+| triaged | Receives triage's classification. `code` first creates (if needed) and attaches `build`, then adds `ticket:triaged`; `investigation` and `manual` add only `ticket:triaged`. |
 | in progress | add `ticket:in-progress`, remove `ticket:triaged` |
 | pending review | add `ticket:pending-review`, remove `ticket:in-progress` |
 | done | `gh issue close <id> --repo <org/repo>` and remove `ticket:pending-review` |
 
-Create a missing label once with
-`gh label create ticket:<state> --repo <org/repo>`. A label that cannot be
-created (no permission, or the repository disallows it) is the contract's
-non-fatal failure: say so in one line and continue.
+Create a missing status label once with
+`gh label create ticket:<state> --repo <org/repo>`. For a `code` triage, first
+ensure and attach the independent type label:
+
+```sh
+gh label create build --repo <org/repo> --color 1d76db --description "Implementable ticket" --force
+gh issue edit <id> --repo <org/repo> --add-label build
+gh issue edit <id> --repo <org/repo> --add-label ticket:triaged
+```
+
+Creation failure or attachment failure is the contract's one non-fatal status
+failure: report it, retain the posted work order, and do not run the later
+`ticket:triaged` command. `investigation` does not create or attach `build` and
+applies only `ticket:triaged`. `manual` does not create or attach `build` and
+applies only `ticket:triaged`. Every other `ticket:*` transition
+remains exactly as listed above.
 
 A repository whose project board owns status is served the same way. The labels
 are this binding's status channel, and the board stays the humans' view.

--- a/skills/drivers/ticket/bindings/github-issues.md
+++ b/skills/drivers/ticket/bindings/github-issues.md
@@ -20,12 +20,13 @@ another tracker, or a guess at the ticket's contents.
 ## 1. Read a ticket
 
 ```sh
-gh issue view <id> --repo <org/repo> --json number,title,body,state,parent,comments
+gh issue view <id> --repo <org/repo> --json number,title,body,state,labels,parent,comments
 ```
 
-`parent` lets triage select the epic-child lifecycle. `comments` arrives
-oldest-first, each with `body` and `createdAt`. Sort by `createdAt` when a verb
-wants newest-first.
+`parent` lets triage find a candidate parent; a second read through this same
+operation supplies that parent's `labels` so triage can confirm the `epic` type.
+`comments` arrives oldest-first, each with `body` and `createdAt`. Sort by
+`createdAt` when a verb wants newest-first.
 
 A missing issue exits non-zero with `Could not resolve to an issue`. That is the
 absent-ticket failure: stop, naming the id.

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -10,6 +10,11 @@ report. Anything larger than mechanical goes back to a delegate.
 What follows is what this skill adds on top. It replaces `start` steps 8 through
 11, and rejoins that verb at step 12 when the last chunk has merged.
 
+An epic child creates, folds, revises, and records no per-child change record.
+Coordinator work leaves the parent epic's existing change/archive flow, settled
+baseline timing, and standing planning-pull-request contents unchanged. Outside an
+epic, the ticket skill's per-ticket change-record rule still applies.
+
 1. **One branch, one pull request, still.** The ticket branch from `start` step 4 is
    the trunk. Each chunk gets its own branch cut from it and merges back. Nothing
    chunk-related reaches the default branch directly.

--- a/skills/drivers/ticket/references/review-actions.md
+++ b/skills/drivers/ticket/references/review-actions.md
@@ -6,7 +6,11 @@ Ground each finding before choosing exactly one disposition.
   pull request.
 * **Necessary follow-up.** It is real but outside the order; file a ticket with
   evidence, desired outcome, and a checked duplicate search. Keep it out of this
-  pull request.
+  pull request. Under an epic, read
+  [the epic tracker reference](../../epic/references/github-tracker.md): when the
+  epic destination requires it, file the follow-up as an in-scope native child;
+  otherwise file it as a native child with its `spike` or `build` type plus
+  `deferred`, and report it on the originating ticket.
 * **Ask the maintainer.** A real choice remains; surface it before editing.
 * **Discard as preference.** It is unsupported reviewer taste; make no change and
   say why in the reply.

--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -82,8 +82,10 @@ session, never cut more chunks.
 * Target each chunk at a projected peak under 180k.
 * Never slice below one pull-request-sized piece of work. A chunk that would peak
   under 120k is mostly overhead; fold it into a neighbour.
-* Practical ceiling: four chunks. More than that means the ticket is really an
-  epic and wants child tickets, not sub-orders.
+* Practical ceiling: four chunks. Promote to `/epic` only when more than four
+  projected chunks leave at least one decision unsettled. Purely mechanical
+  oversize is hand-split into serial `build` tickets instead: the epic apparatus
+  is for fog, not bulk.
 
 ## Where these numbers came from
 

--- a/skills/drivers/ticket/references/tracker-contract.md
+++ b/skills/drivers/ticket/references/tracker-contract.md
@@ -32,12 +32,19 @@ binding and ships with the skill.
 ## 3. Move a ticket's status
 
 * **Input:** a ticket id and one target state from this skill's vocabulary:
-  triaged, in progress, pending review, or done.
+  triaged, in progress, pending review, or done. A move to `triaged` also receives
+  triage's classification: `code`, `investigation`, or `manual`.
 * **Output:** the ticket's state after the move.
+* **Classification rule:** for a code classification, the binding first ensures
+  the `build` label exists and is attached, then applies `ticket:triaged`. For
+  `investigation` and `manual`, it neither creates nor attaches `build`, and applies
+  only the status transition. Type labels and `ticket:*` status remain independent.
 * **Failure:** the state does not exist in the tracker's workflow, the move is not
-  permitted, or the transport fails. This is the one non-fatal operation: say so
-  in one line and continue the verb. Never retry a failed move, and never
-  substitute a different state to make the move succeed.
+  permitted, or the transport fails. A `code` path that cannot create or attach
+  `build` is this operation's one non-fatal status failure: report it in one line,
+  retain any posted work order, and do not apply the later `ticket:triaged` label.
+  Never retry a failed move, and never substitute a different state to make the move
+  succeed.
 
 ## 4. Locate the newest work order
 

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -21,10 +21,12 @@ the code host back to the tracker; this verb is that sync.
 
    d. Move the ticket to done. Report a failed move; do not retry.
 
-   e. Verify the change record landed in the ticket's last pull request, per the
-   skill page's change-record rule. Missed: flag it in the report as sweep debt,
-   never as a per-ticket follow-up pull request and never as a push to an approved
-   pull request.
+   e. Outside an epic, verify the change record landed in the ticket's last pull
+   request, per the skill page's change-record rule. Missed: flag it in the report
+   as sweep debt, never as a per-ticket follow-up pull request and never as a push
+   to an approved pull request. An epic child neither verifies a per-child change
+   record nor incurs sweep debt; the parent epic's existing change/archive flow is
+   its record.
 
    f. Tear the worktree and branch down:
 

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -67,9 +67,11 @@ long ago and the pull request is one diff.
    code changed.
 
 8. **Push and respond.** Push to the same branch. Reply to each addressed comment on
-   the pull request, resolving or answering it. Update the repo's change record if
-   its checklist moved, and update its decision record if a decision changed during
-   review.
+   the pull request, resolving or answering it. Outside an epic, update the repo's
+   change record if its checklist moved, and update its decision record if a
+   decision changed during review. An epic child revises neither a per-child change record
+   nor the parent epic record; its parent epic's existing change/archive flow
+   remains authoritative.
 
 9. **Status.** Comment on the ticket (attribution first) only if the round
    materially changed the plan. Routine fix-and-push rounds need no ticket comment.

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -74,7 +74,8 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    has none, work to the user's global standards. Follow the order's Do section.
    Match the repo's existing idioms, reading neighboring code first. Record the
    change where the repo already records changes, on the same branch, per the skill
-   page's change-record rule.
+   page's change-record rule. An epic child creates no change record: the parent
+   epic's existing change record is authoritative.
 
    **Route by shape of the change.** `Surface lifecycle: build` runs `/ui-craft
    build` against the named locked manifest. `Surface lifecycle: revise` runs
@@ -118,6 +119,9 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
     `/review`; Full orders run one `/review` round after hardening.
 
 11. **Fold the change record into the baseline in the order's last pull request.**
+    This step applies outside an epic. An epic child does not fold a per-child
+    change record; it leaves the parent epic's settled baseline timing and standing
+    planning-pull-request contents unchanged.
     When the pull request being opened is the order's final one (single-pull-request
     orders: the only one), the same diff completes whatever the repo's convention
     asks for at landing time. This lands before the pull request is opened or marked

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -1,8 +1,10 @@
 # /ticket triage `<ticket-id>`
 
 Turn a ticket into a locked work order, or establish why it cannot be one yet.
-Runs entirely in the ticket's worktree, and writes only to the tracker and to
-scope and spec documents committed in that worktree.
+Runs in the ticket's worktree. Outside an epic it writes the tracker and the
+applicable scope and spec documents there. An **epic child** writes only its work
+order to the tracker; its review instrumentation is untracked session scratch outside
+the branch, and its change record already belongs to the parent epic.
 
 ## Procedure
 
@@ -111,7 +113,12 @@ scope and spec documents committed in that worktree.
    instead. A single missing fact with no judgment attached (a hostname, a version)
    is the only exception. When nothing is genuinely uncertain, scope says so and
    returns without asking anything; that outcome is the pass signal, not a wasted
-   step. Resolved answers go into the order.
+   step. Resolved answers go into the order. For an epic child, every `/scope`
+   specialist keeps its instrumentation in untracked session scratch outside the branch, discards it
+   after the final order, and creates no scope ledger or docs/scope state. `/epic` alone owns the
+   proposal, design, and ledger. If triage discovers a required spec amendment,
+   land it first as a separate docs-only pull request to main, then stamp the
+   order; the child branch never writes that amendment or any other spec state.
 
    **Resolve the surface lifecycle.** Every order and sub-order gets one closed
    `Surface lifecycle:` value:
@@ -192,10 +199,12 @@ scope and spec documents committed in that worktree.
     measured review forwarded a single unverified reviewer claim; it got baked into
     the order and cost a full round to retract.
 
-    b. Instrument every round in the scope ledger: blockers found, each tagged
-    `authoring` (present since the draft) or `injected` (introduced by a prior fix
-    round). Injected blockers climbing across rounds is the rewrite-clean signal
-    firing.
+    b. Outside an epic child, instrument every round in the scope ledger:
+    blockers found, each tagged `authoring` (present since the draft) or
+    `injected` (introduced by a prior fix round). For an epic child, keep the same
+    instrumentation in untracked session scratch outside the branch and discard it after the final
+    order; create no scope ledger or docs/scope state, and do not write the epic ledger. Injected
+    blockers climbing across rounds is the rewrite-clean signal firing.
 
     c. Reviewers get the facts already verified live this session and the user's
     settled decisions, marked do-not-re-litigate.
@@ -225,7 +234,9 @@ scope and spec documents committed in that worktree.
     first, then the human summary, then the fenced order or sub-orders. One comment
     carries the whole order, chunked or not.
 
-14. **Move the status** to triaged. Report a failed move; do not retry.
+14. **Move the status** to triaged, passing the classification from step 6. Report
+    a failed move; do not retry. A failed code classification `build` creation or
+    attachment retains the posted work order but prevents `ticket:triaged`.
 
 ## Refusals
 

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -11,7 +11,10 @@ the branch, and its change record already belongs to the parent epic.
 1. **Read the ticket.** Use the contract's read operation for the description and
    every comment. Note the parent, the links, and any prior work order comment. If
    an order already exists, say so and ask whether to supersede it; a new order
-   posted later wins.
+   posted later wins. A non-null parent is only an epic-child candidate: read that
+   parent through the tracker contract and select the epic-child lifecycle only
+   when its labels include the `epic` label. A missing parent or a parent without
+   `epic` leaves this as an ordinary ticket.
 
 2. **Cut or reuse the worktree.** Before any grounding or repo read, derive a short
    kebab slug from the ticket title, then:

--- a/skills/workflows/scope/SKILL.md
+++ b/skills/workflows/scope/SKILL.md
@@ -7,7 +7,10 @@ description: Triage front door for work that isn't ready to build. Classifies th
 
 Diagnose why work isn't buildable yet, route to exactly one specialist skill, and open
 a ledger the moment routing happens. Never do the specialist's work yourself — a
-correct route with no other output is a complete session.
+correct route with no other output is a complete session. For an epic child, every
+specialist instead uses untracked session scratch outside the child branch, discarded after the final order;
+it creates no scope ledger or docs/scope ledger. `/epic` alone owns proposal/design
+and its ledger.
 
 ## Routing table
 
@@ -15,6 +18,8 @@ Classify the **dominant** uncertainty — the one that, if resolved, makes the o
 tractable — and route to exactly one of:
 
 - **Big and foggy, many interlocking decisions that block each other** → `epic`.
+  Mechanical bulk without an unsettled decision is not an epic route; hand-split it
+  into serial build tickets.
 - **A concrete plan or design exists in someone's head, untested** → interview mode
   ([references/interview.md](references/interview.md), in this skill).
 - **A written plan, work order, spec, or brief exists and needs stress-testing
@@ -37,7 +42,8 @@ names `epic`), route there directly without re-diagnosing.
 
 ## Ledger — required
 
-At the moment routing happens, open a ledger before invoking the specialist:
+Outside an epic child, at the moment routing happens, open a ledger before invoking
+the specialist:
 
 - **Path:** `docs/scope/<slug>.md` in the target project's repo when that path is
   writable; otherwise the session scratchpad. `<slug>` is a short kebab-case name for
@@ -48,6 +54,10 @@ At the moment routing happens, open a ledger before invoking the specialist:
   `→ ADR`, `→ issue`, or `inline`.
 - The ledger is the durable session state. A fresh agent resumes by reading it, not by
   re-deriving context from chat history.
+
+For an epic child, the remaining ledger, risk-contract, evidence, and exit rules are
+applied only through the stamped work order and parent epic authority; session scratch
+is never made durable.
 
 ## Risk contract
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3181,6 +3181,10 @@ class EpicProtocolContractTests(unittest.TestCase):
     def test_epic_names_proposal_and_design_as_authority(self):
         self.require(self.EPIC, r"proposal\.md.*design\.md.*authoritative")
 
+    def test_epic_change_folder_uses_tracker_children_and_the_planning_pr_ledger(self):
+        self.require(self.EPIC, r"tracker children substitute for `tasks\.md`")
+        self.require(self.EPIC, r"ledger\.md.*standing planning pull request")
+
     def test_epic_ledger_template_has_all_normative_sections(self):
         for heading in ("Status", "Notes", "Fog", "Decisions", "Spikes", "Builds", "Deferred", "Rounds"):
             self.assertIn(f"## {heading}", self.EPIC)
@@ -3231,6 +3235,17 @@ class EpicProtocolContractTests(unittest.TestCase):
     def test_tracker_uses_native_children_and_blocked_by_edges(self):
         self.require(self.TRACKER, r"--add-sub-issue")
         self.require(self.TRACKER, r"--add-blocked-by")
+
+    def test_tracker_has_one_command_follow_up_creation_interface(self):
+        self.require(
+            self.TRACKER,
+            r"gh issue create --repo OWNER/REPO --title.*--body-file.*--label (build|spike).*--parent EPIC_NUMBER",
+        )
+        self.require(self.TRACKER, r"returned URL.*originating ticket")
+        self.require(
+            self.TRACKER,
+            r"gh issue create --help.*--repo.*--title.*--body-file.*--label.*--parent",
+        )
 
     def test_tracker_reads_child_completion_fields_and_merged_at(self):
         self.require(self.TRACKER, r"subIssues\.nodes")

--- a/tests/test_ci_changed_paths.py
+++ b/tests/test_ci_changed_paths.py
@@ -1,0 +1,177 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci_changed_paths.py"
+
+
+def run(command, *, cwd=None, check=True):
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+class ChangedPathsCliTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.repo = Path(self.temporary.name) / "repo"
+        self.repo.mkdir()
+        run(["git", "init", "-q"], cwd=self.repo)
+        run(["git", "config", "user.email", "fixture@example.com"], cwd=self.repo)
+        run(["git", "config", "user.name", "Fixture"], cwd=self.repo)
+        (self.repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+        run(["git", "add", "."], cwd=self.repo)
+        run(["git", "commit", "-qm", "seed"], cwd=self.repo)
+        self.base = run(["git", "rev-parse", "HEAD"], cwd=self.repo).stdout.strip()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def commit(self, changes):
+        for relative_path, content in changes.items():
+            path = self.repo / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        run(["git", "add", "-A"], cwd=self.repo)
+        run(["git", "commit", "-qm", "fixture change"], cwd=self.repo)
+        return run(["git", "rev-parse", "HEAD"], cwd=self.repo).stdout.strip()
+
+    def classify(
+        self, *, event="pull_request", base=None, head=None, output=None, repo=None
+    ):
+        output = output or (Path(self.temporary.name) / "github-output")
+        result = run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo",
+                str(repo or self.repo),
+                "--event",
+                event,
+                "--base",
+                base or self.base,
+                "--head",
+                head or "HEAD",
+                "--github-output",
+                str(output),
+            ],
+            check=False,
+        )
+        value = output.read_text(encoding="utf-8").strip() if output.is_file() else None
+        return result, value
+
+    def test_documentation_only_pull_requests_skip_expensive_work(self):
+        safe_paths = (
+            "README.md",
+            "CONTRIBUTING.md",
+            "SECURITY.md",
+            "LICENSE",
+            "NOTICE",
+            "docs/adr/adr-143-example.md",
+            "docs/scope/example.md",
+            "docs/overlay.md",
+            "openspec/changes/epic-rework/ledger.md",
+        )
+        head = self.commit({path: "documentation\n" for path in safe_paths})
+
+        result, output = self.classify(head=head)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "run_expensive=false")
+
+    def test_unsafe_and_mixed_pull_requests_run_expensive_work(self):
+        for relative_path in (
+            "docs/render_comparison.py",
+            "docs/evidence/contract-v2.json",
+            "skills/drivers/ticket/SKILL.md",
+            "scripts/validate.py",
+            "tests/test_ticket.py",
+            ".github/workflows/validate.yml",
+        ):
+            with self.subTest(relative_path=relative_path):
+                head = self.commit({relative_path: "changed\n"})
+                result, output = self.classify(base=f"{head}^", head=head)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(output, "run_expensive=true")
+
+        head = self.commit({"docs/adr/safe.md": "safe\n", "tools/unsafe.txt": "unsafe\n"})
+        result, output = self.classify(base=f"{head}^", head=head)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "run_expensive=true")
+
+    def test_rename_and_deletion_classify_both_sides_of_the_change(self):
+        unsafe = self.repo / "scripts" / "tool.py"
+        unsafe.parent.mkdir(parents=True)
+        unsafe.write_text("print('unsafe')\n", encoding="utf-8")
+        run(["git", "add", "-A"], cwd=self.repo)
+        run(["git", "commit", "-qm", "add unsafe"], cwd=self.repo)
+        before_rename = run(["git", "rev-parse", "HEAD"], cwd=self.repo).stdout.strip()
+        safe = self.repo / "docs" / "tool.md"
+        safe.parent.mkdir(parents=True)
+        os.rename(unsafe, safe)
+        run(["git", "add", "-A"], cwd=self.repo)
+        run(["git", "commit", "-qm", "rename across boundary"], cwd=self.repo)
+
+        result, output = self.classify(base=before_rename)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "run_expensive=true")
+
+        before_delete = run(["git", "rev-parse", "HEAD"], cwd=self.repo).stdout.strip()
+        (self.repo / "seed.txt").unlink()
+        run(["git", "add", "-A"], cwd=self.repo)
+        run(["git", "commit", "-qm", "delete unsafe"], cwd=self.repo)
+        result, output = self.classify(base=before_delete)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "run_expensive=true")
+
+    def test_non_pr_empty_and_invalid_diffs_fail_closed_to_full_work(self):
+        for event, base, head in (
+            ("push", self.base, "HEAD"),
+            ("pull_request", "HEAD", "HEAD"),
+            ("pull_request", "missing-ref", "HEAD"),
+        ):
+            with self.subTest(event=event, base=base, head=head):
+                result, output = self.classify(event=event, base=base, head=head)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(output, "run_expensive=true")
+
+    def test_pull_request_diff_uses_the_merge_base_not_the_moving_base_tip(self):
+        advanced_base = self.commit({"scripts/base-only.py": "print('base')\n"})
+        run(["git", "checkout", "-q", self.base], cwd=self.repo)
+        head = self.commit({"docs/pr-only.md": "documentation\n"})
+
+        result, output = self.classify(base=advanced_base, head=head)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "run_expensive=false")
+
+    def test_repository_discovery_failure_fails_closed_when_output_is_writable(self):
+        missing_repo = Path(self.temporary.name) / "not-a-repository"
+
+        result, output = self.classify(repo=missing_repo)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "run_expensive=true")
+
+    def test_output_transport_failure_is_visible(self):
+        output = Path(self.temporary.name) / "missing" / "github-output"
+
+        result, written = self.classify(event="push", output=output)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIsNone(written)
+        self.assertIn("ci-changed-paths: cannot write GitHub output", result.stderr)
+        self.assertNotIn("can't open file", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_changed_paths.py
+++ b/tests/test_ci_changed_paths.py
@@ -184,6 +184,21 @@ class ChangedPathsCliTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(output.read_text(encoding="utf-8").strip(), "run_expensive=true")
 
+    def test_malformed_input_recovers_equals_form_github_output(self):
+        output = Path(self.temporary.name) / "github-output"
+        result = run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bogus",
+                f"--github-output={output}",
+            ],
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output.read_text(encoding="utf-8").strip(), "run_expensive=true")
+
     def test_output_transport_failure_is_visible(self):
         output = Path(self.temporary.name) / "missing" / "github-output"
 

--- a/tests/test_ci_changed_paths.py
+++ b/tests/test_ci_changed_paths.py
@@ -163,6 +163,27 @@ class ChangedPathsCliTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(output, "run_expensive=true")
 
+    def test_missing_classifier_input_fails_closed_when_output_is_writable(self):
+        output = Path(self.temporary.name) / "github-output"
+        result = run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo",
+                str(self.repo),
+                "--event",
+                "pull_request",
+                "--head",
+                "HEAD",
+                "--github-output",
+                str(output),
+            ],
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output.read_text(encoding="utf-8").strip(), "run_expensive=true")
+
     def test_output_transport_failure_is_visible(self):
         output = Path(self.temporary.name) / "missing" / "github-output"
 

--- a/tests/test_ci_changed_paths.py
+++ b/tests/test_ci_changed_paths.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "ci_changed_paths.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "validate.yml"
 
 
 def run(command, *, cwd=None, check=True):
@@ -22,7 +23,7 @@ def run(command, *, cwd=None, check=True):
 
 class ChangedPathsCliTests(unittest.TestCase):
     def setUp(self):
-        self.temporary = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.temporary = tempfile.TemporaryDirectory()
         self.repo = Path(self.temporary.name) / "repo"
         self.repo.mkdir()
         run(["git", "init", "-q"], cwd=self.repo)
@@ -171,6 +172,55 @@ class ChangedPathsCliTests(unittest.TestCase):
         self.assertIsNone(written)
         self.assertIn("ci-changed-paths: cannot write GitHub output", result.stderr)
         self.assertNotIn("can't open file", result.stderr)
+
+
+class ValidateWorkflowContractTests(unittest.TestCase):
+    EXPENSIVE_STEPS = (
+        "Fresh-install through the standard skills CLI",
+        "Verify installed skills",
+        "Install pinned browser driver dependencies",
+        "Run browser driver self-check",
+    )
+    CLASSIFIER_CONDITION = "steps.changed-paths.outputs.run_expensive != 'false'"
+
+    def setUp(self):
+        self.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def step(self, name):
+        marker = f"      - name: {name}\n"
+        start = self.workflow.index(marker)
+        end = self.workflow.find("      - name:", start + len(marker))
+        return self.workflow[start : None if end == -1 else end]
+
+    def test_required_skills_job_and_classifier_are_unconditional(self):
+        self.assertIn("  pull_request:\n", self.workflow)
+        self.assertNotIn("paths:", self.workflow)
+        self.assertNotIn("paths-ignore:", self.workflow)
+        self.assertIn("  skills:\n    runs-on:", self.workflow)
+        self.assertNotIn("\n        if:", self.step("Classify changed paths"))
+
+    def test_classifier_is_the_single_output_producer_after_unconditional_checks(self):
+        classifier = self.step("Classify changed paths")
+        self.assertEqual(self.workflow.count("id: changed-paths"), 1)
+        self.assertIn('python3 scripts/ci_changed_paths.py', classifier)
+        self.assertIn('--event "${{ github.event_name }}"', classifier)
+        self.assertIn('--base "${{ github.event.pull_request.base.sha }}"', classifier)
+        self.assertIn('--head "${{ github.event.pull_request.head.sha }}"', classifier)
+        self.assertIn('--github-output "$GITHUB_OUTPUT"', classifier)
+        self.assertLess(
+            self.workflow.index("Check Python, JavaScript, and shell syntax"),
+            self.workflow.index("Classify changed paths"),
+        )
+
+    def test_every_expensive_step_uses_the_same_classifier_condition(self):
+        conditions = []
+        for name in self.EXPENSIVE_STEPS:
+            step = self.step(name)
+            self.assertIn(f"if: {self.CLASSIFIER_CONDITION}", step)
+            conditions.append(
+                next(line.strip() for line in step.splitlines() if line.strip().startswith("if:"))
+            )
+        self.assertEqual(conditions, [f"if: {self.CLASSIFIER_CONDITION}"] * 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -511,15 +511,25 @@ class TicketSkillContractTests(unittest.TestCase):
         self.assertRegex(contract, r"manual.{0,240}(does not|do not|without).{0,120}build")
         self.assertIn("ticket:triaged", contract)
 
-    def test_ticket_read_supplies_parent_for_epic_child_detection(self):
+    def test_ticket_read_supplies_parent_and_labels_for_epic_child_detection(self):
         binding = (
             TICKET_DIRECTORY / "bindings" / "github-issues.md"
         ).read_text(encoding="utf-8")
+        triage = " ".join(
+            (TICKET_DIRECTORY / "verbs" / "triage.md")
+            .read_text(encoding="utf-8")
+            .lower()
+            .split()
+        )
 
         self.assertIn(
-            "--json number,title,body,state,parent,comments",
+            "--json number,title,body,state,labels,parent,comments",
             binding,
         )
+        self.assertIn("parent is only an epic-child candidate", triage)
+        self.assertIn("read that parent through the tracker contract", triage)
+        self.assertIn("`epic` label", triage)
+        self.assertIn("ordinary ticket", triage)
 
     def test_code_triage_stops_before_status_when_build_creation_or_attachment_fails(self):
         binding = (TICKET_DIRECTORY / "bindings" / "github-issues.md").read_text(

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -511,6 +511,67 @@ class TicketSkillContractTests(unittest.TestCase):
         self.assertRegex(contract, r"manual.{0,240}(does not|do not|without).{0,120}build")
         self.assertIn("ticket:triaged", contract)
 
+    def test_code_triage_stops_before_status_when_build_creation_or_attachment_fails(self):
+        binding = (TICKET_DIRECTORY / "bindings" / "github-issues.md").read_text(
+            encoding="utf-8"
+        ).lower()
+
+        self.assertIn("creation failure or attachment failure", binding)
+        self.assertIn("do not run the later", binding)
+        self.assertIn("retain the posted work order", binding)
+
+    def test_promotion_requires_both_oversize_and_an_unsettled_decision(self):
+        slicing = (TICKET_DIRECTORY / "references" / "slicing.md").read_text(
+            encoding="utf-8"
+        ).lower()
+
+        contract = " ".join(slicing.split())
+        self.assertRegex(contract, r"more than four.*decision unsettled")
+        self.assertIn("mechanical oversize", contract)
+        self.assertIn("serial `build` tickets", contract)
+
+    def test_epic_child_change_record_consumers_state_their_phase_boundary(self):
+        expected = {
+            "start.md": "creates no change record",
+            "revise.md": "revises neither a per-child change record",
+            "finalize.md": "nor incurs sweep debt",
+            "coordinator-mode.md": "creates, folds, revises, and records no per-child",
+        }
+
+        for filename, boundary in expected.items():
+            path = (
+                TICKET_DIRECTORY / "references" / filename
+                if filename == "coordinator-mode.md"
+                else TICKET_DIRECTORY / "verbs" / filename
+            )
+            with self.subTest(consumer=filename):
+                self.assertIn(boundary, path.read_text(encoding="utf-8").lower())
+
+    def test_status_binding_orders_code_prerequisites_before_triaged_and_excludes_them_otherwise(self):
+        binding = " ".join(
+            (TICKET_DIRECTORY / "bindings" / "github-issues.md")
+            .read_text(encoding="utf-8")
+            .lower()
+            .split()
+        )
+
+        triaged_command = "gh issue edit <id> --repo <org/repo> --add-label ticket:triaged"
+        self.assertLess(binding.index("gh label create build"), binding.index(triaged_command))
+        self.assertLess(binding.index("--add-label build"), binding.index(triaged_command))
+        for classification in ("investigation", "manual"):
+            self.assertIn(f"`{classification}` does not create or attach `build`", binding)
+
+    def test_epic_child_triage_keeps_spec_and_review_state_off_the_child_branch(self):
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
+        contract = " ".join(triage.lower().split())
+
+        self.assertIn("writes only its work order", contract)
+        self.assertIn("separate docs-only pull request to main", contract)
+        self.assertIn("untracked session scratch", contract)
+        self.assertIn("outside the branch", contract)
+        self.assertIn("discard it after the final order", contract)
+        self.assertIn("do not write the epic ledger", contract)
+
     def test_revise_requires_a_base_currency_and_mergeability_refresh(self):
         revise = (TICKET_DIRECTORY / "verbs" / "revise.md").read_text(encoding="utf-8")
 

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -511,6 +511,16 @@ class TicketSkillContractTests(unittest.TestCase):
         self.assertRegex(contract, r"manual.{0,240}(does not|do not|without).{0,120}build")
         self.assertIn("ticket:triaged", contract)
 
+    def test_ticket_read_supplies_parent_for_epic_child_detection(self):
+        binding = (
+            TICKET_DIRECTORY / "bindings" / "github-issues.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "--json number,title,body,state,parent,comments",
+            binding,
+        )
+
     def test_code_triage_stops_before_status_when_build_creation_or_attachment_fails(self):
         binding = (TICKET_DIRECTORY / "bindings" / "github-issues.md").read_text(
             encoding="utf-8"

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -451,6 +451,66 @@ class TicketSkillContractTests(unittest.TestCase):
         ):
             self.assertIn(disposition, actions)
 
+    def test_under_epic_followups_use_the_epic_tracker_creation_interface(self):
+        actions = (TICKET_DIRECTORY / "references" / "review-actions.md").read_text(
+            encoding="utf-8"
+        )
+        tracker_path = (
+            ROOT / "skills" / "drivers" / "epic" / "references" / "github-tracker.md"
+        )
+        tracker = tracker_path.read_text(encoding="utf-8")
+
+        self.assertIn("../../epic/references/github-tracker.md", actions)
+        self.assertIn("Necessary follow-up", actions)
+        self.assertRegex(
+            tracker,
+            r"gh issue create .*--repo OWNER/REPO.*--title .*--body-file .*--label (spike|build).*--parent EPIC_NUMBER",
+        )
+
+    def test_every_epic_child_change_record_consumer_uses_the_epic_record(self):
+        consumers = {
+            "shared": TICKET_DIRECTORY / "SKILL.md",
+            "triage": TICKET_DIRECTORY / "verbs" / "triage.md",
+            "start": TICKET_DIRECTORY / "verbs" / "start.md",
+            "revise": TICKET_DIRECTORY / "verbs" / "revise.md",
+            "finalize": TICKET_DIRECTORY / "verbs" / "finalize.md",
+            "coordinator": TICKET_DIRECTORY / "references" / "coordinator-mode.md",
+        }
+
+        for name, path in consumers.items():
+            with self.subTest(consumer=name):
+                text = " ".join(path.read_text(encoding="utf-8").lower().split())
+                self.assertIn("epic child", text)
+                self.assertIn("change record", text)
+
+    def test_epic_child_scope_instrumentation_never_creates_a_scope_ledger(self):
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
+        scope = (ROOT / "skills" / "workflows" / "scope" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        contract = " ".join((triage + "\n" + scope).lower().split())
+
+        self.assertIn("epic child", contract)
+        self.assertIn("session scratch", contract)
+        self.assertIn("every specialist", contract)
+        self.assertIn("no scope ledger", contract)
+
+    def test_triaged_build_label_is_conditioned_on_code_classification(self):
+        tracker = (TICKET_DIRECTORY / "references" / "tracker-contract.md").read_text(
+            encoding="utf-8"
+        )
+        binding = (TICKET_DIRECTORY / "bindings" / "github-issues.md").read_text(
+            encoding="utf-8"
+        )
+        contract = " ".join((tracker + "\n" + binding).lower().split())
+
+        for classification in ("code", "investigation", "manual"):
+            self.assertIn(classification, contract)
+        self.assertRegex(contract, r"code classification.{0,240}build")
+        self.assertRegex(contract, r"investigation.{0,240}(does not|do not|without).{0,120}build")
+        self.assertRegex(contract, r"manual.{0,240}(does not|do not|without).{0,120}build")
+        self.assertIn("ticket:triaged", contract)
+
     def test_revise_requires_a_base_currency_and_mergeability_refresh(self):
         revise = (TICKET_DIRECTORY / "verbs" / "revise.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Epic children now follow one lifecycle from triage through close-out, while the required `skills` job stays present on every pull request and skips installation and browser work only for documentation-only changes. Before this, ticket phases disagreed about child records and every pull request paid for the full installation and browser checks.

* Triage confirms the parent carries the `epic` type before using the child exception, applies `build` before `ticket:triaged` for code work, and leaves investigation, manual, parentless, and non-epic child tickets on the ordinary path.
* The changed-path classifier fails closed for mixed, executable, malformed, empty, non-pull-request, and transport-failure cases. One output gates exactly the four expensive steps inside the unconditional required job.
* The epic owns child change records and planning state, and qualified review follow-ups become native child issues attached to it. ADR 143 records why the lifecycle behavior followed the mechanical rename separately, and the active skill, script, README, and workflow paths contain no retired driver-name references.
* Known review residue: the epic-parent contract test pins every required clause but does not encode the complete three-way prose predicate strongly enough to reject every possible inverted rewrite. Full review stopped at its three-round cap with this item partial.

Closes #143

## Verification

```text
validated 27 skills and 291 files
Ran 358 tests in 83.917s
OK (skipped=23)
py_compile exit 0
git diff --check exit 0
clean temporary install: 27 skills installed
installed-skill subset comparison: exit 0
active-path legacy-name search: no matches
```

The required `skills` job will exercise the full-work branch because this pull request changes scripts, tests, and workflow machinery. The documentation-only skip branch is table-tested here; its live confirmation belongs to the first later documentation-only pull request.
