### PR TITLE
docs(review): authorize mandatory delegation

### DIFF
--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -58,6 +58,10 @@ substitutes a lighter check for the depth the order stamped. Below Full depth un
 `Profile: hardening`, [start](verbs/start.md) and [revise](verbs/revise.md) use its
 exception instead.
 
+## Delegation authority
+
+This authority covers triage's mandatory `/plan-review` and start/revise's `/review` route. Invoking `/ticket` authorizes every sub-agent dispatch that this procedure marks mandatory, including a mandatory nested review skill. Do not ask again solely because a session-level preference says "do not spawn agents"; apply that preference to discretionary delegation only. An explicit task-level refusal of this required review or revocation of delegation overrides this authorization: stop and state that the requested workflow cannot run without its required independent review.
+
 ## Shared rules (every verb)
 
 1. **Open with the ticket summary.** Before any other work, read the ticket and

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -186,6 +186,8 @@ the branch, and its change record already belongs to the parent epic.
     returns objections and a verdict. Review depth follows that skill's stakes
     tiering: an ordinary order gets one panel, and a load-bearing one ends only
     when a fresh cold pass returns no blocking objections.
+    The ticket skill page's `## Delegation authority` section covers this mandatory
+    `/plan-review`.
 
     When the stamped profile is hardening, run `/plan-review` only on Full-depth
     orders. Default-workflow orders keep this review unconditionally.

--- a/skills/tools/code-review/SKILL.md
+++ b/skills/tools/code-review/SKILL.md
@@ -29,6 +29,10 @@ forgotten:
    `unverified` or is dropped. A plausible-sounding finding nobody traced is how
    a fix gets written for a defect that was never there.
 
+## Delegation authority
+
+Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, including a mandatory nested review skill. Do not ask again solely because a session-level preference says "do not spawn agents"; apply that preference to discretionary delegation only. An explicit task-level refusal of this required review or revocation of delegation overrides this authorization: stop and state that the requested workflow cannot run without its required independent review.
+
 ## Modes
 
 **First review** — the full process below.

--- a/skills/tools/plan-review/SKILL.md
+++ b/skills/tools/plan-review/SKILL.md
@@ -35,6 +35,10 @@ separate cold subagent per plan with only the plan's location, the rubric, and
 read access to the repo. Self-review by the author reliably misses what a cold
 reader catches, no matter how honestly the author tries to re-derive.
 
+## Delegation authority
+
+Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, including a mandatory nested review skill. Do not ask again solely because a session-level preference says "do not spawn agents"; apply that preference to discretionary delegation only. An explicit task-level refusal of this required review or revocation of delegation overrides this authorization: stop and state that the requested workflow cannot run without its required independent review.
+
 ## The rubric
 
 Judge the plan on exactly these five axes. For axes 3 and 4, ground in the

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3538,5 +3538,61 @@ class UiCraftCliMainGuardTests(unittest.TestCase):
         )
 
 
+class DelegationAuthorityContractTests(unittest.TestCase):
+    CODE_REVIEW = (ROOT / "skills" / "tools" / "code-review" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    PLAN_REVIEW = (ROOT / "skills" / "tools" / "plan-review" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    TICKET = (ROOT / "skills" / "drivers" / "ticket" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    TRIAGE = (ROOT / "skills" / "drivers" / "ticket" / "verbs" / "triage.md").read_text(
+        encoding="utf-8"
+    )
+    PERSONA_REVIEW = (
+        ROOT / "skills" / "tools" / "persona-review" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    ENTRY_POINTS = (CODE_REVIEW, PLAN_REVIEW, TICKET)
+    AUTHORIZATION = "authorizes every sub-agent dispatch that this procedure marks mandatory"
+    DISCRETIONARY_ONLY = (
+        'Do not ask again solely because a session-level preference says "do not spawn '
+        'agents"; apply that preference to discretionary delegation only.'
+    )
+    REFUSAL_STOPS_WORKFLOW = (
+        "An explicit task-level refusal of this required review or revocation of "
+        "delegation overrides this authorization: stop and state that the requested "
+        "workflow cannot run without its required independent review."
+    )
+
+    def test_all_required_review_entry_points_authorize_mandatory_dispatch(self):
+        for skill in self.ENTRY_POINTS:
+            self.assertIn(self.AUTHORIZATION, skill)
+
+    def test_session_preference_leaves_required_dispatch_authorized(self):
+        for skill in self.ENTRY_POINTS:
+            self.assertIn(self.DISCRETIONARY_ONLY, skill)
+
+    def test_explicit_refusal_or_revocation_stops_required_review_workflow(self):
+        for skill in self.ENTRY_POINTS:
+            self.assertIn(self.REFUSAL_STOPS_WORKFLOW, skill)
+
+    def test_persona_review_keeps_conditional_serial_fallback_without_authority(self):
+        self.assertNotIn(self.AUTHORIZATION, self.PERSONA_REVIEW)
+        self.assertIn(
+            "Where subagents aren't available, review personas serially in the main session",
+            self.PERSONA_REVIEW,
+        )
+
+    def test_ticket_authority_covers_triage_plan_review(self):
+        self.assertIn("triage's mandatory `/plan-review`", self.TICKET)
+
+    def test_triage_points_to_ticket_authority_without_repeating_it(self):
+        self.assertIn("ticket skill page's `## Delegation authority` section", self.TRIAGE)
+        self.assertNotIn(self.AUTHORIZATION, self.TRIAGE)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Invoking code review, plan review, or a ticket verb now authorizes every sub-agent dispatch the procedure marks mandatory, so a session-level preference against spawning agents no longer stalls a required review round. Before this, such a preference forced the reviewer to stop and ask, or to run its independent axes inline in the same session that authored the work.

* The authorization is one settled paragraph, byte-identical in three skills from its operative clause onward; a contract test pins the shared sentences in all three copies.
* An explicit task-level refusal of a required review still stops the run: the paragraph distinguishes a standing preference from a direct instruction, and only the former is overridden.
* Persona review keeps its conditional wording and serial fallback; it claims no unconditional authority.
* Review residue: the clause covering a mandatory nested review skill appears in no test constant, so drift in that one clause would go undetected.

The ruling behind the wording is spike #140's findings comment.

Closes #146

## Verification

```text
validated 27 skills and 291 files
Ran 364 tests ... OK (skipped=23)
py_compile exit 0
```

On the pre-change tree, five of the six new tests fail on the missing wording; the sixth is the persona-review negative assertion, which passes on both trees by design. All six pass after.
