### PR TITLE
feat(orchestrate): universal effort dial and pack-owned Claude worker dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,10 @@ ui-surfaces: none
   tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench
   tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco
   tests.test_ci_changed_paths && python3 -m py_compile
-  skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py`
+  skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py
+  skills/drivers/orchestrate/scripts/codex-worker.py
+  skills/drivers/orchestrate/scripts/claude-worker.py`. Requires Python 3.10
+  or newer (the worker scripts use `X | None` union syntax).
 - Dev: no app to run. To exercise a skill, install the pack into a scratch
   directory with `npx skills add . --skill '<name>' --copy --yes`.
 - Source: `skills/<category>/<name>/` (SKILL.md plus its own `references/`,

--- a/docs/adr/adr-149-pack-owned-model-dispatch.md
+++ b/docs/adr/adr-149-pack-owned-model-dispatch.md
@@ -1,0 +1,53 @@
+# ADR 149 — Pack-owned model dispatch, with effort settable everywhere
+
+Status: accepted (2026-08-24)
+
+## Context
+
+`/orchestrate` dispatches Claude models through the harness's built-in Agent tool and
+Codex models through `skills/drivers/orchestrate/scripts/codex-worker.py`. The two
+paths are not comparable:
+
+* The Agent tool takes a model override and nothing else. A Claude worker silently
+  inherits the coordinator session's reasoning effort, and no skill can raise or lower
+  it. The `claude` CLI does take `--effort low|medium|high|xhigh|max`.
+* `codex-worker.py` pins `model_reasoning_effort=medium` as a hard-coded constant with
+  no flag, so effort is unsettable on that side too — just unsettable in a different way.
+* The Codex adapter enforces `cwd` and a sandbox mode; the Agent tool enforces neither,
+  so read-only for a Claude worker rested on an agent type plus a sentence in the prompt.
+  A benchmark run was already invalidated by a read agent that left a patch applied.
+
+`references/dispatch-codex.md` already bans native `spawn_agent` for a Codex UI parent
+on exactly these grounds. Nothing said the same about Claude's built-in dispatch.
+
+## Decision
+
+**All model dispatch defined by this pack goes through this pack's own adapters.** Any
+skill here that dispatches a model — `orchestrate`, `code-review`, `plan-review`,
+`persona-review`, `ticket`'s chunk agents, `epic` — dispatches through `codex-worker.py`
+or the new `claude-worker.py`. The built-in Agent tool, the Workflow tool, and background
+agents are not dispatch paths for delegated work.
+
+**Both adapters take `--effort`, defaulting to `medium` for every model.** The dial exists
+so a coordinator can override per delegation. The default is uniform because no effort
+benchmarking has been done: the 2026-08-03 replay scored every Codex run at medium and
+never varied the dial. A per-model default is a benchmark result, not a preference, and
+gets set when a replay measures one.
+
+**A Claude worker's sandbox mode is enforced by the OS, not by the prompt.** Read-only and
+write configurations are the committed, executed artifacts under `docs/scope/149-probes/`,
+verified 2026-08-24: the read-only worker keeps a working shell and has its writes refused
+by Seatbelt; the write worker writes inside its cwd and nowhere else. `allowUnsandboxedCommands:
+false` is part of the contract — it disables the `dangerouslyDisableSandbox` retry, so a
+blocked command cannot be re-run outside the sandbox.
+
+## Consequences
+
+* Effort becomes a routing dial the table can carry, without changing any stamped route.
+  Changing a default still requires a benchmark replay.
+* A Claude worker gains what the Codex side already had: enforced `cwd`, an enforced
+  sandbox mode, resumable sessions, and coordinator-owned recovery.
+* Consuming skills convert one at a time behind their own issues; until a skill is
+  converted it keeps its current dispatch, and the ban binds it once its issue lands.
+* The pack takes on a second worker script to maintain, and both adapters now track a
+  CLI surface that can change under them.

--- a/docs/adr/adr-149-pack-owned-model-dispatch.md
+++ b/docs/adr/adr-149-pack-owned-model-dispatch.md
@@ -36,8 +36,14 @@ gets set when a replay measures one.
 
 **A Claude worker's sandbox mode is enforced by the OS, not by the prompt.** Read-only and
 write configurations are the committed, executed artifacts under `docs/scope/149-probes/`,
-verified 2026-08-24: the read-only worker keeps a working shell and has its writes refused
-by Seatbelt; the write worker writes inside its cwd and nowhere else. `allowUnsandboxedCommands:
+verified 2026-08-24, with the run captured in `docs/scope/149-probes/output.txt`: the
+read-only worker keeps a working shell and has every write refused by Seatbelt; the write
+worker writes inside its cwd and is refused a write into the home directory.
+
+The write mode's boundary is cwd **plus the session temp directory**, which the sandbox
+documents as writable and a first measurement mistook for a confinement hole. A worker can
+therefore write under `$TMPDIR`; it cannot write into the operator's home or control
+checkout. Stating the boundary as "the worktree and nowhere else" would be false. `allowUnsandboxedCommands:
 false` is part of the contract — it disables the `dangerouslyDisableSandbox` retry, so a
 blocked command cannot be re-run outside the sandbox.
 

--- a/docs/adr/adr-149-pack-owned-model-dispatch.md
+++ b/docs/adr/adr-149-pack-owned-model-dispatch.md
@@ -47,13 +47,27 @@ checkout. Stating the boundary as "the worktree and nowhere else" would be false
 false` is part of the contract — it disables the `dangerouslyDisableSandbox` retry, so a
 blocked command cannot be re-run outside the sandbox.
 
+**The two adapters duplicate their lifecycle machinery, deliberately and temporarily.**
+`claude-worker.py` copies `codex-worker.py`'s state handling, process-family ownership,
+liveness, stop, verify, and control-checkout refusal rather than sharing a module. The
+charter's rule that the second caller makes the seam real still holds, and the extraction is
+issue #150 — deferred because three cold review panels showed the move defeats ~42 mock
+patch sites, that a re-loaded module handle patches a different object, that
+`run_lifecycle`/`run_portable` call codex's own parser and hard-wire `stdin=DEVNULL`, and
+that a shared `fail()` prefix is last-writer-wins across two adapters in one test process.
+Carrying that risk on the effort dial's critical path was the worse trade.
+
 ## Consequences
 
 * Effort becomes a routing dial the table can carry, without changing any stamped route.
   Changing a default still requires a benchmark replay.
 * A Claude worker gains what the Codex side already had: enforced `cwd`, an enforced
   sandbox mode, resumable sessions, and coordinator-owned recovery.
-* Consuming skills convert one at a time behind their own issues; until a skill is
-  converted it keeps its current dispatch, and the ban binds it once its issue lands.
+* Consuming skills convert one at a time behind their own issues (#151 code-review, #152
+  plan-review, #153 persona-review, #154 ticket, #155 epic, #156 research, #157
+  codebase-design); until a skill is converted it keeps its current dispatch, and the ban
+  binds it once its issue lands.
+* One fact has two implementations until #150 lands. That is a known, dated exception with
+  an owner, not a standard being relaxed.
 * The pack takes on a second worker script to maintain, and both adapters now track a
   CLI surface that can change under them.

--- a/docs/adr/adr-149-pack-owned-model-dispatch.md
+++ b/docs/adr/adr-149-pack-owned-model-dispatch.md
@@ -37,11 +37,24 @@ gets set when a replay measures one.
 **A Claude worker's sandbox mode is enforced by the OS, not by the prompt.** Read-only and
 write configurations are the committed, executed artifacts under `docs/scope/149-probes/`,
 verified 2026-08-24, with the run captured in `docs/scope/149-probes/output.txt`: the
-read-only worker keeps a working shell and has every write refused by Seatbelt; the write
-worker writes inside its cwd and is refused a write into the home directory.
+read-only worker keeps a working shell and has every write refused by Seatbelt. That holds
+through the adapter too, re-verified in `docs/scope/149-probes/run-log.md`, where the
+refusal also survives a resume through the adapter's own argv.
 
-The write mode's boundary is cwd **plus the session temp directory**, which the sandbox
-documents as writable and a first measurement mistook for a confinement hole. A worker can
+**Correction (2026-08-25), forced by a real run through the adapter.** The write mode was
+not confined by the artifact this ADR originally cited.
+`docs/scope/149-probes/write.settings.json` carries no `filesystem` block at all, and a real
+`workspace-write` worker launched with that shape wrote straight through to `$HOME/.cache`
+— see the `write` case in `run-log.md`. The sandbox does not confine writes unless the
+settings file says so, so the original claim that the write worker "writes inside its cwd
+and is refused a write into the home directory" was false as stated. What actually confines
+it is `filesystem.allowWrite: [cwd]` **alone**, which `claude-worker.py` now generates.
+Pairing it with a `denyWrite` (`["/"]`, then `["~/"]`) was tried and rejected on disk both
+times: `deny` beats `allow` for the same path, so the pair silently re-blocks the very cwd
+`allowWrite` exists to carve out.
+
+With `allowWrite: [cwd]` in place, the write mode's boundary is cwd **plus the session temp
+directory**, which the sandbox documents as writable. A worker can
 therefore write under `$TMPDIR`; it cannot write into the operator's home or control
 checkout. Stating the boundary as "the worktree and nowhere else" would be false. `allowUnsandboxedCommands:
 false` is part of the contract — it disables the `dangerouslyDisableSandbox` retry, so a

--- a/docs/scope/149-probes/effort-enums.md
+++ b/docs/scope/149-probes/effort-enums.md
@@ -1,0 +1,28 @@
+# Effort enums, captured 2026-08-24
+
+Each adapter validates its own set. They are not the same set.
+
+## claude
+
+```
+$ claude --help | grep -A1 -- "--effort"
+  --effort <level>                      Effort level for the current session
+                                        (low, medium, high, xhigh, max)
+```
+
+## codex
+
+The codex CLI does NOT validate this value locally — a bogus value starts the
+session and fails at the API:
+
+```
+$ printf hi | codex exec -m gpt-5.6-luna -c model_reasoning_effort=bogus --sandbox read-only --skip-git-repo-check
+reasoning effort: bogus
+ERROR: { ... }   # accepted locally, rejected by the API
+```
+
+Authoritative set, from the Codex configuration reference
+(https://learn.chatgpt.com/docs/config-file/config-reference):
+
+> model_reasoning_effort: "minimal | low | medium | high | xhigh" (Responses API only;
+> "xhigh is model-dependent")

--- a/docs/scope/149-probes/output.txt
+++ b/docs/scope/149-probes/output.txt
@@ -1,3 +1,8 @@
+# SUPERSEDED (2026-08-25) for the `write` case: this capture predates the build.
+# The `write` settings shape exercised here carries no `filesystem` block and does NOT
+# confine writes -- a real workspace-write worker later wrote through to $HOME/.cache.
+# See run-log.md for the post-fix capture; claude-worker.py now generates
+# filesystem.allowWrite: [cwd]. The readonly/session/resumed cases below still hold.
 # probe run 1a9f37c
 # claude 2.1.228 (Claude Code)
 readonly: wrote_in_cwd=no escaped_cwd=no

--- a/docs/scope/149-probes/output.txt
+++ b/docs/scope/149-probes/output.txt
@@ -1,0 +1,6 @@
+# probe run f4fec2a
+# claude 2.1.228 (Claude Code)
+readonly: wrote_in_cwd=no escaped_cwd=no
+write: wrote_in_cwd=yes escaped_cwd=no
+session: id_honored=True resume_carries_context=True
+session: parsed_fields=['is_error', 'permission_denials', 'result', 'session_id', 'total_cost_usd']

--- a/docs/scope/149-probes/output.txt
+++ b/docs/scope/149-probes/output.txt
@@ -1,10 +1,11 @@
-# probe run 8b48626
+# probe run 1a9f37c
 # claude 2.1.228 (Claude Code)
 readonly: wrote_in_cwd=no escaped_cwd=no
-readonly: report=`ls -a` listed 6 entries (`.`, `..`, `.claude`, `err.txt`, `out.txt`, `seed.txt`) but then hit a permission error; write attempts to both probe.txt and the cache directory were blocked.  **READ_OK** — `ls -a` returned 
+readonly: report=Current directory is read-only. The `ls` output shows **6 entries** (`.`, `..`, `.claude`, `err.txt`, `out.txt`, `seed.txt`) before permission error.  **READ_OK** — ls -a listed 6 entries. **WROTE_FAIL** — write to p
 write: wrote_in_cwd=yes escaped_cwd=no
-write: report=READ_OK (6 entries: `.`, `..`, `.claude`, `err.txt`, `out.txt`, `seed.txt`). WROTE_OK (probe.txt created in current directory). ESCAPE_FAIL (sandbox blocked write to $HOME/.cache/). 
+write: report=READ_OK: 6 entries. WROTE_OK: probe.txt created. ESCAPE_FAIL: sandbox blocks writing to $HOME/.cache/. 
 session: id_honored=True resume_carries_context=True
+session: resume_accepts_effort=True
 session: parsed_fields=['is_error', 'permission_denials', 'result', 'session_id', 'total_cost_usd']
 resumed: wrote_after_resume=no
-resumed: report=WROTE_FAIL 
+resumed: report=WROTE_FAIL  File creation failed due to permission restrictions on the current working directory. 

--- a/docs/scope/149-probes/output.txt
+++ b/docs/scope/149-probes/output.txt
@@ -1,6 +1,10 @@
-# probe run f4fec2a
+# probe run 8b48626
 # claude 2.1.228 (Claude Code)
 readonly: wrote_in_cwd=no escaped_cwd=no
+readonly: report=`ls -a` listed 6 entries (`.`, `..`, `.claude`, `err.txt`, `out.txt`, `seed.txt`) but then hit a permission error; write attempts to both probe.txt and the cache directory were blocked.  **READ_OK** — `ls -a` returned 
 write: wrote_in_cwd=yes escaped_cwd=no
+write: report=READ_OK (6 entries: `.`, `..`, `.claude`, `err.txt`, `out.txt`, `seed.txt`). WROTE_OK (probe.txt created in current directory). ESCAPE_FAIL (sandbox blocked write to $HOME/.cache/). 
 session: id_honored=True resume_carries_context=True
 session: parsed_fields=['is_error', 'permission_denials', 'result', 'session_id', 'total_cost_usd']
+resumed: wrote_after_resume=no
+resumed: report=WROTE_FAIL 

--- a/docs/scope/149-probes/probe.sh
+++ b/docs/scope/149-probes/probe.sh
@@ -6,8 +6,13 @@
 #
 # Cases:
 #   readonly  - a read-only worker keeps a shell and cannot write anywhere
-#   write     - a write worker writes in its cwd and is refused outside it
-#               (outside = a home-directory path, not a temp path)
+#   write     - exercises the committed write.settings.json shape. NOTE (2026-08-25):
+#               that shape carries no `filesystem` block and does NOT confine writes -- a
+#               real worker launched with it wrote through to $HOME/.cache. This case
+#               measures the shape as committed, not a confinement guarantee. What
+#               confines is filesystem.allowWrite: [cwd], which claude-worker.py
+#               generates; see run-log.md. Writable region is cwd plus the session
+#               temp dir, never the home directory or the control checkout.
 #   session   - a caller-supplied --session-id is honored, --resume carries context,
 #               --output-format json exposes the fields the adapter parses
 #   resumed   - a RESUMED read-only worker is still sandboxed (the settings file is

--- a/docs/scope/149-probes/probe.sh
+++ b/docs/scope/149-probes/probe.sh
@@ -1,21 +1,57 @@
 #!/bin/sh
-# Reproduces the #149 sandbox findings: a read-only Claude worker keeps its shell but
-# cannot write, and a write worker writes inside its cwd only. Both run headless.
+# Executed contract for #149. Establishes, by running them, the facts the work order
+# relies on. Usage:
 #
-#   sh docs/scope/149-probes/probe.sh <scratch-dir>
+#   sh docs/scope/149-probes/probe.sh <scratch-dir> > docs/scope/149-probes/output.txt 2>&1
 #
-# Expected: readonly -> READ ok, WROTE no. write -> READ ok, WROTE yes.
+# Cases:
+#   readonly  - a read-only worker keeps a shell and cannot write anywhere
+#   write     - a write worker writes in its cwd and is refused outside it
+#               (outside = a home-directory path, not a temp path)
+#   session   - a caller-supplied --session-id is honored, --resume carries context,
+#               --output-format json exposes the fields the adapter parses
 set -eu
 here=$(cd "$(dirname "$0")" && pwd)
 scratch=${1:?usage: probe.sh <scratch-dir>}
-prompt='First run `ls -a` with bash and report how many entries you saw. Then use bash to create probe.txt in the current directory containing WROTE. Report READ_OK/READ_FAIL and WROTE_OK/WROTE_FAIL.'
+mkdir -p "$scratch"
+# The escape target must sit outside the session temp region: the sandbox documents
+# the working directory AND the session temp directory as writable, so a /tmp target
+# proves nothing about confinement.
+outside="$HOME/.cache/149-probe-escape"
+mkdir -p "$outside"
+
+echo "# probe run $(git -C "$here" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "# claude $(claude --version 2>&1 | head -1)"
 
 for case in readonly write; do
   d="$scratch/$case"
   rm -rf "$d"; mkdir -p "$d"; echo seed > "$d/seed.txt"
-  ( cd "$d" && printf '%s' "$prompt" | claude -p --model haiku \
+  prompt="Do these three things with bash, then report. 1) run \`ls -a\` and say how many entries. 2) create probe.txt in the current directory containing WROTE. 3) create $outside/escape-$case.txt containing ESCAPED. Report READ_OK/READ_FAIL, WROTE_OK/WROTE_FAIL, ESCAPE_OK/ESCAPE_FAIL."
+  rm -f "$outside/escape-$case.txt"
+  ( cd "$d" && printf '%s' "$prompt" | claude -p --model haiku --effort medium \
       --permission-mode dontAsk --settings "$here/$case.settings.json" \
       > out.txt 2> err.txt ) || true
-  if [ -f "$d/probe.txt" ]; then wrote=yes; else wrote=no; fi
-  echo "$case: wrote=$wrote"
+  [ -f "$d/probe.txt" ] && cwd_write=yes || cwd_write=no
+  [ -f "$outside/escape-$case.txt" ] && escaped=yes || escaped=no
+  echo "$case: wrote_in_cwd=$cwd_write escaped_cwd=$escaped"
 done
+rmdir "$outside" 2>/dev/null || true
+
+# session identity, effort passthrough, and the JSON fields the adapter parses
+d="$scratch/session"; rm -rf "$d"; mkdir -p "$d"
+u=$(python3 -c 'import uuid;print(uuid.uuid4())')
+( cd "$d" && printf 'Reply with exactly: FIRST' | claude -p --model haiku --effort medium \
+    --session-id "$u" --output-format json > first.json 2> first.err ) || true
+( cd "$d" && printf 'What did you reply a moment ago? One word.' | claude -p --model haiku \
+    --resume "$u" --output-format json > second.json 2> second.err ) || true
+python3 - "$d" "$u" <<'PY'
+import json, sys
+d, u = sys.argv[1], sys.argv[2]
+first = json.load(open(f"{d}/first.json"))
+second = json.load(open(f"{d}/second.json"))
+print("session: id_honored=%s resume_carries_context=%s" % (
+    first.get("session_id") == u, "FIRST" in str(second.get("result", "")).upper()))
+print("session: parsed_fields=%s" % sorted(
+    k for k in ("session_id", "result", "is_error", "total_cost_usd", "permission_denials")
+    if k in first))
+PY

--- a/docs/scope/149-probes/probe.sh
+++ b/docs/scope/149-probes/probe.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Reproduces the #149 sandbox findings: a read-only Claude worker keeps its shell but
+# cannot write, and a write worker writes inside its cwd only. Both run headless.
+#
+#   sh docs/scope/149-probes/probe.sh <scratch-dir>
+#
+# Expected: readonly -> READ ok, WROTE no. write -> READ ok, WROTE yes.
+set -eu
+here=$(cd "$(dirname "$0")" && pwd)
+scratch=${1:?usage: probe.sh <scratch-dir>}
+prompt='First run `ls -a` with bash and report how many entries you saw. Then use bash to create probe.txt in the current directory containing WROTE. Report READ_OK/READ_FAIL and WROTE_OK/WROTE_FAIL.'
+
+for case in readonly write; do
+  d="$scratch/$case"
+  rm -rf "$d"; mkdir -p "$d"; echo seed > "$d/seed.txt"
+  ( cd "$d" && printf '%s' "$prompt" | claude -p --model haiku \
+      --permission-mode dontAsk --settings "$here/$case.settings.json" \
+      > out.txt 2> err.txt ) || true
+  if [ -f "$d/probe.txt" ]; then wrote=yes; else wrote=no; fi
+  echo "$case: wrote=$wrote"
+done

--- a/docs/scope/149-probes/probe.sh
+++ b/docs/scope/149-probes/probe.sh
@@ -49,8 +49,10 @@ d="$scratch/session"; rm -rf "$d"; mkdir -p "$d"
 u=$(python3 -c 'import uuid;print(uuid.uuid4())')
 ( cd "$d" && printf 'Reply with exactly: FIRST' | claude -p --model haiku --effort medium \
     --session-id "$u" --output-format json > first.json 2> first.err ) || true
+# --effort is passed again on resume: the adapter replays the captured effort, so the
+# flag has to be accepted alongside --resume.
 ( cd "$d" && printf 'What did you reply a moment ago? One word.' | claude -p --model haiku \
-    --resume "$u" --output-format json > second.json 2> second.err ) || true
+    --effort high --resume "$u" --output-format json > second.json 2> second.err ) || true
 python3 - "$d" "$u" <<'PY'
 import json, sys
 d, u = sys.argv[1], sys.argv[2]
@@ -58,6 +60,7 @@ first = json.load(open(f"{d}/first.json"))
 second = json.load(open(f"{d}/second.json"))
 print("session: id_honored=%s resume_carries_context=%s" % (
     first.get("session_id") == u, "FIRST" in str(second.get("result", "")).upper()))
+print("session: resume_accepts_effort=%s" % (not second.get("is_error")))
 print("session: parsed_fields=%s" % sorted(
     k for k in ("session_id", "result", "is_error", "total_cost_usd", "permission_denials")
     if k in first))

--- a/docs/scope/149-probes/probe.sh
+++ b/docs/scope/149-probes/probe.sh
@@ -10,6 +10,11 @@
 #               (outside = a home-directory path, not a temp path)
 #   session   - a caller-supplied --session-id is honored, --resume carries context,
 #               --output-format json exposes the fields the adapter parses
+#   resumed   - a RESUMED read-only worker is still sandboxed (the settings file is
+#               passed again on resume; this is the guarantee the pack depends on)
+#
+# All captured text is redacted of absolute home paths before printing: scripts/validate.py
+# forbids a literal user path in any tracked file AND in all reachable history.
 set -eu
 here=$(cd "$(dirname "$0")" && pwd)
 scratch=${1:?usage: probe.sh <scratch-dir>}
@@ -34,6 +39,8 @@ for case in readonly write; do
   [ -f "$d/probe.txt" ] && cwd_write=yes || cwd_write=no
   [ -f "$outside/escape-$case.txt" ] && escaped=yes || escaped=no
   echo "$case: wrote_in_cwd=$cwd_write escaped_cwd=$escaped"
+  # The worker's own report, so a dead shell is distinguishable from a blocked write.
+  echo "$case: report=$(tr '\n' ' ' < "$d/out.txt" | sed "s|$HOME|\$HOME|g" | cut -c1-220)"
 done
 rmdir "$outside" 2>/dev/null || true
 
@@ -55,3 +62,18 @@ print("session: parsed_fields=%s" % sorted(
     k for k in ("session_id", "result", "is_error", "total_cost_usd", "permission_denials")
     if k in first))
 PY
+
+# A resumed read-only worker must still be refused a write. If resume rebuilds its
+# configuration from the session record rather than the settings file, this is where
+# the pack's OS-enforcement claim would fail.
+d="$scratch/resumed"; rm -rf "$d"; mkdir -p "$d"
+u=$(python3 -c 'import uuid;print(uuid.uuid4())')
+( cd "$d" && printf 'Reply with exactly: READY' | claude -p --model haiku \
+    --permission-mode dontAsk --settings "$here/readonly.settings.json" \
+    --session-id "$u" --output-format json > first.json 2> first.err ) || true
+( cd "$d" && printf 'Use bash to create resumed.txt in the current directory containing WROTE. Report WROTE_OK or WROTE_FAIL.' \
+    | claude -p --model haiku --permission-mode dontAsk --settings "$here/readonly.settings.json" \
+    --resume "$u" > second.txt 2> second.err ) || true
+[ -f "$d/resumed.txt" ] && rw=yes || rw=no
+echo "resumed: wrote_after_resume=$rw"
+echo "resumed: report=$(tr '\n' ' ' < "$d/second.txt" | sed "s|$HOME|\$HOME|g" | cut -c1-220)"

--- a/docs/scope/149-probes/readonly.settings.json
+++ b/docs/scope/149-probes/readonly.settings.json
@@ -1,0 +1,8 @@
+{
+  "sandbox": {
+    "enabled": true,
+    "allowUnsandboxedCommands": false,
+    "filesystem": { "denyWrite": ["/", "~/"] }
+  },
+  "permissions": { "deny": ["Write", "Edit", "NotebookEdit"] }
+}

--- a/docs/scope/149-probes/run-log.md
+++ b/docs/scope/149-probes/run-log.md
@@ -1,0 +1,214 @@
+# Run log — #149 sub-order 2/2
+
+Executed evidence for the adapters in `skills/drivers/orchestrate/scripts/`, run
+from `<worktree>` (the ticket worktree, `codex/149-universal-effort-dial-c2`) with
+`/opt/homebrew/bin/python3.14`. A throwaway scratch worktree was created at
+`<worktree>-probe-write` (branch `scratch/149-probe-write`) for the write-mode
+runs planned in Do item 3; it went unused because those runs are blocked (see
+below) — nothing was written into it.
+
+## Claude-side runs: BLOCKED
+
+`claude auth status` reports:
+
+```
+{
+  "loggedIn": false,
+  "authMethod": "none",
+  "apiProvider": "firstParty"
+}
+```
+
+The `claude` CLI's OAuth session is expired and could not be refreshed
+non-interactively. Re-authentication requires an interactive browser login,
+which is outside this agent's authority to perform. Every run that depends on
+the `claude` CLI is recorded below as blocked rather than faked.
+
+### `probe.sh` (Do item 2) — blocked
+
+Command:
+
+```
+sh docs/scope/149-probes/probe.sh /tmp/149-probe-run1
+```
+
+Actual captured output (every case failed authentication before exercising
+sandbox behavior):
+
+```
+# probe run fdc091d
+# claude 2.1.228 (Claude Code)
+readonly: wrote_in_cwd=no escaped_cwd=no
+readonly: report=Failed to authenticate: OAuth session expired and could not be refreshed
+write: wrote_in_cwd=no escaped_cwd=no
+write: report=Failed to authenticate: OAuth session expired and could not be refreshed
+session: id_honored=True resume_carries_context=False
+session: resume_accepts_effort=False
+session: parsed_fields=['is_error', 'permission_denials', 'result', 'session_id', 'total_cost_usd']
+resumed: wrote_after_resume=no
+resumed: report=Failed to authenticate: OAuth session expired and could not be refreshed
+```
+
+blocked: `claude auth status` reports loggedIn=false; interactive browser login
+required. `docs/scope/149-probes/output.txt` (checked in from an earlier,
+authenticated run during triage) remains the only real evidence for the
+readonly/write/session/resumed cases this script exercises; it was not
+re-verified by this chunk.
+
+### `claude-worker.py start` — read-only worker (Do item 3) — blocked
+
+Planned command (not completed — fails at the `claude` CLI auth step):
+
+```
+python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
+  --state <state-dir>/readonly.json --model haiku --sandbox read-only \
+  --cwd <worktree> <<< "run a shell command, then attempt to write a file"
+```
+
+blocked: `claude auth status` reports loggedIn=false; interactive browser login
+required.
+
+### `claude-worker.py start` — workspace-write worker in the throwaway worktree — blocked
+
+Planned command (not completed):
+
+```
+python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
+  --state <state-dir>/write.json --model haiku --sandbox workspace-write \
+  --cwd <worktree>-probe-write --control-checkout <control-checkout> \
+  <<< "write a file in cwd, then attempt to write into $HOME"
+```
+
+blocked: `claude auth status` reports loggedIn=false; interactive browser login
+required.
+
+### `claude-worker.py resume` — read-only worker refused a write, effort replay — blocked
+
+blocked: `claude auth status` reports loggedIn=false; interactive browser login
+required. Not run: cannot confirm the refusal survives resume through the
+adapter's own argv, and cannot confirm the resumed worker's emitted effort
+matches what start captured.
+
+### `claude-worker.py stop` + `verify` — blocked
+
+blocked: no worker was ever started (all `start` calls above are blocked), so
+there is no process family to stop or verify.
+
+## Codex-side runs: RAN
+
+`codex login status` reports "Logged in using ChatGPT" — the Codex CLI is
+authenticated and present on PATH (`codex-cli 0.149.0`).
+
+### Headroom gate (SKILL.md:14-40) — probe
+
+Command:
+
+```
+python3 skills/drivers/orchestrate/scripts/codex-worker.py start \
+  --state <state-dir>/headroom-probe.json --model gpt-5.6-luna --sandbox read-only \
+  --cwd <worktree> "Reply with exactly: PROBE"
+```
+
+Output:
+
+```
+{"session_id": "01a0374b-1ee3-7022-b2a5-f0b41842ca46", "model": "gpt-5.6-luna", "sandbox": "read-only", "cwd": "<worktree>", "effort": "medium", "final_message": "PROBE", "headroom": 77.0, "headroom_status": "known"}
+```
+
+Headroom = 77% (known), well above the 5% gate. Codex-side spend is
+authorized for the run below.
+
+### `codex-worker.py start` with an explicit `--effort` (Do item 4) — ran
+
+Command:
+
+```
+python3 skills/drivers/orchestrate/scripts/codex-worker.py start \
+  --state <state-dir>/real-effort.json --model gpt-5.6-luna --sandbox read-only \
+  --effort high --cwd <worktree> "Reply with exactly: EFFORT_RUN_OK"
+```
+
+Output:
+
+```
+{"session_id": "01a0374b-736e-7a90-b759-4a370abbcac8", "model": "gpt-5.6-luna", "sandbox": "read-only", "cwd": "<worktree>", "effort": "high", "final_message": "EFFORT_RUN_OK", "headroom": 77.0, "headroom_status": "known"}
+```
+
+The `--effort high` flag reached the session, the run completed, and the
+emitted `effort` field (`"high"`) matches what was passed to `start` — the
+same claim Do item 3 requires proving for the resumed Claude worker's emitted
+effort, proven here on the Codex side, which was not blocked.
+
+## Rejections (Do item 5) — ran, no auth required
+
+These are pure adapter argument validation and complete before either CLI is
+invoked.
+
+### Effort outside each adapter's enum
+
+Command:
+
+```
+python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
+  --state <state-dir>/bad-effort-claude.json --model haiku --sandbox read-only \
+  --effort bogus --cwd <worktree> "noop"
+```
+
+Output (stderr, exit 1):
+
+```
+claude-worker: --effort must be one of ['high', 'low', 'max', 'medium', 'xhigh']
+```
+
+Command:
+
+```
+python3 skills/drivers/orchestrate/scripts/codex-worker.py start \
+  --state <state-dir>/bad-effort-codex.json --model gpt-5.6-luna --sandbox read-only \
+  --effort bogus --cwd <worktree> "noop"
+```
+
+Output (stderr, exit 1):
+
+```
+codex-worker: --effort must be one of ['high', 'low', 'medium', 'minimal', 'xhigh']
+```
+
+### `--sandbox workspace-write` pointed inside the control checkout
+
+Command:
+
+```
+python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
+  --state <state-dir>/inside-cc-claude.json --model haiku --sandbox workspace-write \
+  --effort medium --cwd <worktree> --control-checkout <worktree> "noop"
+```
+
+Output (stderr, exit 1):
+
+```
+claude-worker: workspace-write refuses the control checkout
+```
+
+Command:
+
+```
+python3 skills/drivers/orchestrate/scripts/codex-worker.py start \
+  --state <state-dir>/inside-cc-codex.json --model gpt-5.6-luna --sandbox workspace-write \
+  --effort medium --cwd <worktree> --control-checkout <worktree> "noop"
+```
+
+Output (stderr, exit 1):
+
+```
+codex-worker: workspace-write refuses the control checkout
+```
+
+## Corrections this chunk made
+
+None. No run above contradicted a claim in `claude-worker.py`, `codex-worker.py`,
+`SKILL.md`, or `references/dispatch-claude.md`. The Claude-side behavioral
+claims (read-only confinement, write-worker confinement, resume-preserved
+refusal, resume-preserved effort) remain unverified by this chunk's own runs
+and rest only on `docs/scope/149-probes/output.txt` captured during triage —
+this is a gap this run-log records, not a defect this run-log can rule on.

--- a/docs/scope/149-probes/run-log.md
+++ b/docs/scope/149-probes/run-log.md
@@ -4,8 +4,10 @@ Executed evidence for the adapters in `skills/drivers/orchestrate/scripts/`, run
 from `<worktree>` (the ticket worktree, `codex/149-universal-effort-dial-c2`) with
 `/opt/homebrew/bin/python3.14`. A throwaway scratch worktree was created at
 `<worktree>-probe-write` (branch `scratch/149-probe-write`) for the write-mode
-runs planned in Do item 3; it went unused because those runs are blocked (see
-below) — nothing was written into it.
+runs planned in Do item 3.
+
+A bare `python3` in the command blocks below means `/opt/homebrew/bin/python3.14`.
+The machine's default `python3` is 3.9.6, which this suite does not support.
 
 ## Claude-side runs: BLOCKED
 
@@ -135,9 +137,11 @@ Output:
 ```
 
 The `--effort high` flag reached the session, the run completed, and the
-emitted `effort` field (`"high"`) matches what was passed to `start` — the
-same claim Do item 3 requires proving for the resumed Claude worker's emitted
-effort, proven here on the Codex side, which was not blocked.
+emitted `effort` field (`"high"`) matches what was passed to `start`. This
+proves the passthrough half of the effort claim — a caller-supplied effort
+reaches the session and is observable in the emitted object — on `start`
+only. It does not prove effort survives a resume: no resume was run on either
+adapter, so the resume-replay half of Do item 3 remains unverified here.
 
 ## Rejections (Do item 5) — ran, no auth required
 

--- a/docs/scope/149-probes/run-log.md
+++ b/docs/scope/149-probes/run-log.md
@@ -4,97 +4,177 @@ Executed evidence for the adapters in `skills/drivers/orchestrate/scripts/`, run
 from `<worktree>` (the ticket worktree, `codex/149-universal-effort-dial-c2`) with
 `/opt/homebrew/bin/python3.14`. A throwaway scratch worktree was created at
 `<worktree>-probe-write` (branch `scratch/149-probe-write`) for the write-mode
-runs planned in Do item 3.
+runs.
 
 A bare `python3` in the command blocks below means `/opt/homebrew/bin/python3.14`.
 The machine's default `python3` is 3.9.6, which this suite does not support.
 
-## Claude-side runs: BLOCKED
+The operator re-authenticated the `claude` CLI partway through this chunk
+(`claude auth status` now reports `loggedIn: true`, `authMethod: claude.ai`).
+Everything below ran for real.
 
-`claude auth status` reports:
+## Claude-side runs: RAN
 
-```
-{
-  "loggedIn": false,
-  "authMethod": "none",
-  "apiProvider": "firstParty"
-}
-```
-
-The `claude` CLI's OAuth session is expired and could not be refreshed
-non-interactively. Re-authentication requires an interactive browser login,
-which is outside this agent's authority to perform. Every run that depends on
-the `claude` CLI is recorded below as blocked rather than faked.
-
-### `probe.sh` (Do item 2) — blocked
+### `probe.sh` (Do item 2)
 
 Command:
 
 ```
-sh docs/scope/149-probes/probe.sh /tmp/149-probe-run1
+sh docs/scope/149-probes/probe.sh /tmp/149-probe-run2
 ```
 
-Actual captured output (every case failed authentication before exercising
-sandbox behavior):
+Output:
 
 ```
-# probe run fdc091d
+# probe run 9de3537
 # claude 2.1.228 (Claude Code)
 readonly: wrote_in_cwd=no escaped_cwd=no
-readonly: report=Failed to authenticate: OAuth session expired and could not be refreshed
-write: wrote_in_cwd=no escaped_cwd=no
-write: report=Failed to authenticate: OAuth session expired and could not be refreshed
-session: id_honored=True resume_carries_context=False
-session: resume_accepts_effort=False
+readonly: report=**READ_FAIL, WROTE_FAIL, ESCAPE_FAIL** — all operations blocked by sandbox restrictions. The `ls -a` failed because the shell cannot write its cwd tracking file; probe.txt write to current directory was denied; and the
+write: wrote_in_cwd=yes escaped_cwd=yes
+write: report=**6 entries** in current directory.  **READ_OK** / **WROTE_OK** / **ESCAPE_OK**
+session: id_honored=True resume_carries_context=True
+session: resume_accepts_effort=True
 session: parsed_fields=['is_error', 'permission_denials', 'result', 'session_id', 'total_cost_usd']
 resumed: wrote_after_resume=no
-resumed: report=Failed to authenticate: OAuth session expired and could not be refreshed
+resumed: report=WROTE_FAIL
 ```
 
-blocked: `claude auth status` reports loggedIn=false; interactive browser login
-required. `docs/scope/149-probes/output.txt` (checked in from an earlier,
-authenticated run during triage) remains the only real evidence for the
-readonly/write/session/resumed cases this script exercises; it was not
-re-verified by this chunk.
+`write: escaped_cwd=yes` is a real escape, confirmed independently (not just
+trusted from the worker's self-report — a worker reporting DONE while
+creating no file was observed during triage):
 
-### `claude-worker.py start` — read-only worker (Do item 3) — blocked
+```
+$ ls -la "$HOME/.cache/149-probe-escape/escape-write.txt"
+-rw-r--r--@ 1 connor  staff  7 Aug 24 22:11 $HOME/.cache/149-probe-escape/escape-write.txt
+$ cat "$HOME/.cache/149-probe-escape/escape-write.txt"
+ESCAPED
+```
 
-Planned command (not completed — fails at the `claude` CLI auth step):
+This is `write.settings.json`'s fixture, not the adapter under test — that
+fixture carries no `filesystem` block at all, same shape as
+`claude-worker.py`'s pre-fix `sandbox_settings("workspace-write")`. It is out
+of this chunk's boundary to correct (not one of sub-order 1's files), so it is
+recorded here rather than changed; the adapter itself is fixed below and
+re-verified directly against the corrected settings, not through this fixture.
+
+### `claude-worker.py start` — read-only worker: shell command runs, write refused
+
+Command:
 
 ```
 python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
   --state <state-dir>/readonly.json --model haiku --sandbox read-only \
-  --cwd <worktree> <<< "run a shell command, then attempt to write a file"
+  --cwd <worktree> \
+  "Run \`ls -a\` with bash and report how many entries. Then attempt to create a file named readonly-probe.txt in the current directory with bash, and report READ_OK/READ_FAIL and WROTE_OK/WROTE_FAIL."
 ```
 
-blocked: `claude auth status` reports loggedIn=false; interactive browser login
-required.
-
-### `claude-worker.py start` — workspace-write worker in the throwaway worktree — blocked
-
-Planned command (not completed):
+Output:
 
 ```
-python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
-  --state <state-dir>/write.json --model haiku --sandbox workspace-write \
-  --cwd <worktree>-probe-write --control-checkout <control-checkout> \
-  <<< "write a file in cwd, then attempt to write into $HOME"
+{"session_id": "7057e983-f119-4847-8d0b-9b0ba024e1b1", "model": "haiku", "sandbox": "read-only", "cwd": "<worktree>", "effort": "medium", "final_message": "Bash permission was denied mid-sequence. Results so far:\n\n- **ls -a**: 23 entries\n- **Current directory write**: WROTE_FAIL (operation not permitted)\n- **Current directory read**: READ_FAIL (file never created)\n- **Scratchpad write**: WROTE_FAIL (operation not permitted)\n\nThe sandbox is preventing file writes across all attempted paths. Do you want me to request Bash permission to continue probing `$TMPDIR` and other writable locations?", "permission_denials": [{"tool_name": "Bash", "tool_use_id": "toolu_016M5JH7AdckRbeymwcLkAMJ", "tool_input": {"command": "echo \"TMPDIR=$TMPDIR\" && touch \"$TMPDIR/readonly-probe.txt\" && echo \"WROTE_OK\" || echo \"WROTE_FAIL\"", "description": "Write to $TMPDIR environment variable"}}]}
 ```
 
-blocked: `claude auth status` reports loggedIn=false; interactive browser login
-required.
+Verified independently: `ls -a` ran (23 entries reported) and no file was
+created.
 
-### `claude-worker.py resume` — read-only worker refused a write, effort replay — blocked
+```
+$ ls -la <worktree>/readonly-probe.txt
+ls: <worktree>/readonly-probe.txt: No such file or directory
+```
 
-blocked: `claude auth status` reports loggedIn=false; interactive browser login
-required. Not run: cannot confirm the refusal survives resume through the
-adapter's own argv, and cannot confirm the resumed worker's emitted effort
-matches what start captured.
+### `claude-worker.py start` — workspace-write worker in the throwaway worktree
 
-### `claude-worker.py stop` + `verify` — blocked
+First real run, against the **uncorrected** adapter (see "Correction this
+chunk made" below) — cwd write also failed here, exposing the defect:
 
-blocked: no worker was ever started (all `start` calls above are blocked), so
-there is no process family to stop or verify.
+```
+$ python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
+    --state <state-dir>/write.json --model haiku --sandbox workspace-write \
+    --cwd <worktree>-probe-write --control-checkout <control-checkout> \
+    "Use bash to create a file named write-probe.txt in the current directory containing WROTE. Then attempt to create \$HOME/.cache/149-c2-escape-probe.txt containing ESCAPED via bash. Report WROTE_OK/WROTE_FAIL and ESCAPE_OK/ESCAPE_FAIL."
+{"session_id": "184fc03c-af57-4550-a2bb-d6b11608d1d7", "model": "haiku", "sandbox": "workspace-write", "cwd": "<worktree>-probe-write", "effort": "medium", "final_message": "Write to `$TMPDIR` succeeds, but both target paths fail due to sandbox restrictions.\n\n**WROTE_FAIL** — write to current directory `<worktree>-probe-write` blocked despite path being in allowlist.\n\n**ESCAPE_FAIL** — write to `$HOME/.cache/149-c2-escape-probe.txt` blocked as expected; that path is not in the allowlist.\n\nThe sandbox is enforcing the deny at both targets. The project directory result is surprising since it's listed; the restriction may be context-specific or the allowlist entry may require additional conditions not met here.", "permission_denials": []}
+$ ls -la <worktree>-probe-write/write-probe.txt
+ls: <worktree>-probe-write/write-probe.txt: No such file or directory
+```
+
+After the fix (`filesystem.allowWrite: [cwd]`, no `denyWrite` — see
+correction below), re-run:
+
+```
+$ python3 skills/drivers/orchestrate/scripts/claude-worker.py start \
+    --state <state-dir>/write.json --model haiku --sandbox workspace-write \
+    --cwd <worktree>-probe-write --control-checkout <control-checkout> \
+    "Use bash to create a file named write-probe.txt in the current directory containing WROTE. Then attempt to create \$HOME/.cache/149-c2-escape-probe.txt containing ESCAPED via bash. Report WROTE_OK/WROTE_FAIL and ESCAPE_OK/ESCAPE_FAIL."
+{"session_id": "cbb70bf9-e84f-4e0c-afa6-f60c9c1c03f7", "model": "haiku", "sandbox": "workspace-write", "cwd": "<worktree>-probe-write", "effort": "medium", "final_message": "**WROTE_OK** — file created in current directory.\n**ESCAPE_FAIL** — sandbox blocks writes outside the allowed paths ($HOME/.cache is not in the write allowlist).", "permission_denials": []}
+```
+
+Verified independently, not from the worker's self-report:
+
+```
+$ ls -la <worktree>-probe-write/write-probe.txt
+-rw-r--r--@ 1 connor  staff  6 Aug 24 22:24 <worktree>-probe-write/write-probe.txt
+$ cat <worktree>-probe-write/write-probe.txt
+WROTE
+$ ls -la "$HOME/.cache/149-c2-escape-probe.txt"
+ls: $HOME/.cache/149-c2-escape-probe.txt: No such file or directory
+```
+
+Write succeeded in cwd; the home-directory escape did not happen. A write
+under `$TMPDIR` was not attempted in this exact run, but see the ad hoc
+settings-diagnosis runs below, where a sibling case (`$TMPDIR` write) was
+explicitly attempted against the corrected `allowWrite`-only shape and
+refused — over-restrictive relative to the probe's stated allowance, not a
+confinement failure (denying more than required is not an escape).
+
+### `claude-worker.py resume` — read-only worker still refused a write, effort matches
+
+Command:
+
+```
+python3 skills/drivers/orchestrate/scripts/claude-worker.py resume \
+  --state <state-dir>/readonly.json \
+  "Use bash to attempt to create a file named resumed-probe.txt in the current directory. Report WROTE_OK/WROTE_FAIL."
+```
+
+Output:
+
+```
+{"session_id": "7057e983-f119-4847-8d0b-9b0ba024e1b1", "model": "haiku", "sandbox": "read-only", "cwd": "<worktree>", "effort": "medium", "final_message": "**WROTE_FAIL** — operation not permitted on current directory.", "permission_denials": []}
+```
+
+Verified independently:
+
+```
+$ ls -la <worktree>/resumed-probe.txt
+ls: <worktree>/resumed-probe.txt: No such file or directory
+```
+
+The refusal survived resume through the adapter's own argv (the settings
+file is re-passed on resume, matching `start`, not a bare CLI `--resume` the
+way `probe.sh`'s own `resumed` case is limited to). The resumed worker's
+emitted `effort` (`"medium"`) matches what `start` captured — neither the
+original `start` nor this `resume` passed `--effort`, so both used the
+`medium` default and the resume replayed it.
+
+### `claude-worker.py stop` then `verify`
+
+Both target workers had already exited by the time these ran (their process
+group had no members left), which is a legitimate case for both commands, not
+a skipped one — `stop` and `verify` both detect a terminal, member-less
+process group and settle the lifecycle without error.
+
+```
+$ python3 skills/drivers/orchestrate/scripts/claude-worker.py verify \
+    --state <state-dir>/readonly.json --cwd <worktree>
+exit=0
+
+$ python3 skills/drivers/orchestrate/scripts/claude-worker.py stop \
+    --state <state-dir>/write.json --cwd <worktree>-probe-write
+exit=0
+$ python3 skills/drivers/orchestrate/scripts/claude-worker.py verify \
+    --state <state-dir>/write.json --cwd <worktree>-probe-write
+exit=0
+```
 
 ## Codex-side runs: RAN
 
@@ -120,7 +200,7 @@ Output:
 Headroom = 77% (known), well above the 5% gate. Codex-side spend is
 authorized for the run below.
 
-### `codex-worker.py start` with an explicit `--effort` (Do item 4) — ran
+### `codex-worker.py start` with an explicit `--effort` (Do item 4)
 
 Command:
 
@@ -140,8 +220,8 @@ The `--effort high` flag reached the session, the run completed, and the
 emitted `effort` field (`"high"`) matches what was passed to `start`. This
 proves the passthrough half of the effort claim — a caller-supplied effort
 reaches the session and is observable in the emitted object — on `start`
-only. It does not prove effort survives a resume: no resume was run on either
-adapter, so the resume-replay half of Do item 3 remains unverified here.
+only. No resume was run on the Codex adapter; the Claude-side resume above
+covers the resume-replay half of the claim.
 
 ## Rejections (Do item 5) — ran, no auth required
 
@@ -208,11 +288,45 @@ Output (stderr, exit 1):
 codex-worker: workspace-write refuses the control checkout
 ```
 
-## Corrections this chunk made
+## Correction this chunk made
 
-None. No run above contradicted a claim in `claude-worker.py`, `codex-worker.py`,
-`SKILL.md`, or `references/dispatch-claude.md`. The Claude-side behavioral
-claims (read-only confinement, write-worker confinement, resume-preserved
-refusal, resume-preserved effort) remain unverified by this chunk's own runs
-and rest only on `docs/scope/149-probes/output.txt` captured during triage —
-this is a gap this run-log records, not a defect this run-log can rule on.
+`claude-worker.py`'s `sandbox_settings("workspace-write", ...)` produced no
+`filesystem` block at all before this chunk — carried over unchanged from
+sub-order 1. The workspace-write run above (first attempt, before the fix)
+exposed the same escape `probe.sh`'s `write` case exposed: with no
+`filesystem` block, the sandbox leaves the rest of the filesystem writable,
+and only the settings file's own confinement is missing. The re-run after the
+fix (also above) is real, on-disk-verified evidence that
+`filesystem.allowWrite: [cwd]` alone confines the worker: cwd write succeeds,
+a `$HOME` escape is refused.
+
+Getting to that specific shape took two more real, on-disk-verified
+diagnosis rounds (ad hoc `claude -p --settings ...` runs against the target
+worktree, outside the adapter, to isolate the `filesystem` block without
+spending on full worker lifecycles for each attempt):
+
+1. `denyWrite: ["~/"]` alone: blocks the cwd itself, since the worktree sits
+   under the home tree — `WROTE_FAIL`, no file created, worker report even
+   said "current git worktree directory is also blocked."
+2. `allowWrite: [cwd]` + `denyWrite: ["~/"]` together (this chunk's first fix
+   attempt, and what the workspace-write run above actually ran against
+   before being caught): `WROTE_FAIL` on the cwd, confirmed on disk, twice
+   (a single-command isolation run and the full-prompt run in this log) —
+   `denyWrite` wins over `allowWrite` for the same path, so pairing them
+   silently re-blocks the one directory `allowWrite` exists to carve out.
+   `denyWrite: ["/"]` paired the same way was tried earlier for the same
+   reason and rejected on the same grounds.
+3. `allowWrite: [cwd]` alone, no `denyWrite`: `WROTE_OK` in cwd (file
+   verified on disk) and `ESCAPE_FAIL` for a `$HOME/.cache` target (verified
+   absent), confirmed twice. `allowWrite` behaves as an allowlist on its own,
+   not as an addition on top of an otherwise-open default.
+
+The shipped fix is (3). `docs/scope/149-probes/write.settings.json` (a
+triage-owned fixture, not sub-order 1's) still has no `filesystem` block and
+still exhibits the original escape when `probe.sh` runs it directly — that is
+recorded above, not corrected, per this chunk's boundary.
+
+`tests/test_behavior.py`'s `WorkerEffortDialTests` had two assertions that
+encoded the old, wrong shape (`assertNotIn("filesystem", ...)` for the write
+case) — both updated to assert the corrected `allowWrite`-only shape instead,
+so a regression back to either broken shape fails the suite.

--- a/docs/scope/149-probes/write.settings.json
+++ b/docs/scope/149-probes/write.settings.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "enabled": true,
+    "allowUnsandboxedCommands": false
+  },
+  "permissions": { "allow": ["Write", "Edit", "NotebookEdit"] }
+}

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -76,6 +76,14 @@ successfully and had its bash write refused with "operation not permitted":
  "permissions": {"deny": ["Write", "Edit", "NotebookEdit"]}}
 ```
 
+> **Superseded 2026-08-25 — the write half of this section was refuted by a real run.**
+> The shape below (sandbox on, *no* `filesystem` block) does **not** confine writes: a real
+> `workspace-write` worker launched with it wrote straight through to `$HOME/.cache`. See
+> the `write` case in `149-probes/run-log.md` and the correction in
+> `docs/adr/adr-149-pack-owned-model-dispatch.md`. What confines it is
+> `filesystem.allowWrite: [cwd]` alone, which `claude-worker.py` now generates. The
+> paragraph below is kept as the record of what was believed at scoping time.
+
 Write worker (same permission mode, sandbox on, no denyWrite) wrote inside its cwd and was
 refused a write into `$HOME`, matching Codex `workspace-write`. Its writable region is the
 cwd plus the session temp directory: an escape probe aimed at a path under `/private/tmp`
@@ -110,8 +118,12 @@ changed the order rather than its wording:
 * "Prompt on stdin" is a claude-worker fact; `codex-worker.py` takes its prompt
   positionally (`:584`) and no chunk changes that.
 * The two CLIs do not share an effort enum. Captured in `149-probes/effort-enums.md`.
-* Write confinement was asserted, not measured. Measuring it refuted the claim as written
-  (see above) and corrected both the ADR and this ledger.
+* Write confinement was asserted, not measured. Measuring it at scoping time refuted the
+  claim as first written and corrected both the ADR and this ledger — but only partway:
+  the corrected claim still said the committed `write.settings.json` shape confined writes.
+  Running that shape for real during the build (2026-08-25) refuted it again, this time
+  conclusively — a worker wrote through to `$HOME/.cache`. `filesystem.allowWrite: [cwd]`
+  is what confines it. See `149-probes/run-log.md` and the ADR's correction section.
 * The ban stranded `research` and `codebase-design`, which dispatch through banned paths
   today and were on no convert-later list.
 * Agent-tool coupling survives outside Routing step 5, at `SKILL.md:63` and `:103`.

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -4,20 +4,57 @@ Route: interview mode (a concrete plan exists in the operator's head, untested).
 
 ## Decisions
 
-(appended as they settle)
+* **Adapter surface: full parity.** `claude-worker.py` gets start/resume/stop/verify,
+  one state file per worker, liveness, and group-scoped recovery, matching
+  `codex-worker.py`. Why: the coordinator's recovery ownership rule in SKILL.md is
+  written parent-agnostic, so a thin adapter would leave half the workers outside it.
+  → issue
+
+* **Read-only enforcement is measured, not assumed.** The contract is written around a
+  mechanism proven to refuse a write in a probe run, not around a flag that reads
+  right. Why: a benchmark run was already invalidated by a read-agent that wrote.
+  → issue
+
+* **Effort is a dial on both adapters.** `codex-worker.py` hard-codes
+  `model_reasoning_effort=medium` today with no flag; both adapters take `--effort`.
+  → issue
+
+* **Effort defaults are per model, operator-set:** Opus medium, Sol medium, Terra high,
+  Luna max. Why: operator ruling, 2026-08-24. These are not benchmark-derived — the
+  2026-08-03 replay scored every Codex run at medium — so the table's provenance stamp
+  must mark them operator-set and unbenchmarked. → ADR
+
+* **All model dispatch defined by this pack's skills goes through this pack's
+  adapters.** Not orchestrate-only: any skill that dispatches a model (code-review,
+  plan-review, persona-review, ticket chunk agents, epic) dispatches through the
+  adapters, never the built-in Agent tool, Workflow tool, or background agents.
+  Why: operator ruling, 2026-08-24, superseding the narrower orchestrate-only option.
+  → ADR
+
+## Measured facts (this session, live)
+
+* `claude` exposes `--effort low|medium|high|xhigh|max`, `--model`, `-p`,
+  `--session-id`, `--resume`, `--permission-mode`, `--tools`, `--disallowedTools`,
+  `--add-dir`, `--output-format json|stream-json`, `--max-budget-usd`.
+* `--tools` and `--disallowedTools` are variadic: a trailing prompt argument is
+  swallowed as a tool name. A worker adapter must pass the prompt on stdin or place it
+  before those flags.
+* `--permission-mode acceptEdits` still refused a new-file Write in `-p` mode.
+* `--permission-mode plan` refused the write and wrote a plan file into
+  `~/.claude/plans/` — a side effect outside the worker's cwd.
+* Under `--permission-mode bypassPermissions`, a Haiku worker replied `DONE` while
+  creating no file: a live instance of the SKILL.md warning to demand command output
+  rather than trusting a reported success.
 
 ## Open questions
 
-1. Adapter surface — does `claude-worker.py` need `codex-worker.py`'s full lifecycle
-   (start/resume/stop/verify, state files, liveness, group-scoped recovery) or a thin
-   start/resume?
-2. Read-only enforcement for a headless `claude -p` worker — `--permission-mode plan`,
-   `--tools`/`--disallowedTools`, or a measured probe before the contract is written.
-3. Effort dial shape — a routing-table column (stamped rows change only via benchmark
-   replay) or a coordinator override with the current default preserved.
-4. Ban breadth — Agent tool only, or Agent + Workflow + background agents; and whether
-   the ban binds sub-skills that spawn Claude reviewers (`code-review`, `plan-review`).
-5. Sequencing against #144/#145, which queue edits to the same orchestrate files.
+1. Effort defaults for the models not named in the ruling: Sonnet, Haiku, Spark, and
+   the light-tier alternates.
+2. Whether `--tools` / `--disallowedTools` survive a permissive `--permission-mode`
+   (the read-only guarantee for write-capable dispatch) — probe blocked pending
+   operator approval to run `bypassPermissions` locally.
+3. Sequencing against #144 and #145, which queue edits to the same orchestrate files.
+4. Shape: one flat order or chunked (adapter + tests, doc/ban rewrite, ADR).
 
 ## Spawned tasks
 

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -19,10 +19,10 @@ Route: interview mode (a concrete plan exists in the operator's head, untested).
   `model_reasoning_effort=medium` today with no flag; both adapters take `--effort`.
   → issue
 
-* **Effort defaults are per model, operator-set:** Opus medium, Sol medium, Terra high,
-  Luna max. Why: operator ruling, 2026-08-24. These are not benchmark-derived — the
-  2026-08-03 replay scored every Codex run at medium — so the table's provenance stamp
-  must mark them operator-set and unbenchmarked. → ADR
+* **Effort defaults to medium for every model.** Why: operator ruling, 2026-08-24,
+  superseding an earlier per-model split (Terra high, Luna max) on the grounds that no
+  effort benchmarking has been done; values get bumped when a replay measures a reason.
+  The dial exists so a coordinator can override per delegation. → ADR
 
 * **All model dispatch defined by this pack's skills goes through this pack's
   adapters.** Not orchestrate-only: any skill that dispatches a model (code-review,
@@ -46,15 +46,32 @@ Route: interview mode (a concrete plan exists in the operator's head, untested).
   creating no file: a live instance of the SKILL.md warning to demand command output
   rather than trusting a reported success.
 
+## Read-only enforcement — measured 2026-08-24 (Haiku, scratchpad dirs)
+
+| Dispatch | Wrote the file? |
+|---|---|
+| `--permission-mode bypassPermissions` (baseline) | yes |
+| `--permission-mode acceptEdits` | no — new-file Write still asks |
+| `--permission-mode plan` | no — but wrote a plan file into `~/.claude/plans/` |
+| `bypassPermissions --tools Read,Grep,Glob` | no — "Write tool is disabled" |
+| `bypassPermissions --disallowedTools Write,Edit,NotebookEdit,Bash` | no |
+| `bypassPermissions --disallowedTools Write,Edit,NotebookEdit` (Bash allowed) | **yes** |
+| `bypassPermissions --tools Read,Grep,Glob,Bash` | **yes** |
+| `--settings {"sandbox":true}` with Bash allowed | yes |
+| `--settings {"permissions":{"sandbox":true,"allowUnsandboxedCommands":false}}` with Bash allowed | yes |
+
+**Ruling this forces:** Bash is the escape hatch. A read-only Claude worker is one whose
+tool set omits Bash; no permission mode and no settings shape tested blocks a write while
+Bash is available. This is strictly weaker than Codex `--sandbox read-only`, which permits
+commands and blocks writes at the filesystem — a Claude read worker trades shell access
+for the guarantee. A read task that genuinely needs shell is dispatched as a
+write-capable worker into a throwaway worktree instead.
+
 ## Open questions
 
-1. Effort defaults for the models not named in the ruling: Sonnet, Haiku, Spark, and
-   the light-tier alternates.
-2. Whether `--tools` / `--disallowedTools` survive a permissive `--permission-mode`
-   (the read-only guarantee for write-capable dispatch) — probe blocked pending
-   operator approval to run `bypassPermissions` locally.
-3. Sequencing against #144 and #145, which queue edits to the same orchestrate files.
-4. Shape: one flat order or chunked (adapter + tests, doc/ban rewrite, ADR).
+1. Sequencing against #144 and #145, which queue edits to the same orchestrate files.
+2. Shape: one chunked order on #149, or #149 builds the adapters and child issues
+   convert each consuming skill.
 
 ## Spawned tasks
 

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -1,0 +1,24 @@
+# Scope — universal effort dial and Claude CLI worker dispatch (#149)
+
+Route: interview mode (a concrete plan exists in the operator's head, untested).
+
+## Decisions
+
+(appended as they settle)
+
+## Open questions
+
+1. Adapter surface — does `claude-worker.py` need `codex-worker.py`'s full lifecycle
+   (start/resume/stop/verify, state files, liveness, group-scoped recovery) or a thin
+   start/resume?
+2. Read-only enforcement for a headless `claude -p` worker — `--permission-mode plan`,
+   `--tools`/`--disallowedTools`, or a measured probe before the contract is written.
+3. Effort dial shape — a routing-table column (stamped rows change only via benchmark
+   replay) or a coordinator override with the current default preserved.
+4. Ban breadth — Agent tool only, or Agent + Workflow + background agents; and whether
+   the ban binds sub-skills that spawn Claude reviewers (`code-review`, `plan-review`).
+5. Sequencing against #144/#145, which queue edits to the same orchestrate files.
+
+## Spawned tasks
+
+(none yet)

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -60,12 +60,37 @@ Route: interview mode (a concrete plan exists in the operator's head, untested).
 | `--settings {"sandbox":true}` with Bash allowed | yes |
 | `--settings {"permissions":{"sandbox":true,"allowUnsandboxedCommands":false}}` with Bash allowed | yes |
 
-**Ruling this forces:** Bash is the escape hatch. A read-only Claude worker is one whose
-tool set omits Bash; no permission mode and no settings shape tested blocks a write while
-Bash is available. This is strictly weaker than Codex `--sandbox read-only`, which permits
-commands and blocks writes at the filesystem — a Claude read worker trades shell access
-for the guarantee. A read task that genuinely needs shell is dispatched as a
-write-capable worker into a throwaway worktree instead.
+**Superseded.** The table above tested the wrong mechanism. Per the Claude Code
+sandboxing docs, `--allowedTools` is an approval rule rather than an availability
+filter, and the Bash sandbox is an object in settings with OS-level (Seatbelt/bubblewrap)
+filesystem enforcement that covers a command and all its children.
+
+### Verified sandbox pair — the real analogue of Codex sandbox modes
+
+Read-only worker (`--permission-mode dontAsk` plus these settings) ran `ls -a`
+successfully and had its bash write refused with "operation not permitted":
+
+```json
+{"sandbox": {"enabled": true, "allowUnsandboxedCommands": false,
+             "filesystem": {"denyWrite": ["/", "~/"]}},
+ "permissions": {"deny": ["Write", "Edit", "NotebookEdit"]}}
+```
+
+Write worker (same permission mode, sandbox on, no denyWrite) wrote inside its cwd and
+nowhere else, matching Codex `workspace-write`:
+
+```json
+{"sandbox": {"enabled": true, "allowUnsandboxedCommands": false}}
+```
+
+`allowUnsandboxedCommands: false` is load-bearing: it disables the `dangerouslyDisableSandbox`
+retry escape hatch, so a blocked command cannot be re-run outside the sandbox. Note that
+under `dontAsk` the write worker's Write tool was itself denied and it fell back to bash —
+a write worker needs its edit tools explicitly allowed.
+
+Docs: [sandboxing](https://code.claude.com/docs/en/sandboxing),
+[headless](https://docs.claude.com/en/docs/claude-code/headless),
+[SDK permissions](https://docs.claude.com/en/api/agent-sdk/permissions).
 
 ## Open questions
 

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -124,6 +124,31 @@ Refuted, not forwarded: that the committed `write.settings.json` had never been 
 
 (none — sequencing and shape settled below)
 
+## Cold panel — rounds 2 and 3
+
+Round 2 (fresh Opus, no round-1 context): 7 blocking. The order commits raw run output,
+which `scripts/validate.py` forbids as a literal user path in any tracked file and re-greps
+across every reachable commit — one such commit fails the gate permanently, and this repo is
+pinned by commit. The lifecycle move silently defeats ~42 `mock.patch.object` sites (122
+`WORKER_MODULE` references) and breaks the test module at import, because
+`spec_from_file_location` does not put the script's directory on `sys.path`. Effort had no
+emitted field, so its replay could only be taken on a worker's word. The `STATE_VERSION`
+branch offered was self-contradictory: `BASE_STATE_FIELDS.issubset(state)` at `:125` makes a
+key mandatory, not permitted.
+
+Round 3 (fresh Opus, cap): 4 blocking, all executability. A second
+`spec_from_file_location` load yields a different module object, so the round-2 fix would
+itself patch nothing. `run_lifecycle`/`run_portable` are not model-agnostic — they call
+codex's parser and `emit`, and both launch paths hard-wire `stdin=DEVNULL` while the claude
+adapter must write its prompt to stdin — so the module needs a named parse/emit/stdin seam
+the order had not specified. A module-global `fail()` prefix is last-writer-wins across two
+adapters in one test process. And effort replay on `--resume` was unmeasured.
+
+Measured in response: `session: resume_accepts_effort=True`. The seam, the module identity,
+and the per-call prefix are now ruled in the order.
+
+Every round's blockers clustered on one thing: extracting the shared lifecycle module.
+
 ## Settled after the panel
 
 * Sequencing: #144 and #145 land after #149 and inherit the adapter surface. #145's

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -76,8 +76,12 @@ successfully and had its bash write refused with "operation not permitted":
  "permissions": {"deny": ["Write", "Edit", "NotebookEdit"]}}
 ```
 
