### PR TITLE
docs(orchestrate): dispatch reference for Claude-parent Codex reviewers

### DIFF
--- a/skills/drivers/orchestrate/SKILL.md
+++ b/skills/drivers/orchestrate/SKILL.md
@@ -8,7 +8,9 @@ description: Flip the session into coordinator mode — the parent agent plans, 
 Invoking this skill flips the **whole session** into coordinator mode until the
 operator says otherwise. Detect the parent before dispatching:
 
-- **Claude Code parent:** use the Claude and Codex mechanics below.
+- **Claude Code parent:** use the Claude and Codex mechanics below. Before
+  dispatching a Codex worker, read
+  `references/dispatch-codex-from-claude.md`.
 - **Codex UI parent:** read `references/dispatch-codex.md` before routing. In
   this v0, every delegation uses its CLI-worker adapter; do not use native
   `spawn_agent` for implementation or review.

--- a/skills/drivers/orchestrate/references/dispatch-codex-from-claude.md
+++ b/skills/drivers/orchestrate/references/dispatch-codex-from-claude.md
@@ -1,0 +1,51 @@
+# Claude Code parent dispatching a Codex worker
+
+Use this reference only when the interactive coordinator is a Claude Code
+parent dispatching a **Codex** worker for review. `dispatch-codex.md` remains
+Codex-UI-parent-only and is unchanged by this document. This document adds no
+route and no gate of its own — it composes the existing Codex headroom gate
+in `SKILL.md` with the existing Code review row in `references/routing-table.md`.
+
+## Admission procedure
+
+a. **Run the presence-and-headroom gate first, before any Codex spend.** The
+   gate — `command -v codex`, then a fresh Luna probe, dropping every Codex
+   route on absent / unknown / ≤5% / rate-limited — is defined once in
+   `SKILL.md`'s "Codex headroom gate" section. Cite it here; this document does
+   not restate its thresholds as independent prose.
+b. **With usable headroom, dispatch routine code review as Luna**
+   (`gpt-5.6-luna`) with `--sandbox read-only` through `codex-worker.py start`,
+   persisting one state file for that worker. Review is a read task, so
+   `workspace-write` is never correct for it — that is a rule, not an example.
+c. **Retry a failed routine review once in the same worker session** via
+   `codex-worker.py resume` against that state file, carrying the specific
+   finding. State is preserved for the retry; do not start a second worker for
+   it. When that retry also fails, escalate one tier per the Code review row's
+   escalation column (Luna → Sonnet → Opus) — SKILL.md's "Verification and
+   escalation" item 2 for a Claude parent. Item 3's `NO_VALIDATED_ROUTE` stop
+   and its "never escalate Terra, Luna, or Sol to Sonnet or Opus" ban are
+   Codex-UI-parent rules and do not apply here.
+d. **Route load-bearing or safety review to Claude Opus directly**, per the
+   Code review row. It is never a Codex worker on this path, and Opus is top
+   of ladder — there is nothing above it to escalate to.
+e. **On Codex absent, unknown headroom, headroom at or below 5%, or a
+   rate-limited probe or delegation, enter the Claude-only branch SKILL.md
+   already defines:** routine review begins at Sonnet and escalates to Opus;
+   load-bearing review stays Opus. Make no second Codex attempt for the rest
+   of the session.
+
+## Infrastructure failure vs. model-quality failure
+
+A worker that failed to launch, hung before session start, lost its rollout,
+or was refused for headroom is a dispatch failure, matching the rule
+`dispatch-codex.md` already states. It is not evidence that Luna reviewed
+badly, so it consumes neither the one same-session retry in step c above nor
+an escalation rung. See `dispatch-codex.md`'s "Worker liveness" and
+"Interrupted workers" sections for the shared mechanics — they are not
+duplicated here. The launching coordinator owns stop-then-verify before any
+successor touches the worktree.
+
+## Boundary
+
+This document does not cover dispatching a **Claude** worker; there is no
+`dispatch-claude.md` on this base to name.

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2072,6 +2072,49 @@ class OrchestrateCodexPolicyTests(unittest.TestCase):
         self.assertIn("`ps -o time` is growing", dispatch)
         self.assertIn("rollout-*.jsonl", dispatch)
 
+    def test_claude_parent_codex_dispatch_reference_is_pinned(self):
+        skill = (ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        dispatch = (
+            ROOT / "skills" / "drivers" / "orchestrate" / "references" / "dispatch-codex.md"
+        ).read_text(encoding="utf-8")
+        from_claude = (
+            ROOT
+            / "skills"
+            / "drivers"
+            / "orchestrate"
+            / "references"
+            / "dispatch-codex-from-claude.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "Before\n  dispatching a Codex worker, read\n  `references/dispatch-codex-from-claude.md`.",
+            skill,
+        )
+        self.assertIn(
+            "Use this adapter only when the interactive coordinator is a Codex UI parent.",
+            dispatch,
+        )
+
+        self.assertIn(
+            "only when the interactive coordinator is a Claude Code\nparent dispatching a **Codex** worker",
+            from_claude,
+        )
+        self.assertIn("gpt-5.6-luna", from_claude)
+        self.assertIn("read-only", from_claude)
+        self.assertIn("Retry a failed routine review once in the same worker session", from_claude)
+        self.assertIn("do not start a second worker for\n   it", from_claude)
+        self.assertIn("escalate one tier per the Code review row's", from_claude)
+        self.assertIn("Luna → Sonnet → Opus", from_claude)
+        self.assertIn(
+            "Item 3's `NO_VALIDATED_ROUTE` stop\n   and its \"never escalate Terra, Luna, or Sol to Sonnet or Opus\" ban are\n   Codex-UI-parent rules and do not apply here.",
+            from_claude,
+        )
+        self.assertIn("Route load-bearing or safety review to Claude Opus directly", from_claude)
+        self.assertIn("routine review begins at Sonnet and escalates to Opus", from_claude)
+        self.assertIn("Make no second Codex attempt for the rest\n   of the session.", from_claude)
+
 
 class WorkerLifecycleContractTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

A Claude coordinator now has a documented admission procedure for dispatching Codex reviewer workers, instead of the only dispatch reference being expressly Codex-UI-parent-only. Routine review admits Luna read-only through the existing worker helper after the presence and headroom gate; load-bearing review stays on Opus.

* The document adds no route and no gate of its own: it cites the skill's headroom gate and the routing table's code-review row rather than restating their thresholds.
* When Codex is absent, unknown, rate-limited, or at the headroom floor, the procedure enters the established Claude-only branch with no second Codex attempt, and it has an explicit terminus after the single same-session retry fails.
* The sibling adapter for a pack-owned Claude worker did not exist on this base, so the document names it only in a boundary note; nothing here depends on it.
* A contract test pins the document's load-bearing sentences and the parent-detection pointer, so a later change that drops either fails required CI.

The ruling behind the design is spike #140's findings comment; the order's cold reviews and their rulings are on the issue.

Closes #145

## Verification

```text
validated 27 skills and 292 files
Ran 347 tests ... OK (skipped=23)
py_compile exit 0
```

The file count is exactly base plus one, matching the order's expectation; the diff to the existing dispatch reference and routing table is empty.