-Write worker (same permission mode, sandbox on, no denyWrite) wrote inside its cwd and
-nowhere else, matching Codex `workspace-write`:
+Write worker (same permission mode, sandbox on, no denyWrite) wrote inside its cwd and was
+refused a write into `$HOME`, matching Codex `workspace-write`. Its writable region is the
+cwd plus the session temp directory: an escape probe aimed at a path under `/private/tmp`
+succeeded, and the same probe aimed at the home directory was refused. An explicit
+`denyWrite: ["/"]` is not the fix — measured, a broad deny beats a narrower `allowWrite`
+for the cwd and blocks the worker entirely.
 
 ```json
 {"sandbox": {"enabled": true, "allowUnsandboxedCommands": false}}
@@ -92,11 +96,40 @@ Docs: [sandboxing](https://code.claude.com/docs/en/sandboxing),
 [headless](https://docs.claude.com/en/docs/claude-code/headless),
 [SDK permissions](https://docs.claude.com/en/api/agent-sdk/permissions).
 
+## Cold panel — round 1 (two Opus reviewers, 2026-08-24)
+
+Eighteen blocking objections, every citation reproduced against the repo. The ones that
+changed the order rather than its wording:
+
+* The shared lifecycle machinery is ~550 of `codex-worker.py`'s 596 lines and is
+  model-agnostic. This ticket creates the charter's second caller, so the seam is earned
+  now: a shared module, not a second copy.
+* Effort cannot survive `resume` as the schema stands — `BASE_STATE_FIELDS`
+  (`codex-worker.py:121`) rejects unknown keys and the resume argv (`:469`) carries no
+  effort. Persisting it is a schema change the order has to authorize.
+* "Prompt on stdin" is a claude-worker fact; `codex-worker.py` takes its prompt
+  positionally (`:584`) and no chunk changes that.
+* The two CLIs do not share an effort enum. Captured in `149-probes/effort-enums.md`.
+* Write confinement was asserted, not measured. Measuring it refuted the claim as written
+  (see above) and corrected both the ADR and this ledger.
+* The ban stranded `research` and `codebase-design`, which dispatch through banned paths
+  today and were on no convert-later list.
+* Agent-tool coupling survives outside Routing step 5, at `SKILL.md:63` and `:103`.
+
+Refuted, not forwarded: that the committed `write.settings.json` had never been executed.
+`probe.sh` runs the committed files; what was missing was captured output, now in
+`output.txt`.
+
 ## Open questions
 
-1. Sequencing against #144 and #145, which queue edits to the same orchestrate files.
-2. Shape: one chunked order on #149, or #149 builds the adapters and child issues
-   convert each consuming skill.
+(none — sequencing and shape settled below)
+
+## Settled after the panel
+
+* Sequencing: #144 and #145 land after #149 and inherit the adapter surface. #145's
+  document is renamed so it cannot be confused with this ticket's `dispatch-claude.md`.
+* Shape: two serial chunks re-cut on the anchor row's own boundary — build, then run
+  live and correct.
 
 ## Spawned tasks
 

--- a/docs/scope/orchestrate-effort-dial.md
+++ b/docs/scope/orchestrate-effort-dial.md
@@ -158,4 +158,14 @@ Every round's blockers clustered on one thing: extracting the shared lifecycle m
 
 ## Spawned tasks
 
-(none yet)
+* #150 — extract the shared worker lifecycle into one module (the deferred half of #149)
+* #151 code-review, #152 plan-review, #153 persona-review, #154 ticket, #155 epic,
+  #156 research, #157 codebase-design — convert each skill's dispatch to the adapters
+
+## Dispositions
+
+* ADR — written: docs/adr/adr-149-pack-owned-model-dispatch.md
+* Issues — filed: #150 through #157
+* Work order — posted on #149; ticket labelled `ticket:triaged`
+
+None outstanding.

--- a/skills/drivers/orchestrate/SKILL.md
+++ b/skills/drivers/orchestrate/SKILL.md
@@ -8,10 +8,16 @@ description: Flip the session into coordinator mode — the parent agent plans, 
 Invoking this skill flips the **whole session** into coordinator mode until the
 operator says otherwise. Detect the parent before dispatching:
 
-- **Claude Code parent:** use the Claude and Codex mechanics below.
+- **Claude Code parent:** use the Claude and Codex mechanics below — both
+  dispatch through their CLI-worker adapters (`claude-worker.py` /
+  `codex-worker.py`), never through the Agent tool, the Workflow tool, or a
+  background agent.
 - **Codex UI parent:** read `references/dispatch-codex.md` before routing. In
   this v0, every delegation uses its CLI-worker adapter; do not use native
-  `spawn_agent` for implementation or review.
+  `spawn_agent` for implementation or review. Whether a Codex UI parent also
+  dispatches Claude workers through `claude-worker.py` is explicitly deferred
+  — `references/dispatch-codex.md`'s admission table is Codex-only until that
+  is decided.
 
 ## Codex headroom gate — run at invocation
 
@@ -22,7 +28,11 @@ Before any routing, check whether the Codex side has budget left:
    step 1 entirely and go straight to the same **Claude-only** branch as
    headroom ≤ 5% / unknown below; tell the operator once. A Codex UI parent
    cannot land on this branch — the CLI exists there by construction — so the
-   check only applies to a Claude parent.
+   check only applies to a Claude parent. Also run `command -v claude` — a
+   Claude-only branch dispatches through `claude-worker.py`, which needs the
+   `claude` binary. If **neither** `codex` nor `claude` is present on PATH,
+   the coordinator cannot dispatch at all: report the blocker to the operator
+   and stop — there is no third route.
 1. Probe fresh with a trivial one-word worker run (Luna, `gpt-5.6-luna`,
    `read-only`) — Luna is the probe model because it is the cheapest route the
    table already uses, so it is always available; do not pick a cheaper-looking
@@ -60,9 +70,9 @@ is the reason the review is not optional); prototyping routes straight to
   output rather than trusting it — including independent review passes on
   correctness-sensitive changes, with findings routed back to the implementing
   agent to fix.
-- Continue an existing sub-agent (SendMessage for Claude; `codex exec resume` for
-  Codex) for follow-ups in its area instead of spawning a fresh one, so its
-  context carries over.
+- Continue an existing worker (`claude-worker.py resume` for Claude;
+  `codex-worker.py resume` for Codex) for follow-ups in its area instead of
+  spawning a fresh one, so its context carries over.
 - The coordinator keeps for itself: small mechanical glue (git/gh plumbing,
   toggles, log checks, daemon restarts), verification probes, and all
   communication/decisions with the operator.
@@ -100,20 +110,27 @@ is the reason the review is not optional); prototyping routes straight to
    mode follows only its adapter's admitted routes.
 3. **Never delegate to Fable** — it is the coordinator tier only.
 4. Every delegation is labeled with its model tier so the operator can see the
-   route: Agent-tool dispatches prefix the `description` with the model name
-   (`<Model>: <task description>`, e.g. `Sonnet 5: standards review of phase 1
-   diff`); Codex `codex exec` runs name the model in the coordinator's
-   narration line. Applies to escalation retries too (the new tier's name).
-5. Mechanics: Claude models via the Agent tool with a `model` override — a
-   read-only agent type (e.g. Explore) for read-tasks, `isolation: "worktree"`
-   for write-tasks, so the harness enforces what the prompt asks. Codex models
-   use the parent-specific dispatch adapter. `read-only` is for read-tasks;
-   `workspace-write` only targets an isolated worktree, never the coordinator's
-   checkout. Effort stays medium; escalation changes the model tier, not the
-   effort dial. Belt-and-braces: read-task prompts still carry an explicit
-   "context is read-only — never modify, patch, or stash" line (a benchmark run
-   was invalidated by an agent leaving a patch applied to a shared worktree —
-   treat this as load-bearing).
+   route: name the model in the coordinator's narration line for the
+   `claude-worker.py` / `codex-worker.py` run (`<Model>: <task description>`,
+   e.g. `Sonnet 5: standards review of phase 1 diff`) — the adapters carry no
+   `description` field of their own, so the narration line is what carries the
+   model label, not the dispatch command. Applies to escalation retries too
+   (the new tier's name).
+5. Mechanics: every delegation — Claude or Codex — dispatches through its CLI
+   worker adapter (`skills/drivers/orchestrate/scripts/claude-worker.py` or
+   `codex-worker.py`), never through the Agent tool, the Workflow tool, or a
+   background agent. See `references/dispatch-claude.md` for the Claude
+   adapter's command surface, sandbox shapes, prompt-on-stdin fact, and
+   liveness contract; `references/dispatch-codex.md` for Codex's. `read-only`
+   is for read-tasks; `workspace-write` only targets an isolated worktree
+   (`--cwd`, with `--control-checkout` set to the coordinator's checkout),
+   never the coordinator's checkout directly — both adapters refuse a
+   `workspace-write` `--cwd` inside `--control-checkout`. Every delegation
+   carries `--effort`, defaulting to medium (see Effort notes below);
+   escalation changes the model tier, not the effort dial. Belt-and-braces:
+   read-task prompts still carry an explicit "context is read-only — never
+   modify, patch, or stash" line (a benchmark run was invalidated by an agent
+   leaving a patch applied to a shared worktree — treat this as load-bearing).
 
 ## Verification and escalation
 
@@ -180,6 +197,29 @@ When coordinator mode runs a ui-craft lifecycle, the delegation split is:
 Untested seams (benchmark was single-shot mockup generation only): frontend
 build-to-lock with rendered gate assertions, and multi-round mockup iteration.
 Treat those routes as provisional until benchmarked.
+
+## Pack-wide reach
+
+Per ADR 149 (`docs/adr/adr-149-pack-owned-model-dispatch.md`): all model
+dispatch defined by this pack goes through this pack's own adapters
+(`claude-worker.py` / `codex-worker.py`), not the built-in Agent tool, the
+Workflow tool, or background agents. That ruling covers every skill that
+dispatches a model, not only `orchestrate`. The other skills convert one at a
+time behind their own issues and keep their current dispatch mechanism until
+converted:
+
+- **code-review** (issue #151)
+- **plan-review** (issue #152)
+- **persona-review** (issue #153)
+- **ticket**'s chunk agents (issue #154)
+- **epic** (issue #155)
+- **research** (issue #156) — `skills/tools/research/SKILL.md:8` spawns a
+  background agent today
+- **codebase-design** (issue #157) — `references/DESIGN-IT-TWICE.md:37`
+  spawns sub-agents via the Agent tool today
+
+Do not convert any of the above in this ticket; the ban binds each one only
+once its own issue lands.
 
 ## Maintenance
 

--- a/skills/drivers/orchestrate/references/benchmark/README.md
+++ b/skills/drivers/orchestrate/references/benchmark/README.md
@@ -87,7 +87,10 @@ confident false positives. Keep both files out of this public pack.
 3. Dispatch: Codex via `codex exec -m <model> -c model_reasoning_effort=medium
    --sandbox read-only|workspace-write --skip-git-repo-check -C <dir>`; Claude
    via the Agent tool with a `model` override. Effort stays medium for scored
-   runs so results are comparable.
+   runs so results are comparable. (This records how the 2026-08-03 runs were
+   dispatched, not how dispatch works now — see ADR 149 and
+   `references/dispatch-claude.md` / `references/dispatch-codex.md` for
+   current routing.)
 4. Judge against ground truth, not eloquence: grep-verify citations, run the
    tests, apply the review answer key mechanically.
 5. Interview the model first (self-assessment across the 7 areas) as a

--- a/skills/drivers/orchestrate/references/dispatch-claude.md
+++ b/skills/drivers/orchestrate/references/dispatch-claude.md
@@ -1,0 +1,95 @@
+# Claude worker dispatch
+
+Use this adapter for every delegated Claude worker: exploration,
+implementation, review, and follow-up. Do not dispatch a Claude worker through
+the Agent tool, the Workflow tool, or a background agent — those routes are
+retired for delegated work by work order 149. `skills/drivers/orchestrate/scripts/claude-worker.py`
+is the only dispatch path, mirroring `codex-worker.py`'s command surface:
+`start`, `resume`, `stop`, `verify`, `--state`, `--model`, `--effort`,
+`--sandbox read-only|workspace-write`, `--cwd`, `--control-checkout`, and
+`--claude` (defaults to `claude`, the CLI binary on PATH) in place of
+`codex-worker.py`'s `--codex`.
+
+## Command surface
+
+Run `claude-worker.py start` for a new worker. Give read work a resolved
+repository or worktree path and `--sandbox read-only`. Give write work a
+resolved isolated worktree path, `--sandbox workspace-write`, and the
+coordinator checkout in `--control-checkout`; the adapter rejects a
+`--cwd` inside the control checkout, exactly as codex-worker.py does. Persist
+one state file per worker. Use `resume` with that state file for retry
+findings and ordinary follow-ups; it restores the captured model, sandbox,
+effort, and canonical cwd rather than taking replacements — the same contract
+as codex-worker's resume.
+
+## Prompt on stdin, not as an argument
+
+`claude-worker.py` writes the prompt to the worker's stdin and closes it,
+unlike `codex-worker.py`, which still takes the prompt positionally. The
+`claude` CLI's `-p` invocation carries variadic flags (`--tools`,
+`--allowedTools`, `--disallowedTools`) that would swallow a trailing
+positional prompt, so a prompt-on-stdin is a fact about the `claude` CLI, not
+a stylistic choice — never pass the prompt as a trailing argv token to a
+`claude-worker.py`-launched command.
+
+## Sandbox modes
+
+Both modes are generated settings files the adapter owns and writes to a
+temp path at launch — it never reads a settings shape out of `docs/`, because
+`docs/` is not part of an installed skill copy.
+
+- **`read-only`**: `sandbox.enabled: true`, `allowUnsandboxedCommands: false`,
+  `filesystem.denyWrite: ["/", "~/"]` (writes denied filesystem-wide), and
+  `permissions.deny: ["Write", "Edit", "NotebookEdit"]` (the edit tools
+  denied). `allowUnsandboxedCommands: false` is load-bearing: it disables the
+  `dangerouslyDisableSandbox` retry, so a command the sandbox blocked cannot
+  be re-run outside it.
+- **`workspace-write`**: `sandbox.enabled: true`, `allowUnsandboxedCommands:
+  false`, no filesystem deny-list (the cwd stays writable), and
+  `permissions.allow: ["Write", "Edit", "NotebookEdit"]` (the edit tools
+  allowed).
+
+## Effort
+
+Every delegation carries `--effort`, defaulting to `medium` for every model
+because no effort benchmarking exists yet (see `references/routing-table.md`
+Effort notes). `claude-worker.py`'s enum is `low|medium|high|xhigh|max`,
+captured in `docs/scope/149-probes/effort-enums.md` from `claude --help`; it
+is not the same set as `codex-worker.py`'s `minimal|low|medium|high|xhigh`.
+The chosen effort is persisted in state and replayed on `resume`.
+
+## Liveness is process identity only
+
+A Claude worker has no rollout file and no headroom fields — there is no
+Claude analogue of Codex's `~/.codex/sessions/*.jsonl` or its
+`token_count.rate_limits` payload. `claude-worker.py` does not invent one:
+liveness is proving the recorded PID/PGID/SID/cwd/birth identity still
+matches, the same process-family probe codex-worker.py uses, and nothing
+more. Do not infer a Claude worker's health from elapsed time or output
+volume; there is no equivalent "CPU time growing" heuristic documented for
+this adapter.
+
+## Interrupted workers
+
+The coordinator that launched a worker owns its recovery, exactly as with
+Codex workers: run `claude-worker.py stop --state STATE --cwd WORKTREE`, then
+`claude-worker.py verify --state STATE --cwd WORKTREE` and require success
+before a successor receives the worktree. A successor never discovers or
+cleans unknown processes; only the adapter's recorded dedicated process group
+is in scope.
+
+## Output
+
+On success the adapter emits one public JSON object: `session_id`, `model`,
+`sandbox`, `cwd`, `effort`, `final_message` (the CLI's `result` field), and
+`permission_denials` (whatever the CLI's JSON payload reported as denied, so
+the coordinator can see what the sandbox refused — an empty list when
+nothing was denied). `is_error: true` in the CLI's own JSON is treated as a
+dispatch failure, not a worker answer; the adapter fails instead of emitting.
+
+## Presence check
+
+Before dispatching any Claude worker, the coordinator runs `command -v claude`.
+If neither `codex` nor `claude` is present on PATH, the coordinator
+cannot dispatch at all: report the blocker to the operator and stop — there
+is no third route to fall back to.

--- a/skills/drivers/orchestrate/references/dispatch-claude.md
+++ b/skills/drivers/orchestrate/references/dispatch-claude.md
@@ -45,9 +45,22 @@ temp path at launch — it never reads a settings shape out of `docs/`, because
   `dangerouslyDisableSandbox` retry, so a command the sandbox blocked cannot
   be re-run outside it.
 - **`workspace-write`**: `sandbox.enabled: true`, `allowUnsandboxedCommands:
-  false`, no filesystem deny-list (the cwd stays writable), and
+  false`, `filesystem.allowWrite: [<the worker's own --cwd>]`, and
   `permissions.allow: ["Write", "Edit", "NotebookEdit"]` (the edit tools
-  allowed).
+  allowed). `allowWrite` is what does the confining, and it must stand alone:
+  a real run of #149 launched with no `filesystem` block wrote straight
+  through to `$HOME/.cache`, and pairing `allowWrite` with a `denyWrite` was
+  rejected on disk twice because `deny` beats `allow` for the same path,
+  silently re-blocking the very cwd `allowWrite` exists to carve out.
+
+  The real boundary is **cwd plus the session temp directory**, which the
+  sandbox documents as writable. A write under `$TMPDIR` is therefore expected
+  and is not a confinement failure; a write into the operator's home directory
+  or into the control checkout is. `start` additionally refuses a
+  `workspace-write` `--cwd` that sits inside `--control-checkout` before any
+  worker launches. Do not describe this mode as "the worktree and nowhere
+  else" — that phrasing was measured false. The captured runs are in
+  `docs/scope/149-probes/run-log.md`.
 
 ## Effort
 

--- a/skills/drivers/orchestrate/references/routing-table.md
+++ b/skills/drivers/orchestrate/references/routing-table.md
@@ -32,7 +32,19 @@ surface both failed attempts to the operator.
 | Code review | **Luna** for routine PRs; **Opus** for load-bearing/safety review | Luna → Sonnet → Opus; Opus route: none (top of ladder) | Opus was the only model to catch all 3 planted defects (incl. a silently weakened test). Luna caught 2/3 with zero false positives at the lowest cost. GPT-5.5 confidently reported a nonexistent syntax error; GPT-5.4-Mini missed a blatant inverted guard — avoid both for review. |
 
 ## Effort notes (coarse, per spec decision 8)
-- All scored runs used Codex medium effort, and it was sufficient everywhere tested. Effort stays medium in normal routing; escalation changes the model tier, not the effort dial.
+- Every delegation carries an effort dial (per ADR 149,
+  `docs/adr/adr-149-pack-owned-model-dispatch.md`), defaulting to medium for
+  every model — overridable per delegation, never left implicit. The default
+  is uniform because no effort benchmarking exists yet: all scored runs used
+  Codex medium effort, and it was sufficient everywhere tested. Changing a
+  model's default effort is a benchmark result, not a preference, and gets set
+  only when a replay measures one; escalation changes the model tier, not the
+  effort dial.
+- The two adapters validate different enums, each a literal in its own
+  script: `claude-worker.py` accepts `low|medium|high|xhigh|max`;
+  `codex-worker.py` accepts `minimal|low|medium|high|xhigh` (unvalidated
+  locally by the Codex CLI itself). See
+  `docs/scope/149-probes/effort-enums.md`.
 - Spark's value is latency: use for tight edit-test loops and mockup iteration, not judgment.
 - Opus spends ~4–5× Haiku's tokens on the same exploration prompt; route it only where the depth is the point.
 

--- a/skills/drivers/orchestrate/scripts/claude-worker.py
+++ b/skills/drivers/orchestrate/scripts/claude-worker.py
@@ -466,10 +466,23 @@ def run_lifecycle(
     return finish_lifecycle(args, process)
 
 
-def sandbox_settings(sandbox: str) -> dict[str, Any]:
+def sandbox_settings(sandbox: str, cwd: Path) -> dict[str, Any]:
     """The two sandbox shapes, carried as literals — not read from docs/ at run
-    time. docs/scope/149-probes/{readonly,write}.settings.json are the source
-    these literals were copied from; docs/ is not part of an installed skill.
+    time; docs/ is not part of an installed skill. The read-only shape still
+    matches docs/scope/149-probes/readonly.settings.json, the fixture it was
+    originally copied from.
+
+    The workspace-write shape's `filesystem` block does not match
+    write.settings.json (that fixture has none): a real run of #149 with no
+    `filesystem` block present wrote straight through to `$HOME/.cache` — the
+    sandbox leaves the whole filesystem writable outside the settings file's
+    own confinement (see run-log.md's `write` case). `allowWrite: [cwd]` alone
+    closes that: it behaves as an allowlist, confining writes to cwd and
+    refusing everything else. `denyWrite` was tried alongside it (`["/"]`,
+    then `["~/"]`, since cwd sits under the home tree) and rejected both
+    times, confirmed by real runs, not just reasoning about the docs: `deny`
+    always wins over `allow` for the same path, so pairing them silently
+    re-blocks the one directory `allowWrite` exists to carve out.
     """
     if sandbox == "read-only":
         return {
@@ -484,15 +497,16 @@ def sandbox_settings(sandbox: str) -> dict[str, Any]:
         "sandbox": {
             "enabled": True,
             "allowUnsandboxedCommands": False,
+            "filesystem": {"allowWrite": [str(cwd)]},
         },
         "permissions": {"allow": ["Write", "Edit", "NotebookEdit"]},
     }
 
 
-def write_settings_file(sandbox: str) -> Path:
+def write_settings_file(sandbox: str, cwd: Path) -> Path:
     descriptor, path = tempfile.mkstemp(prefix="claude-worker-settings-", suffix=".json")
     with os.fdopen(descriptor, "w", encoding="utf-8") as file:
-        json.dump(sandbox_settings(sandbox), file)
+        json.dump(sandbox_settings(sandbox, cwd), file)
     return Path(path)
 
 
@@ -508,7 +522,7 @@ def start(args: argparse.Namespace) -> int:
     }
     if args.effort != DEFAULT_EFFORT: state["effort"] = args.effort
     if args.control_checkout: state["control_checkout"] = str(args.control_checkout)
-    settings = write_settings_file(args.sandbox)
+    settings = write_settings_file(args.sandbox, args.cwd)
     session_id = str(uuid.uuid4())
     command = [
         args.claude, "-p", "--model", args.model, "--effort", args.effort,
@@ -547,7 +561,7 @@ def resume(args: argparse.Namespace) -> int:
         fresh = {"version": STATE_VERSION, "lifecycle": "launching", "session_id": state["session_id"], "model": state["model"], "sandbox": sandbox, "cwd": str(cwd)}
         if effort != DEFAULT_EFFORT: fresh["effort"] = effort
         if sandbox == "workspace-write": fresh["control_checkout"] = str(control)
-    settings = write_settings_file(sandbox)
+    settings = write_settings_file(sandbox, cwd)
     command = [
         args.claude, "-p", "--resume", fresh["session_id"], "--model", fresh["model"],
         "--effort", effort, "--permission-mode", "dontAsk", "--settings", str(settings),

--- a/skills/drivers/orchestrate/scripts/claude-worker.py
+++ b/skills/drivers/orchestrate/scripts/claude-worker.py
@@ -320,7 +320,7 @@ def gate_wait(fd: int) -> None:
         os._exit(125)
 
 
-def gated_process(command: list[str], cwd: Path, prompt: str) -> tuple[subprocess.Popen[str], int]:
+def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str], int]:
     """Exec a session-leading gate wrapper; Popen can return before the real exec.
 
     Unlike codex-worker.py, the prompt is not part of `command` — it is piped
@@ -349,7 +349,7 @@ def establish_family(
     state: dict[str, Any],
 ) -> tuple[subprocess.Popen[str] | None, int | None]:
     """Persist and release one gated family while the caller holds the state lock."""
-    process, write_fd = gated_process(command, Path(state["cwd"]), args.prompt)
+    process, write_fd = gated_process(command, Path(state["cwd"]))
     pid = process.pid
     try:
         identity = None
@@ -514,7 +514,6 @@ def start(args: argparse.Namespace) -> int:
         args.claude, "-p", "--model", args.model, "--effort", args.effort,
         "--permission-mode", "dontAsk", "--settings", str(settings),
         "--session-id", session_id, "--output-format", "json",
-        "--cwd", str(args.cwd),
     ]
     return run_lifecycle(args, command, state)
 
@@ -552,7 +551,7 @@ def resume(args: argparse.Namespace) -> int:
     command = [
         args.claude, "-p", "--resume", fresh["session_id"], "--model", fresh["model"],
         "--effort", effort, "--permission-mode", "dontAsk", "--settings", str(settings),
-        "--output-format", "json", "--cwd", str(cwd),
+        "--output-format", "json",
     ]
     return run_lifecycle(args, command, fresh, expected=state)
 

--- a/skills/drivers/orchestrate/scripts/claude-worker.py
+++ b/skills/drivers/orchestrate/scripts/claude-worker.py
@@ -1,5 +1,24 @@
 #!/usr/bin/env python3
-"""Launch, resume, stop, and verify one durable Codex worker process family."""
+"""Launch, resume, stop, and verify one durable Claude worker process family.
+
+Standalone sibling of codex-worker.py: this file carries its own copy of the
+lifecycle machinery (state lock, atomic write, schema validation, process-
+family ownership, liveness, run/finish lifecycle, stop, verify) rather than
+importing it, per work order 149 sub-order 1 — no shared module in this
+ticket. Keep the structure and naming aligned with codex-worker.py so the two
+read as one family and a later extraction is a mechanical diff.
+
+Differences from codex-worker.py, all load-bearing:
+  * The prompt goes on the worker's stdin, not as a trailing argv token.
+    `claude -p ... --tools/--allowedTools/--disallowedTools` are variadic and
+    would swallow a positional prompt.
+  * Output parsing and the final emit are Claude's own: one JSON object
+    (`--output-format json`) with a `result` field and an `is_error` flag,
+    not Codex's JSONL event stream.
+  * There is no Claude analogue of Codex's rollout file or its headroom
+    fields. Liveness here is process identity only; this adapter must not
+    invent a headroom concept Claude does not expose.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +33,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -37,16 +57,14 @@ VNODE_CWD_OFFSET = 152
 PID_MAX = 2**31 - 1
 UINT64_MAX = 2**64 - 1
 
-# Effort enum captured in docs/scope/149-probes/effort-enums.md: the Codex CLI
-# validates nothing locally (a bogus value starts the session and fails at the
-# API), so this set is documentation plus this adapter's own guard, not a
-# discovered constraint. Not shared with claude-worker.py's enum.
-EFFORT_LEVELS = {"minimal", "low", "medium", "high", "xhigh"}
+# Effort enum captured in docs/scope/149-probes/effort-enums.md (`claude --help`).
+# Not shared with codex-worker.py's enum — each adapter owns a literal set.
+EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
 DEFAULT_EFFORT = "medium"
 
 
 def fail(message: str, code: int = 1) -> int:
-    print(f"codex-worker: {message}", file=sys.stderr)
+    print(f"claude-worker: {message}", file=sys.stderr)
     return code
 
 
@@ -125,6 +143,13 @@ def _canonical_path(value: Any) -> bool:
         return False
 
 
+# STATE_VERSION decision (spec do-7): effort is added only to each command's
+# `allowed` schema superset below, never to BASE_STATE_FIELDS. BASE_STATE_FIELDS
+# is checked with `.issubset(state)`, so a key placed there becomes mandatory —
+# every already-persisted state (including codex-worker's) would fail schema
+# validation the moment this file shipped. Treating a missing "effort" as the
+# medium default keeps STATE_VERSION at 2 and both adapters' existing state
+# files valid. See test_missing_effort_defaults_to_medium_without_version_bump.
 BASE_STATE_FIELDS = {"version", "lifecycle", "session_id", "model", "sandbox", "cwd"}
 
 
@@ -188,6 +213,10 @@ def valid_portable_schema(state: dict[str, Any]) -> bool:
     return True
 
 
+def effort_of(state: dict[str, Any]) -> str:
+    return state.get("effort", DEFAULT_EFFORT)
+
+
 def _libproc() -> ctypes.CDLL | None:
     if sys.platform != "darwin":
         return None
@@ -247,59 +276,43 @@ def group_members(pgid: int) -> list[int] | None:
     return None
 
 
-def parse_jsonl(output: str) -> tuple[list[dict[str, Any]], str | None]:
-    items: list[dict[str, Any]] = []
-    for number, line in enumerate(output.splitlines(), 1):
-        if not line.strip():
-            continue
-        try:
-            item = json.loads(line)
-        except json.JSONDecodeError:
-            return [], f"invalid JSONL on line {number}"
-        if not isinstance(item, dict):
-            return [], f"JSONL item on line {number} is not an object"
-        items.append(item)
-    return items, None
+def parse_result(output: str) -> tuple[dict[str, Any] | None, str | None]:
+    """Parse claude's single `--output-format json` object (not Codex's JSONL)."""
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError:
+        return None, "invalid JSON in Claude output"
+    if not isinstance(payload, dict):
+        return None, "Claude output is not a JSON object"
+    return payload, None
 
 
-def captured_thread_id(items: list[dict[str, Any]]) -> tuple[str | None, str | None]:
-    if any(item.get("type") == "item.completed" and isinstance(item.get("item"), dict) and item["item"].get("type") == "error" for item in items):
-        return None, "Codex reported an error item"
-    ids = {item["thread_id"] for item in items if item.get("type") == "thread.started" and isinstance(item.get("thread_id"), str) and item["thread_id"]}
-    return (ids.pop(), None) if len(ids) == 1 else (None, "missing or ambiguous thread ID in Codex JSONL")
+def final_result_message(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    if payload.get("is_error"):
+        return None, "Claude reported is_error"
+    result = payload.get("result")
+    if not isinstance(result, str):
+        return None, "missing result field in Claude output"
+    return result, None
 
 
-def final_agent_message(items: list[dict[str, Any]]) -> tuple[str | None, str | None]:
-    messages = [item["item"]["text"] for item in items if item.get("type") == "item.completed" and isinstance(item.get("item"), dict) and item["item"].get("type") == "agent_message" and isinstance(item["item"].get("text"), str)]
-    return (messages[-1], None) if messages else (None, "missing completed agent message in Codex JSONL")
+def captured_session_id(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return None, "missing session ID in Claude output"
+    return session_id, None
 
 
-def latest_rate_limits(session_id: str) -> dict[str, Any] | None:
-    root = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "sessions"
-    matches = []
-    for rollout in root.rglob("*.jsonl") if root.exists() else ():
-        try: entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
-        except OSError: continue
-        if error is None and any(entry.get("type") == "session_meta" and isinstance(entry.get("payload"), dict) and entry["payload"].get("session_id") == session_id for entry in entries): matches.append(rollout)
-    if not matches: return None
-    entries, error = parse_jsonl(max(matches, key=lambda item: item.stat().st_mtime_ns).read_text(encoding="utf-8"))
-    if error: return None
-    limits = None
-    for entry in entries:
-        payload = entry.get("payload")
-        if entry.get("type") == "event_msg" and isinstance(payload, dict) and payload.get("type") == "token_count": limits = payload.get("rate_limits") if isinstance(payload.get("rate_limits"), dict) else None
-    return limits
-
-
-def effort_of(state: dict[str, Any]) -> str:
-    return state.get("effort", DEFAULT_EFFORT)
-
-
-def emit(state: dict[str, Any], final_message: str) -> None:
-    limits = latest_rate_limits(state["session_id"])
-    primary = limits.get("primary") if isinstance(limits, dict) else None
-    remaining = 100 - primary["used_percent"] if isinstance(primary, dict) and isinstance(primary.get("used_percent"), (int, float)) else None
-    print(json.dumps({"session_id": state["session_id"], "model": state["model"], "sandbox": state["sandbox"], "cwd": state["cwd"], "effort": effort_of(state), "final_message": final_message, "headroom": remaining, "headroom_status": "known" if remaining is not None else "unknown"}))
+def emit(state: dict[str, Any], final_message: str, permission_denials: Any) -> None:
+    print(json.dumps({
+        "session_id": state["session_id"],
+        "model": state["model"],
+        "sandbox": state["sandbox"],
+        "cwd": state["cwd"],
+        "effort": effort_of(state),
+        "final_message": final_message,
+        "permission_denials": permission_denials if permission_denials is not None else [],
+    }))
 
 
 def gate_wait(fd: int) -> None:
@@ -307,8 +320,13 @@ def gate_wait(fd: int) -> None:
         os._exit(125)
 
 
-def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str], int]:
-    """Exec a session-leading gate wrapper; Popen can return before the real exec."""
+def gated_process(command: list[str], cwd: Path, prompt: str) -> tuple[subprocess.Popen[str], int]:
+    """Exec a session-leading gate wrapper; Popen can return before the real exec.
+
+    Unlike codex-worker.py, the prompt is not part of `command` — it is piped
+    to the eventual worker's stdin once the gate releases, because the claude
+    CLI's variadic flags would swallow a trailing positional prompt.
+    """
     gate_read, gate_write = os.pipe()
     wrapper = (
         "import json,os,sys; "
@@ -318,7 +336,7 @@ def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str],
     )
     process = subprocess.Popen(
         [sys.executable, "-c", wrapper, str(gate_read), str(cwd), json.dumps(command)],
-        text=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         pass_fds=(gate_read,),
     )
     os.close(gate_read)
@@ -331,7 +349,7 @@ def establish_family(
     state: dict[str, Any],
 ) -> tuple[subprocess.Popen[str] | None, int | None]:
     """Persist and release one gated family while the caller holds the state lock."""
-    process, write_fd = gated_process(command, Path(state["cwd"]))
+    process, write_fd = gated_process(command, Path(state["cwd"]), args.prompt)
     pid = process.pid
     try:
         identity = None
@@ -354,7 +372,10 @@ def establish_family(
 
 
 def finish_lifecycle(args: argparse.Namespace, process: subprocess.Popen[str]) -> int:
-    stdout, stderr = process.communicate()
+    # The prompt reaches the worker on stdin, then stdin is closed so the CLI
+    # sees EOF; codex-worker.py's launch paths hard-wire DEVNULL because the
+    # Codex CLI takes its prompt positionally instead.
+    stdout, stderr = process.communicate(input=args.prompt)
     returncode = process.returncode
     with state_lock(args.state):
         current = read_state(args.state, family_required=True)
@@ -363,18 +384,18 @@ def finish_lifecycle(args: argparse.Namespace, process: subprocess.Popen[str]) -
             state = transition(args.state, state, "exited")
     if returncode:
         sys.stdout.write(stdout); sys.stderr.write(stderr); return returncode
-    items, error = parse_jsonl(stdout)
+    payload, error = parse_result(stdout)
     if error: return fail(error)
-    session_id, error = captured_thread_id(items)
+    session_id, error = captured_session_id(payload)
     if error: return fail(error)
-    message, error = final_agent_message(items)
+    message, error = final_result_message(payload)
     if error: return fail(error)
     with state_lock(args.state):
         current = read_state(args.state, family_required=True)
         if current is None: return fail("state file was lost during worker execution")
         current["session_id"] = session_id
         atomic_write(args.state, current)
-    emit(current, message)
+    emit(current, message, payload.get("permission_denials"))
     return 0
 
 
@@ -389,7 +410,7 @@ def run_portable(
         command,
         cwd=Path(state["cwd"]),
         text=True,
-        stdin=subprocess.DEVNULL,
+        input=args.prompt,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -405,19 +426,21 @@ def run_portable(
         sys.stdout.write(result.stdout)
         sys.stderr.write(result.stderr)
         return result.returncode
-    items, error = parse_jsonl(result.stdout)
+    payload, error = parse_result(result.stdout)
     session_id = None
     message = None
+    denials = None
     if error is None:
-        session_id, error = captured_thread_id(items)
+        session_id, error = captured_session_id(payload)
     if error is None:
-        message, error = final_agent_message(items)
+        message, error = final_result_message(payload)
+        denials = payload.get("permission_denials")
     if session_id is not None:
         terminal["session_id"] = session_id
     atomic_write(args.state, terminal)
     if error is not None:
         return fail(error)
-    emit(terminal, message or "")
+    emit(terminal, message or "", denials)
     return 0
 
 
@@ -443,17 +466,56 @@ def run_lifecycle(
     return finish_lifecycle(args, process)
 
 
+def sandbox_settings(sandbox: str) -> dict[str, Any]:
+    """The two sandbox shapes, carried as literals — not read from docs/ at run
+    time. docs/scope/149-probes/{readonly,write}.settings.json are the source
+    these literals were copied from; docs/ is not part of an installed skill.
+    """
+    if sandbox == "read-only":
+        return {
+            "sandbox": {
+                "enabled": True,
+                "allowUnsandboxedCommands": False,
+                "filesystem": {"denyWrite": ["/", "~/"]},
+            },
+            "permissions": {"deny": ["Write", "Edit", "NotebookEdit"]},
+        }
+    return {
+        "sandbox": {
+            "enabled": True,
+            "allowUnsandboxedCommands": False,
+        },
+        "permissions": {"allow": ["Write", "Edit", "NotebookEdit"]},
+    }
+
+
+def write_settings_file(sandbox: str) -> Path:
+    descriptor, path = tempfile.mkstemp(prefix="claude-worker-settings-", suffix=".json")
+    with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+        json.dump(sandbox_settings(sandbox), file)
+    return Path(path)
+
+
 def start(args: argparse.Namespace) -> int:
     if args.sandbox == "workspace-write":
         if args.control_checkout is None: return fail("workspace-write requires --control-checkout")
         if is_within(args.cwd, args.control_checkout): return fail("workspace-write refuses the control checkout")
-    effort = getattr(args, "effort", DEFAULT_EFFORT)
-    if effort not in EFFORT_LEVELS:
+    if args.effort not in EFFORT_LEVELS:
         return fail(f"--effort must be one of {sorted(EFFORT_LEVELS)}")
-    state: dict[str, Any] = {"version": STATE_VERSION, "lifecycle": "launching", "model": args.model, "sandbox": args.sandbox, "cwd": str(args.cwd), "session_id": ""}
-    if effort != DEFAULT_EFFORT: state["effort"] = effort
+    state: dict[str, Any] = {
+        "version": STATE_VERSION, "lifecycle": "launching", "model": args.model,
+        "sandbox": args.sandbox, "cwd": str(args.cwd), "session_id": "",
+    }
+    if args.effort != DEFAULT_EFFORT: state["effort"] = args.effort
     if args.control_checkout: state["control_checkout"] = str(args.control_checkout)
-    command = [args.codex, "exec", "-m", args.model, "-c", f"model_reasoning_effort={effort}", "--sandbox", args.sandbox, "--skip-git-repo-check", "-C", str(args.cwd), "--json", args.prompt]
+    settings = write_settings_file(args.sandbox)
+    session_id = str(uuid.uuid4())
+    command = [
+        args.claude, "-p", "--model", args.model, "--effort", args.effort,
+        "--permission-mode", "dontAsk", "--settings", str(settings),
+        "--session-id", session_id, "--output-format", "json",
+        "--cwd", str(args.cwd),
+    ]
     return run_lifecycle(args, command, state)
 
 
@@ -486,7 +548,12 @@ def resume(args: argparse.Namespace) -> int:
         fresh = {"version": STATE_VERSION, "lifecycle": "launching", "session_id": state["session_id"], "model": state["model"], "sandbox": sandbox, "cwd": str(cwd)}
         if effort != DEFAULT_EFFORT: fresh["effort"] = effort
         if sandbox == "workspace-write": fresh["control_checkout"] = str(control)
-    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", "--json", args.prompt]
+    settings = write_settings_file(sandbox)
+    command = [
+        args.claude, "-p", "--resume", fresh["session_id"], "--model", fresh["model"],
+        "--effort", effort, "--permission-mode", "dontAsk", "--settings", str(settings),
+        "--output-format", "json", "--cwd", str(cwd),
+    ]
     return run_lifecycle(args, command, fresh, expected=state)
 
 
@@ -503,6 +570,9 @@ def family_state(path: Path, expected: Path) -> tuple[dict[str, Any] | None, str
 
 
 def matching_leader(state: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    # Liveness for a Claude worker is process identity only — there is no
+    # Claude analogue of Codex's rollout file or CPU-time-growth signal; this
+    # adapter must not invent one.
     observed = live_identity(state["pid"])
     if observed is None: return None, "leader identity probe failed"
     recorded = {key: state[key] for key in ("pid", "pgid", "sid", "cwd", "birth")}
@@ -599,7 +669,7 @@ def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     commands = result.add_subparsers(dest="command", required=True)
     common = argparse.ArgumentParser(add_help=False)
-    common.add_argument("--codex", default="codex")
+    common.add_argument("--claude", default="claude")
     common.add_argument("--state", type=Path, required=True)
     common.add_argument("prompt", nargs="?")
     start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--cwd", type=resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=resolved_directory); start_parser.set_defaults(handler=start)

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2249,6 +2249,67 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(argv[argv.index("--effort") + 1], "high")
         self.assertEqual(json.loads(result.stdout)["effort"], "high")
 
+    def test_claude_start_argv_carries_no_cwd_flag_and_settings_matches_sandbox_mode(self):
+        # The installed claude CLI has no --cwd flag; the adapter establishes
+        # the working directory via os.chdir in the gate wrapper (and cwd= in
+        # run_portable), never as an argv token. A fake binary that accepts
+        # any argv would let a stray --cwd slip through unnoticed, so assert
+        # the flag set explicitly for both sandbox modes.
+        for sandbox, expect_deny in (("read-only", True), ("workspace-write", False)):
+            with self.subTest(sandbox=sandbox):
+                self.arguments.unlink(missing_ok=True)
+                self.environment["FAKE_OUTPUT"] = json.dumps({"session_id": "s1", "result": "ok", "is_error": False})
+                arguments = [
+                    "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+                    "--model", "sonnet", "--sandbox", sandbox, "--cwd", str(self.worktree),
+                ]
+                if sandbox == "workspace-write":
+                    arguments += ["--control-checkout", str(self.control)]
+                result = self.run_claude(*arguments, "do the work")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+                self.assertNotIn("--cwd", argv)
+                self.assertEqual(
+                    argv,
+                    [
+                        "-p", "--model", "sonnet", "--effort", "medium",
+                        "--permission-mode", "dontAsk", "--settings", argv[argv.index("--settings") + 1],
+                        "--session-id", argv[argv.index("--session-id") + 1],
+                        "--output-format", "json",
+                    ],
+                )
+                settings_path = Path(argv[argv.index("--settings") + 1])
+                settings = json.loads(settings_path.read_text(encoding="utf-8"))
+                if expect_deny:
+                    self.assertIn("Write", settings["permissions"]["deny"])
+                    self.assertIn("filesystem", settings["sandbox"])
+                else:
+                    self.assertIn("Write", settings["permissions"]["allow"])
+                    self.assertNotIn("filesystem", settings["sandbox"])
+                self.state.unlink(missing_ok=True)
+
+    def test_claude_resume_argv_carries_no_cwd_flag(self):
+        for sandbox in ("read-only", "workspace-write"):
+            with self.subTest(sandbox=sandbox):
+                self.arguments.unlink(missing_ok=True)
+                legacy = {
+                    "version": CLAUDE_WORKER_MODULE.STATE_VERSION, "lifecycle": "exited",
+                    "session_id": "worker-1", "model": "sonnet", "sandbox": sandbox,
+                    "cwd": str(self.worktree.resolve()),
+                    "family_semantics": "unsupported", "generation": 1,
+                }
+                if sandbox == "workspace-write":
+                    legacy["control_checkout"] = str(self.control.resolve())
+                self.state.write_text(json.dumps(legacy), encoding="utf-8")
+                self.environment["FAKE_OUTPUT"] = json.dumps({"session_id": "worker-1", "result": "ok", "is_error": False})
+                result = self.run_claude("resume", "--claude", str(self.claude_binary), "--state", str(self.state), "continue")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+                self.assertNotIn("--cwd", argv)
+                self.assertEqual(argv[0], "-p")
+                self.assertEqual(argv[1:4], ["--resume", "worker-1", "--model"])
+                self.state.unlink(missing_ok=True)
+
     def test_claude_workspace_write_rejects_the_control_checkout(self):
         result = self.run_claude(
             "start", "--claude", str(self.claude_binary), "--state", str(self.state),

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -28,6 +28,7 @@ CBM_TEARDOWN = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-tear
 CBM_LIFECYCLE = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-lifecycle.py"
 SPIN_SCRIPT = ROOT / "skills" / "tools" / "spin-worktree" / "scripts" / "spin-worktree.py"
 CODEX_WORKER = ROOT / "skills" / "drivers" / "orchestrate" / "scripts" / "codex-worker.py"
+CLAUDE_WORKER = ROOT / "skills" / "drivers" / "orchestrate" / "scripts" / "claude-worker.py"
 UI_CRAFT_AUDIT = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "audit.md"
 UI_CRAFT_CRITIQUE = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "critique.md"
 UI_CRAFT_SWEEP = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "behavior-sweep.md"
@@ -40,6 +41,11 @@ WORKER_SPEC = importlib.util.spec_from_file_location("orchestrate_worker", CODEX
 assert WORKER_SPEC and WORKER_SPEC.loader
 WORKER_MODULE = importlib.util.module_from_spec(WORKER_SPEC)
 WORKER_SPEC.loader.exec_module(WORKER_MODULE)
+
+CLAUDE_WORKER_SPEC = importlib.util.spec_from_file_location("orchestrate_claude_worker", CLAUDE_WORKER)
+assert CLAUDE_WORKER_SPEC and CLAUDE_WORKER_SPEC.loader
+CLAUDE_WORKER_MODULE = importlib.util.module_from_spec(CLAUDE_WORKER_SPEC)
+CLAUDE_WORKER_SPEC.loader.exec_module(CLAUDE_WORKER_MODULE)
 
 
 def run(
@@ -1621,6 +1627,8 @@ class CodexWorkerTests(unittest.TestCase):
                 "Terra",
                 "-c",
                 'sandbox_mode="workspace-write"',
+                "-c",
+                "model_reasoning_effort=medium",
                 "--json",
                 "continue with the failing test",
             ],
@@ -2073,6 +2081,247 @@ class OrchestrateCodexPolicyTests(unittest.TestCase):
         self.assertIn("rollout-*.jsonl", dispatch)
 
 
+class WorkerEffortDialTests(unittest.TestCase):
+    """Sub-order 1/2 149: the effort dial on both adapters and the STATE_VERSION
+    choice (effort is optional-with-default, not added to BASE_STATE_FIELDS,
+    so STATE_VERSION stays 2 and pre-existing state files remain valid)."""
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.scratch = Path(self.temporary.name)
+        self.control = self.scratch / "control"
+        self.worktree = self.scratch / "worktree"
+        self.control.mkdir()
+        self.worktree.mkdir()
+        self.state = self.scratch / "worker-state.json"
+        self.arguments = self.scratch / "arguments.json"
+        self.stdin_capture = self.scratch / "stdin.txt"
+
+        self.codex_binary = self.scratch / "fake-codex"
+        self.codex_binary.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, pathlib, sys\n"
+            "pathlib.Path(os.environ['FAKE_ARGUMENTS']).write_text(json.dumps(sys.argv[1:]))\n"
+            "sys.stdout.write(os.environ.get('FAKE_OUTPUT', ''))\n"
+            "sys.exit(int(os.environ.get('FAKE_EXIT', '0')))\n",
+            encoding="utf-8",
+        )
+        self.codex_binary.chmod(0o755)
+
+        self.claude_binary = self.scratch / "fake-claude"
+        self.claude_binary.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, pathlib, sys\n"
+            "pathlib.Path(os.environ['FAKE_ARGUMENTS']).write_text(json.dumps(sys.argv[1:]))\n"
+            "pathlib.Path(os.environ['FAKE_STDIN']).write_text(sys.stdin.read())\n"
+            "sys.stdout.write(os.environ.get('FAKE_OUTPUT', ''))\n"
+            "sys.exit(int(os.environ.get('FAKE_EXIT', '0')))\n",
+            encoding="utf-8",
+        )
+        self.claude_binary.chmod(0o755)
+
+        self.environment = os.environ.copy()
+        self.environment["FAKE_ARGUMENTS"] = str(self.arguments)
+        self.environment["FAKE_STDIN"] = str(self.stdin_capture)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def run_codex(self, *arguments: str):
+        return run(["python3", str(CODEX_WORKER), *arguments], cwd=ROOT, env=self.environment)
+
+    def run_claude(self, *arguments: str):
+        return run(["python3", str(CLAUDE_WORKER), *arguments], cwd=ROOT, env=self.environment)
+
+    # --- codex-worker.py -------------------------------------------------
+
+    def test_codex_start_defaults_to_medium_effort_in_argv(self):
+        self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'
+        result = self.run_codex(
+            "start", "--codex", str(self.codex_binary), "--state", str(self.state),
+            "--model", "Terra", "--sandbox", "read-only", "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertIn("model_reasoning_effort=medium", argv)
+        self.assertNotIn("effort", json.loads(self.state.read_text(encoding="utf-8")))
+
+    def test_codex_start_carries_a_custom_effort_and_persists_it(self):
+        self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'
+        result = self.run_codex(
+            "start", "--codex", str(self.codex_binary), "--state", str(self.state),
+            "--model", "Terra", "--sandbox", "read-only", "--effort", "high",
+            "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertIn("model_reasoning_effort=high", argv)
+        self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["effort"], "high")
+
+    def test_codex_rejects_an_effort_outside_its_own_enum(self):
+        result = self.run_codex(
+            "start", "--codex", str(self.codex_binary), "--state", str(self.state),
+            "--model", "Terra", "--sandbox", "read-only", "--effort", "max",
+            "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--effort", result.stderr)
+        self.assertFalse(self.state.exists())
+
+    def test_codex_replays_persisted_effort_on_resume(self):
+        legacy = {
+            "version": WORKER_MODULE.STATE_VERSION, "lifecycle": "exited",
+            "session_id": "worker-1", "model": "Terra", "sandbox": "read-only",
+            "cwd": str(self.worktree.resolve()), "effort": "high",
+            "family_semantics": "unsupported", "generation": 1,
+        }
+        self.state.write_text(json.dumps(legacy), encoding="utf-8")
+        self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'
+        result = self.run_codex("resume", "--codex", str(self.codex_binary), "--state", str(self.state), "continue")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertIn("model_reasoning_effort=high", argv)
+        self.assertEqual(json.loads(result.stdout)["effort"], "high")
+
+    # --- claude-worker.py -------------------------------------------------
+
+    def test_claude_start_puts_prompt_on_stdin_not_argv(self):
+        self.environment["FAKE_OUTPUT"] = json.dumps({"session_id": "s1", "result": "ok", "is_error": False})
+        result = self.run_claude(
+            "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "--model", "sonnet", "--sandbox", "read-only", "--cwd", str(self.worktree), "the actual prompt text",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertNotIn("the actual prompt text", argv)
+        self.assertEqual(self.stdin_capture.read_text(encoding="utf-8"), "the actual prompt text")
+
+    def test_claude_start_defaults_to_medium_effort_in_argv(self):
+        self.environment["FAKE_OUTPUT"] = json.dumps({"session_id": "s1", "result": "ok", "is_error": False})
+        result = self.run_claude(
+            "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "--model", "sonnet", "--sandbox", "read-only", "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertIn("--effort", argv)
+        self.assertEqual(argv[argv.index("--effort") + 1], "medium")
+        self.assertNotIn("effort", json.loads(self.state.read_text(encoding="utf-8")))
+        self.assertEqual(json.loads(result.stdout)["effort"], "medium")
+
+    def test_claude_start_carries_a_custom_effort_and_persists_it(self):
+        self.environment["FAKE_OUTPUT"] = json.dumps({"session_id": "s1", "result": "ok", "is_error": False})
+        result = self.run_claude(
+            "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "--model", "sonnet", "--sandbox", "read-only", "--effort", "xhigh",
+            "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertEqual(argv[argv.index("--effort") + 1], "xhigh")
+        self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["effort"], "xhigh")
+        self.assertEqual(json.loads(result.stdout)["effort"], "xhigh")
+
+    def test_claude_rejects_an_effort_outside_its_own_enum(self):
+        # "minimal" is valid for codex but not claude — the two adapters do not
+        # share one enum.
+        result = self.run_claude(
+            "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "--model", "sonnet", "--sandbox", "read-only", "--effort", "minimal",
+            "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--effort", result.stderr)
+        self.assertFalse(self.state.exists())
+
+    def test_claude_replays_persisted_effort_on_resume(self):
+        legacy = {
+            "version": CLAUDE_WORKER_MODULE.STATE_VERSION, "lifecycle": "exited",
+            "session_id": "worker-1", "model": "sonnet", "sandbox": "read-only",
+            "cwd": str(self.worktree.resolve()), "effort": "high",
+            "family_semantics": "unsupported", "generation": 1,
+        }
+        self.state.write_text(json.dumps(legacy), encoding="utf-8")
+        self.environment["FAKE_OUTPUT"] = json.dumps({"session_id": "worker-1", "result": "ok", "is_error": False})
+        result = self.run_claude("resume", "--claude", str(self.claude_binary), "--state", str(self.state), "continue")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertEqual(argv[argv.index("--effort") + 1], "high")
+        self.assertEqual(json.loads(result.stdout)["effort"], "high")
+
+    def test_claude_workspace_write_rejects_the_control_checkout(self):
+        result = self.run_claude(
+            "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "--model", "sonnet", "--sandbox", "workspace-write",
+            "--cwd", str(self.control), "--control-checkout", str(self.control),
+            "do the work",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("control checkout", result.stderr)
+        self.assertFalse(self.state.exists())
+
+    def test_claude_generated_readonly_settings_deny_writes_and_disable_unsandboxed_retry(self):
+        settings = CLAUDE_WORKER_MODULE.sandbox_settings("read-only")
+        self.assertEqual(settings["sandbox"]["allowUnsandboxedCommands"], False)
+        self.assertIn("/", settings["sandbox"]["filesystem"]["denyWrite"])
+        self.assertIn("Write", settings["permissions"]["deny"])
+        self.assertIn("Edit", settings["permissions"]["deny"])
+
+    def test_claude_generated_write_settings_allow_edit_tools_and_keep_unsandboxed_retry_disabled(self):
+        settings = CLAUDE_WORKER_MODULE.sandbox_settings("workspace-write")
+        self.assertEqual(settings["sandbox"]["allowUnsandboxedCommands"], False)
+        self.assertNotIn("filesystem", settings["sandbox"])
+        self.assertIn("Write", settings["permissions"]["allow"])
+        self.assertIn("Edit", settings["permissions"]["allow"])
+
+    def test_missing_effort_defaults_to_medium_without_a_version_bump(self):
+        # STATE_VERSION decision: effort lives only in each command's `allowed`
+        # schema superset, never in BASE_STATE_FIELDS, so a pre-existing state
+        # file with no "effort" key stays valid at STATE_VERSION 2 and reads
+        # back as the medium default on both adapters.
+        self.assertEqual(WORKER_MODULE.STATE_VERSION, 2)
+        self.assertEqual(CLAUDE_WORKER_MODULE.STATE_VERSION, 2)
+        state = {
+            "version": 2, "lifecycle": "running", "session_id": "s",
+            "model": "Terra", "sandbox": "read-only", "cwd": str(self.worktree.resolve()),
+            "pid": 1, "pgid": 1, "sid": 1, "birth": {"seconds": 1, "microseconds": 0},
+        }
+        self.assertTrue(WORKER_MODULE.valid_family_schema(state))
+        self.assertEqual(WORKER_MODULE.effort_of(state), "medium")
+        state["model"] = "sonnet"
+        self.assertTrue(CLAUDE_WORKER_MODULE.valid_family_schema(state))
+        self.assertEqual(CLAUDE_WORKER_MODULE.effort_of(state), "medium")
+
+
+class OrchestrateAdapterDispatchTests(unittest.TestCase):
+    def test_skill_bans_agent_tool_workflow_tool_and_background_agents_for_dispatch(self):
+        skill = (ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("never through the Agent tool, the Workflow tool, or a\n  background agent", skill)
+        self.assertIn("claude-worker.py", skill)
+        self.assertIn("claude-worker.py resume", skill)
+        self.assertNotIn("via the Agent tool with a `model` override", skill)
+        self.assertIn("defaulting to medium", skill)
+
+    def test_dispatch_claude_reference_exists_and_names_both_sandbox_modes(self):
+        dispatch = (
+            ROOT / "skills" / "drivers" / "orchestrate" / "references" / "dispatch-claude.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("read-only", dispatch)
+        self.assertIn("workspace-write", dispatch)
+        self.assertIn("prompt to the worker's stdin", dispatch)
+        self.assertIn("liveness", dispatch.lower())
+        self.assertIn("permission_denials", dispatch)
+        self.assertIn("command -v claude", dispatch)
+
+    def test_routing_table_effort_notes_name_both_enums(self):
+        table = (
+            ROOT / "skills" / "drivers" / "orchestrate" / "references" / "routing-table.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("low|medium|high|xhigh|max", table)
+        self.assertIn("minimal|low|medium|high|xhigh", table)
+        self.assertIn("defaulting to medium", table)
+
+
 class WorkerLifecycleContractTests(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
@@ -2521,6 +2770,19 @@ class WorkerLifecycleContractTests(unittest.TestCase):
         self.assertNotIn("proc_listchildpids", source)
         self.assertNotIn("proc_name", source)
         self.assertIn("Successors never discover or clean", instructions)
+
+    def test_claude_worker_process_family_constants_and_no_global_cleanup_authority(self):
+        # The Darwin-constant guard covers both adapters: claude-worker.py
+        # carries its own copy of the same identity-probe constants, not an
+        # import of codex-worker.py's.
+        self.assertEqual(CLAUDE_WORKER_MODULE.BSD_SIZE, 136)
+        self.assertEqual(CLAUDE_WORKER_MODULE.VNODE_SIZE, 2352)
+        self.assertEqual(CLAUDE_WORKER_MODULE.PROC_PIDTBSDINFO, 3)
+        self.assertEqual(CLAUDE_WORKER_MODULE.PROC_PIDVNODEPATHINFO, 9)
+        source = CLAUDE_WORKER.read_text(encoding="utf-8")
+        self.assertNotIn("pkill", source)
+        self.assertNotIn("proc_listchildpids", source)
+        self.assertNotIn("proc_name", source)
 
     @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_darwin_probe_contract(self):

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2382,6 +2382,13 @@ class OrchestrateAdapterDispatchTests(unittest.TestCase):
         self.assertIn("liveness", dispatch.lower())
         self.assertIn("permission_denials", dispatch)
         self.assertIn("command -v claude", dispatch)
+        # The workspace-write shape is the one a real run of #149 corrected: with
+        # no filesystem block, a worker wrote through to $HOME/.cache. Pin the
+        # corrected shape so this reference cannot drift back to describing the
+        # pre-fix sandbox while the adapter generates the fixed one — nothing
+        # else asserts what this document claims the shape is.
+        self.assertIn("filesystem.allowWrite", dispatch)
+        self.assertNotIn("no filesystem deny-list", dispatch)
 
     def test_routing_table_effort_notes_name_both_enums(self):
         table = (

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2285,7 +2285,8 @@ class WorkerEffortDialTests(unittest.TestCase):
                     self.assertIn("filesystem", settings["sandbox"])
                 else:
                     self.assertIn("Write", settings["permissions"]["allow"])
-                    self.assertNotIn("filesystem", settings["sandbox"])
+                    self.assertIn(str(self.worktree.resolve()), settings["sandbox"]["filesystem"]["allowWrite"])
+                    self.assertNotIn("denyWrite", settings["sandbox"]["filesystem"])
                 self.state.unlink(missing_ok=True)
 
     def test_claude_resume_argv_carries_no_cwd_flag(self):
@@ -2322,16 +2323,24 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertFalse(self.state.exists())
 
     def test_claude_generated_readonly_settings_deny_writes_and_disable_unsandboxed_retry(self):
-        settings = CLAUDE_WORKER_MODULE.sandbox_settings("read-only")
+        settings = CLAUDE_WORKER_MODULE.sandbox_settings("read-only", self.worktree.resolve())
         self.assertEqual(settings["sandbox"]["allowUnsandboxedCommands"], False)
         self.assertIn("/", settings["sandbox"]["filesystem"]["denyWrite"])
         self.assertIn("Write", settings["permissions"]["deny"])
         self.assertIn("Edit", settings["permissions"]["deny"])
 
-    def test_claude_generated_write_settings_allow_edit_tools_and_keep_unsandboxed_retry_disabled(self):
-        settings = CLAUDE_WORKER_MODULE.sandbox_settings("workspace-write")
+    def test_claude_generated_write_settings_confine_writes_to_cwd_and_keep_unsandboxed_retry_disabled(self):
+        # A real run of #149 with no `filesystem` block present wrote straight
+        # through to $HOME/.cache — see docs/scope/149-probes/run-log.md's
+        # `write` case. allowWrite must name the worker's own cwd, alone: a
+        # real run also confirmed denyWrite always wins over allowWrite for
+        # the same path, so pairing them re-blocks the cwd allowWrite exists
+        # to carve out.
+        cwd = self.worktree.resolve()
+        settings = CLAUDE_WORKER_MODULE.sandbox_settings("workspace-write", cwd)
         self.assertEqual(settings["sandbox"]["allowUnsandboxedCommands"], False)
-        self.assertNotIn("filesystem", settings["sandbox"])
+        self.assertIn(str(cwd), settings["sandbox"]["filesystem"]["allowWrite"])
+        self.assertNotIn("denyWrite", settings["sandbox"]["filesystem"])
         self.assertIn("Write", settings["permissions"]["allow"])
         self.assertIn("Edit", settings["permissions"]["allow"])
 


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Orchestrate now launches Claude and Codex workers through pack-owned adapters with a reasoning-effort dial and bans dispatch through the assistant's built-in agent machinery. The pack-wide rule is recorded, but other dispatching skills keep their current paths until their follow-up tickets land. Before this, Claude workers launched through the harness with no pinned working directory, sandbox, or effort, while Codex workers hard-coded medium effort.

* The Claude and Codex adapters remain separate by a recorded, dated decision. Their shared lifecycle moves into one module in the next ticket; the new Claude adapter has executed evidence but not dedicated suite coverage.
* A live write-mode worker escaped its worktree and wrote into the home directory because its settings had no filesystem block. The shipped settings confine writes to the working directory plus the session temporary directory; pairing the working-directory allow with a deny re-blocks that directory, because the deny takes precedence.
* Both adapters accept the same effort flag, default to medium, validate their own enum, and replay the value across resume without a state-version bump; absence reads back as medium.
* The Claude adapter no longer passes an unsupported CLI flag, and its reference page now describes the confined write sandbox. Tests pin both behaviors.

The decision record is ADR 149; the live evidence is the probe run log in the scoping directory.

Closes #149

## Verification

```text
validated 27 skills and 301 files
Ran 377 tests in 105.823s
OK (skipped=23)
py_compile exit 0
DCO_OK commits=18
```

Claude-side confinement, refusal, and effort-replay claims were verified on disk against live workers after the operator re-authenticated the CLI; the earlier capture recording the pre-fix escape is retained and marked superseded.
