### PR TITLE
refactor(orchestrate): one shared worker lifecycle for both adapters

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,6 +45,9 @@ jobs:
           python3 -m py_compile skills/tools/cbm-onboard/scripts/cbm-lifecycle.py
           python3 -m py_compile skills/tools/codebase-memory/scripts/install.py
           python3 -m py_compile scripts/ci_changed_paths.py
+          python3 -m py_compile skills/drivers/orchestrate/scripts/worker_lifecycle.py
+          python3 -m py_compile skills/drivers/orchestrate/scripts/codex-worker.py
+          python3 -m py_compile skills/drivers/orchestrate/scripts/claude-worker.py
           node --check skills/tools/drive-local-webapp/scripts/driver.mjs
           node --check skills/tools/drive-local-webapp/scripts/self-check.mjs
           sh -n skills/tools/cbm-onboard/scripts/cbm-onboard.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ ui-surfaces: none
   tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco
   tests.test_ci_changed_paths && python3 -m py_compile
   skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py
+  skills/drivers/orchestrate/scripts/worker_lifecycle.py
   skills/drivers/orchestrate/scripts/codex-worker.py
   skills/drivers/orchestrate/scripts/claude-worker.py`. Requires Python 3.10
   or newer (the worker scripts use `X | None` union syntax).

--- a/docs/adr/adr-150-shared-worker-lifecycle-module.md
+++ b/docs/adr/adr-150-shared-worker-lifecycle-module.md
@@ -48,6 +48,11 @@ the [Codex stdin liveness ledger](../scope/orchestrate-codex-stdin-liveness.md) 
 shared module: Claude requires prompt-over-stdin. The Codex adapter still passes `None`,
 retains `DEVNULL`, and remains covered by the open-stdin regression guard from #62.
 
+**Correction (2026-08-25).** The initial extraction also moved a `gate_wait` helper,
+but no launch path called it: the subprocess wrapper below `gated_process` implements the
+gate directly so it can run after `setsid()` and before `exec`. The unused helper and its
+ownership-test pin were removed; the wrapper remains the single gate implementation.
+
 ## Consequences
 
 * State durability, schema validation, family ownership, liveness, cleanup, and the

--- a/docs/adr/adr-150-shared-worker-lifecycle-module.md
+++ b/docs/adr/adr-150-shared-worker-lifecycle-module.md
@@ -1,0 +1,59 @@
+# ADR 150 — Shared worker lifecycle module
+
+Status: accepted (2026-08-24)
+
+## Context
+
+[ADR 149](adr-149-pack-owned-model-dispatch.md) deliberately shipped the Codex and
+Claude worker adapters with duplicated state handling, process-family ownership,
+liveness, launch, stop, verify, and control-checkout protection. Two real adapters now
+make the lifecycle seam real. Leaving the copies in place would let their durability and
+safety rules diverge as more skills adopt pack-owned dispatch.
+
+The adapters differ in three load-bearing ways: each CLI has its own output format, each
+adapter emits a different success object, and each adapter owns the prefix on its errors.
+Claude also sends its prompt through stdin because its variadic CLI flags can swallow a
+positional prompt; Codex takes the prompt as an argument and must keep stdin closed.
+
+## Decision
+
+The shared lifecycle lives beside the adapters in
+`skills/drivers/orchestrate/scripts/worker_lifecycle.py`, so it is present in every
+installed copy of the skill. Adapters reach moved machinery only through a qualified
+`lifecycle.` reference. Re-exporting a moved name, assigning an alias, or forwarding it
+through `__getattr__` is forbidden: a test patch could otherwise resolve against an
+adapter's copy while the shared implementation continued through a different global,
+making the patch intercept nothing.
+
+Tests load the shared module once and register it as `worker_lifecycle` in `sys.modules`
+before either adapter is executed. Loading the file separately for tests and adapters
+would create two module objects, so a patch applied to one would not protect calls through
+the other.
+
+The `start`, `resume`, `stop`, and `verify` entry points remain in each adapter. Shared
+preparation and worker-control helpers return errors to those entry points, which report
+them through the adapter's own inline `fail()` function. A shared or module-global prefix
+would be last-writer-wins when both adapters are loaded in one process.
+
+The four launch functions — `establish_family`, `finish_lifecycle`, `run_portable`, and
+`run_lifecycle` — are the exception to return-an-error-string. They take adapter callables,
+including `fail`, as keyword-only inputs and continue returning an integer exit code.
+Converting their failures to returned strings would change `run_lifecycle`'s pinned integer
+contract and break callers that return it directly.
+
+The shared launch interface accepts keyword-only `stdin_text`. A string selects a pipe and
+is written only after the process-family gate is released; `None` selects
+`subprocess.DEVNULL`. This supersedes issue #62's blanket “Unsupported” stdin ruling in
+the [Codex stdin liveness ledger](../scope/orchestrate-codex-stdin-liveness.md) for the
+shared module: Claude requires prompt-over-stdin. The Codex adapter still passes `None`,
+retains `DEVNULL`, and remains covered by the open-stdin regression guard from #62.
+
+## Consequences
+
+* State durability, schema validation, family ownership, liveness, cleanup, and the
+  control-checkout refusal have one implementation for both adapters.
+* Output parsing, success emission, CLI arguments, effort enums, and error prefixes remain
+  adapter-local.
+* Tests patch the one owner of moved machinery and fail loudly if a moved name becomes
+  reachable through either adapter.
+* Both local verification and CI syntax-check the shared module and both adapters.

--- a/skills/drivers/orchestrate/scripts/claude-worker.py
+++ b/skills/drivers/orchestrate/scripts/claude-worker.py
@@ -1,64 +1,21 @@
 #!/usr/bin/env python3
-"""Launch, resume, stop, and verify one durable Claude worker process family.
-
-Standalone sibling of codex-worker.py: this file carries its own copy of the
-lifecycle machinery (state lock, atomic write, schema validation, process-
-family ownership, liveness, run/finish lifecycle, stop, verify) rather than
-importing it, per work order 149 sub-order 1 — no shared module in this
-ticket. Keep the structure and naming aligned with codex-worker.py so the two
-read as one family and a later extraction is a mechanical diff.
-
-Differences from codex-worker.py, all load-bearing:
-  * The prompt goes on the worker's stdin, not as a trailing argv token.
-    `claude -p ... --tools/--allowedTools/--disallowedTools` are variadic and
-    would swallow a positional prompt.
-  * Output parsing and the final emit are Claude's own: one JSON object
-    (`--output-format json`) with a `result` field and an `is_error` flag,
-    not Codex's JSONL event stream.
-  * There is no Claude analogue of Codex's rollout file or its headroom
-    fields. Liveness here is process identity only; this adapter must not
-    invent a headroom concept Claude does not expose.
-"""
+"""Launch, resume, stop, and verify one durable Claude worker process family."""
 
 from __future__ import annotations
 
 import argparse
-import ctypes
-import fcntl
 import json
 import os
-import signal
-import struct
-import subprocess
 import sys
 import tempfile
-import time
 import uuid
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-STATE_VERSION = 2
-UNSUPPORTED = "UNSUPPORTED_PROCESS_FAMILY_SEMANTICS"
-FAMILY_SEMANTICS_UNSUPPORTED = "unsupported"
-TERMINAL = {"stopped", "exited"}
-TRANSITIONS = {
-    "launching": {"running", "stopping", "exited"},
-    "running": {"stopping", "exited"},
-    "stopping": {"stopped", "exited"},
-    "stopped": set(),
-    "exited": set(),
-}
-PROC_PIDTBSDINFO = 3
-PROC_PIDVNODEPATHINFO = 9
-BSD_SIZE = 136
-VNODE_SIZE = 2352
-VNODE_CWD_OFFSET = 152
-PID_MAX = 2**31 - 1
-UINT64_MAX = 2**64 - 1
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import worker_lifecycle as lifecycle
 
-# Effort enum captured in docs/scope/149-probes/effort-enums.md (`claude --help`).
-# Not shared with codex-worker.py's enum — each adapter owns a literal set.
+
 EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
 DEFAULT_EFFORT = "medium"
 
@@ -66,214 +23,6 @@ DEFAULT_EFFORT = "medium"
 def fail(message: str, code: int = 1) -> int:
     print(f"claude-worker: {message}", file=sys.stderr)
     return code
-
-
-def resolved_directory(value: str) -> Path:
-    path = Path(value).resolve(strict=True)
-    if not path.is_dir():
-        raise argparse.ArgumentTypeError("must be an existing directory")
-    return path
-
-
-def is_within(path: Path, directory: Path) -> bool:
-    return path == directory or directory in path.parents
-
-
-@contextmanager
-def state_lock(path: Path):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock = path.with_name(path.name + ".lock")
-    with lock.open("a+") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        yield
-
-
-def atomic_write(path: Path, state: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
-            json.dump(state, file, indent=2, sort_keys=True)
-            file.write("\n")
-            file.flush()
-            os.fsync(file.fileno())
-        os.replace(temporary, path)
-        parent = os.open(path.parent, os.O_RDONLY)
-        try:
-            os.fsync(parent)
-        finally:
-            os.close(parent)
-    finally:
-        if os.path.exists(temporary):
-            os.unlink(temporary)
-
-
-def read_state(path: Path, *, family_required: bool = False) -> dict[str, Any] | None:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(value, dict):
-        return None
-    if family_required and value.get("version") != STATE_VERSION:
-        return None
-    return value
-
-
-def transition(path: Path, state: dict[str, Any], lifecycle: str) -> dict[str, Any]:
-    previous = state.get("lifecycle")
-    if previous not in TRANSITIONS or lifecycle not in TRANSITIONS[previous]:
-        raise ValueError(f"illegal lifecycle transition {previous!r} to {lifecycle!r}")
-    updated = dict(state)
-    updated["lifecycle"] = lifecycle
-    atomic_write(path, updated)
-    return updated
-
-
-def _bounded_integer(value: Any, minimum: int, maximum: int) -> bool:
-    return type(value) is int and minimum <= value <= maximum
-
-
-def _canonical_path(value: Any) -> bool:
-    if not isinstance(value, str) or not value or not Path(value).is_absolute():
-        return False
-    try:
-        return str(Path(value).resolve()) == value
-    except (OSError, RuntimeError, ValueError):
-        return False
-
-
-# STATE_VERSION decision (spec do-7): effort is added only to each command's
-# `allowed` schema superset below, never to BASE_STATE_FIELDS. BASE_STATE_FIELDS
-# is checked with `.issubset(state)`, so a key placed there becomes mandatory —
-# every already-persisted state (including codex-worker's) would fail schema
-# validation the moment this file shipped. Treating a missing "effort" as the
-# medium default keeps STATE_VERSION at 2 and both adapters' existing state
-# files valid. See test_missing_effort_defaults_to_medium_without_version_bump.
-BASE_STATE_FIELDS = {"version", "lifecycle", "session_id", "model", "sandbox", "cwd"}
-
-
-def _valid_common_schema(state: dict[str, Any], allowed: set[str]) -> bool:
-    if not BASE_STATE_FIELDS.issubset(state):
-        return False
-    if not set(state).issubset(allowed):
-        return False
-    if type(state["version"]) is not int or state["version"] != STATE_VERSION:
-        return False
-    if not isinstance(state["lifecycle"], str) or state["lifecycle"] not in TRANSITIONS:
-        return False
-    if not isinstance(state["session_id"], str):
-        return False
-    if not isinstance(state["model"], str) or not state["model"]:
-        return False
-    if not isinstance(state["sandbox"], str) or state["sandbox"] not in {"read-only", "workspace-write"}:
-        return False
-    if not _canonical_path(state["cwd"]):
-        return False
-    if "effort" in state and (not isinstance(state["effort"], str) or state["effort"] not in EFFORT_LEVELS):
-        return False
-    control = state.get("control_checkout")
-    if control is not None and not _canonical_path(control):
-        return False
-    if state["sandbox"] == "workspace-write":
-        if control is None or is_within(Path(state["cwd"]), Path(control)):
-            return False
-    return True
-
-
-def valid_family_schema(state: dict[str, Any]) -> bool:
-    identity = {"pid", "pgid", "sid", "birth"}
-    if not identity.issubset(state):
-        return False
-    if not _valid_common_schema(state, BASE_STATE_FIELDS | identity | {"control_checkout", "effort"}):
-        return False
-    for field in ("pid", "pgid", "sid"):
-        if not _bounded_integer(state[field], 1, PID_MAX):
-            return False
-    birth = state["birth"]
-    if not isinstance(birth, dict) or set(birth) != {"seconds", "microseconds"}:
-        return False
-    if not _bounded_integer(birth["seconds"], 1, UINT64_MAX):
-        return False
-    if not _bounded_integer(birth["microseconds"], 0, 999_999):
-        return False
-    return True
-
-
-def valid_portable_schema(state: dict[str, Any]) -> bool:
-    allowed = BASE_STATE_FIELDS | {"control_checkout", "family_semantics", "generation", "effort"}
-    if not _valid_common_schema(state, allowed):
-        return False
-    if state["lifecycle"] != "exited":
-        return False
-    if state.get("family_semantics") != FAMILY_SEMANTICS_UNSUPPORTED:
-        return False
-    if not _bounded_integer(state.get("generation"), 1, UINT64_MAX):
-        return False
-    return True
-
-
-def effort_of(state: dict[str, Any]) -> str:
-    return state.get("effort", DEFAULT_EFFORT)
-
-
-def _libproc() -> ctypes.CDLL | None:
-    if sys.platform != "darwin":
-        return None
-    try:
-        library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
-        library.proc_pidinfo.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int]
-        library.proc_pidinfo.restype = ctypes.c_int
-        library.proc_listpgrppids.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_int]
-        library.proc_listpgrppids.restype = ctypes.c_int
-        return library
-    except OSError:
-        return None
-
-
-def live_identity(pid: int) -> dict[str, Any] | None:
-    library = _libproc()
-    if library is None:
-        return None
-    bsd = ctypes.create_string_buffer(BSD_SIZE)
-    ctypes.set_errno(0)
-    if library.proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, bsd, BSD_SIZE) != BSD_SIZE:
-        return None
-    cwd = ctypes.create_string_buffer(VNODE_SIZE)
-    ctypes.set_errno(0)
-    if library.proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, cwd, VNODE_SIZE) != VNODE_SIZE:
-        return None
-    try:
-        returned_pid = struct.unpack_from("<I", bsd.raw, 12)[0]
-        pgid = struct.unpack_from("<I", bsd.raw, 100)[0]
-        seconds, microseconds = struct.unpack_from("<QQ", bsd.raw, 120)
-        sid = os.getsid(pid)
-        directory = cwd.raw[VNODE_CWD_OFFSET:].split(b"\0", 1)[0].decode("utf-8")
-        canonical_cwd = str(Path(directory).resolve(strict=True))
-    except (OSError, UnicodeDecodeError, struct.error):
-        return None
-    if returned_pid != pid or not directory:
-        return None
-    return {"pid": pid, "pgid": pgid, "sid": sid, "cwd": canonical_cwd,
-            "birth": {"seconds": seconds, "microseconds": microseconds}}
-
-
-def group_members(pgid: int) -> list[int] | None:
-    library = _libproc()
-    if library is None:
-        return None
-    capacity = 64
-    while capacity <= 65536:
-        values = (ctypes.c_int * capacity)()
-        ctypes.set_errno(0)
-        count = library.proc_listpgrppids(pgid, values, ctypes.sizeof(values))
-        if count < 0 or (count == 0 and ctypes.get_errno()):
-            return None
-        members = list(values[:count])
-        if count < capacity:
-            return members
-        capacity *= 2
-    return None
 
 
 def parse_result(output: str) -> tuple[dict[str, Any] | None, str | None]:
@@ -303,6 +52,22 @@ def captured_session_id(payload: dict[str, Any]) -> tuple[str | None, str | None
     return session_id, None
 
 
+def effort_of(state: dict[str, Any]) -> str:
+    return state.get("effort", DEFAULT_EFFORT)
+
+
+def parse(output: str) -> tuple[str | None, str | None, Any, str | None]:
+    payload, error = parse_result(output)
+    if error:
+        return None, None, None, error
+    assert payload is not None
+    session_id, error = captured_session_id(payload)
+    if error:
+        return None, None, None, error
+    message, error = final_result_message(payload)
+    return session_id, message, payload.get("permission_denials"), error
+
+
 def emit(state: dict[str, Any], final_message: str, permission_denials: Any) -> None:
     print(json.dumps({
         "session_id": state["session_id"],
@@ -315,175 +80,8 @@ def emit(state: dict[str, Any], final_message: str, permission_denials: Any) -> 
     }))
 
 
-def gate_wait(fd: int) -> None:
-    if os.read(fd, 1) != b"R":
-        os._exit(125)
-
-
-def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str], int]:
-    """Exec a session-leading gate wrapper; Popen can return before the real exec.
-
-    Unlike codex-worker.py, the prompt is not part of `command` — it is piped
-    to the eventual worker's stdin once the gate releases, because the claude
-    CLI's variadic flags would swallow a trailing positional prompt.
-    """
-    gate_read, gate_write = os.pipe()
-    wrapper = (
-        "import json,os,sys; "
-        "os.setsid(); os.chdir(sys.argv[2]); "
-        "os.read(int(sys.argv[1]), 1) == b'R' or os._exit(125); "
-        "os.execvp(json.loads(sys.argv[3])[0], json.loads(sys.argv[3]))"
-    )
-    process = subprocess.Popen(
-        [sys.executable, "-c", wrapper, str(gate_read), str(cwd), json.dumps(command)],
-        text=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        pass_fds=(gate_read,),
-    )
-    os.close(gate_read)
-    return process, gate_write
-
-
-def establish_family(
-    args: argparse.Namespace,
-    command: list[str],
-    state: dict[str, Any],
-) -> tuple[subprocess.Popen[str] | None, int | None]:
-    """Persist and release one gated family while the caller holds the state lock."""
-    process, write_fd = gated_process(command, Path(state["cwd"]))
-    pid = process.pid
-    try:
-        identity = None
-        deadline = time.monotonic() + 1
-        while time.monotonic() < deadline:
-            identity = live_identity(pid)
-            if identity and identity["pgid"] == pid and identity["sid"] == pid and identity["cwd"] == state["cwd"]:
-                break
-            time.sleep(0.01)
-        if identity is None or identity["pgid"] != pid or identity["sid"] != pid or identity["cwd"] != state["cwd"]:
-            os.kill(pid, signal.SIGKILL); process.communicate()
-            return None, fail(f"could not establish dedicated worker process family: observed={identity!r} expected_cwd={state['cwd']!r}")
-        state = {**state, **identity}
-        atomic_write(args.state, state)
-        os.write(write_fd, b"R")
-        state = transition(args.state, state, "running")
-    finally:
-        os.close(write_fd)
-    return process, None
-
-
-def finish_lifecycle(args: argparse.Namespace, process: subprocess.Popen[str]) -> int:
-    # The prompt reaches the worker on stdin, then stdin is closed so the CLI
-    # sees EOF; codex-worker.py's launch paths hard-wire DEVNULL because the
-    # Codex CLI takes its prompt positionally instead.
-    stdout, stderr = process.communicate(input=args.prompt)
-    returncode = process.returncode
-    with state_lock(args.state):
-        current = read_state(args.state, family_required=True)
-        if current and current.get("lifecycle") in {"launching", "running"}:
-            state = transition(args.state, current, "running") if current["lifecycle"] == "launching" else current
-            state = transition(args.state, state, "exited")
-    if returncode:
-        sys.stdout.write(stdout); sys.stderr.write(stderr); return returncode
-    payload, error = parse_result(stdout)
-    if error: return fail(error)
-    session_id, error = captured_session_id(payload)
-    if error: return fail(error)
-    message, error = final_result_message(payload)
-    if error: return fail(error)
-    with state_lock(args.state):
-        current = read_state(args.state, family_required=True)
-        if current is None: return fail("state file was lost during worker execution")
-        current["session_id"] = session_id
-        atomic_write(args.state, current)
-    emit(current, message, payload.get("permission_denials"))
-    return 0
-
-
-def run_portable(
-    args: argparse.Namespace,
-    command: list[str],
-    state: dict[str, Any],
-    generation: int,
-) -> int:
-    """Run under the state lock and persist no recoverable process-family claim."""
-    result = subprocess.run(
-        command,
-        cwd=Path(state["cwd"]),
-        text=True,
-        input=args.prompt,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    terminal = {
-        **state,
-        "lifecycle": "exited",
-        "family_semantics": FAMILY_SEMANTICS_UNSUPPORTED,
-        "generation": generation,
-    }
-    if result.returncode:
-        atomic_write(args.state, terminal)
-        sys.stdout.write(result.stdout)
-        sys.stderr.write(result.stderr)
-        return result.returncode
-    payload, error = parse_result(result.stdout)
-    session_id = None
-    message = None
-    denials = None
-    if error is None:
-        session_id, error = captured_session_id(payload)
-    if error is None:
-        message, error = final_result_message(payload)
-        denials = payload.get("permission_denials")
-    if session_id is not None:
-        terminal["session_id"] = session_id
-    atomic_write(args.state, terminal)
-    if error is not None:
-        return fail(error)
-    emit(terminal, message or "", denials)
-    return 0
-
-
-def run_lifecycle(
-    args: argparse.Namespace,
-    command: list[str],
-    state: dict[str, Any],
-    *,
-    expected: dict[str, Any] | None = None,
-) -> int:
-    with state_lock(args.state):
-        if expected is not None and read_state(args.state) != expected:
-            return fail("resume requires an unchanged terminal worker state")
-        if _libproc() is None:
-            previous_generation = expected["generation"] if expected is not None and valid_portable_schema(expected) else 0
-            if previous_generation == UINT64_MAX:
-                return fail("portable state generation exhausted")
-            return run_portable(args, command, state, previous_generation + 1)
-        process, error = establish_family(args, command, state)
-        if error is not None:
-            return error
-    assert process is not None
-    return finish_lifecycle(args, process)
-
-
 def sandbox_settings(sandbox: str, cwd: Path) -> dict[str, Any]:
-    """The two sandbox shapes, carried as literals — not read from docs/ at run
-    time; docs/ is not part of an installed skill. The read-only shape still
-    matches docs/scope/149-probes/readonly.settings.json, the fixture it was
-    originally copied from.
-
-    The workspace-write shape's `filesystem` block does not match
-    write.settings.json (that fixture has none): a real run of #149 with no
-    `filesystem` block present wrote straight through to `$HOME/.cache` — the
-    sandbox leaves the whole filesystem writable outside the settings file's
-    own confinement (see run-log.md's `write` case). `allowWrite: [cwd]` alone
-    closes that: it behaves as an allowlist, confining writes to cwd and
-    refusing everything else. `denyWrite` was tried alongside it (`["/"]`,
-    then `["~/"]`, since cwd sits under the home tree) and rejected both
-    times, confirmed by real runs, not just reasoning about the docs: `deny`
-    always wins over `allow` for the same path, so pairing them silently
-    re-blocks the one directory `allowWrite` exists to carve out.
-    """
+    """Build the installed Claude CLI's two sandbox settings shapes."""
     if sandbox == "read-only":
         return {
             "sandbox": {
@@ -511,17 +109,12 @@ def write_settings_file(sandbox: str, cwd: Path) -> Path:
 
 
 def start(args: argparse.Namespace) -> int:
-    if args.sandbox == "workspace-write":
-        if args.control_checkout is None: return fail("workspace-write requires --control-checkout")
-        if is_within(args.cwd, args.control_checkout): return fail("workspace-write refuses the control checkout")
-    if args.effort not in EFFORT_LEVELS:
-        return fail(f"--effort must be one of {sorted(EFFORT_LEVELS)}")
-    state: dict[str, Any] = {
-        "version": STATE_VERSION, "lifecycle": "launching", "model": args.model,
-        "sandbox": args.sandbox, "cwd": str(args.cwd), "session_id": "",
-    }
-    if args.effort != DEFAULT_EFFORT: state["effort"] = args.effort
-    if args.control_checkout: state["control_checkout"] = str(args.control_checkout)
+    state, error = lifecycle.prepare_start(
+        args, effort_levels=EFFORT_LEVELS, default_effort=DEFAULT_EFFORT
+    )
+    if error:
+        return fail(error)
+    assert state is not None
     settings = write_settings_file(args.sandbox, args.cwd)
     session_id = str(uuid.uuid4())
     command = [
@@ -529,153 +122,41 @@ def start(args: argparse.Namespace) -> int:
         "--permission-mode", "dontAsk", "--settings", str(settings),
         "--session-id", session_id, "--output-format", "json",
     ]
-    return run_lifecycle(args, command, state)
+    return lifecycle.run_lifecycle(
+        args, command, state, parse=parse, emit=emit, fail=fail,
+        stdin_text=args.prompt, effort_levels=EFFORT_LEVELS,
+    )
 
 
 def resume(args: argparse.Namespace) -> int:
-    snapshot = read_state(args.state)
-    with state_lock(args.state):
-        state = read_state(args.state)
-        if state != snapshot:
-            return fail("resume requires an unchanged terminal worker state")
-        if state is None: return fail("state file is malformed or incomplete")
-        if "version" not in state:
-            # Legacy completed states are compatible only for ordinary resume.
-            legacy = {"session_id", "model", "sandbox", "cwd"}
-            if not legacy.issubset(state) or not set(state).issubset(legacy | {"control_checkout", "effort"}): return fail("state file is malformed or incomplete")
-            if not all(isinstance(state[key], str) and state[key] for key in legacy): return fail("state file is malformed or incomplete")
-        elif not (valid_family_schema(state) or valid_portable_schema(state)):
-            return fail("state file is malformed or incomplete")
-        elif state["lifecycle"] not in TERMINAL or not state["session_id"]:
-            return fail("resume requires a terminal worker state with a session ID")
-        try: cwd = resolved_directory(state["cwd"])
-        except (OSError, argparse.ArgumentTypeError): return fail("state file has an invalid cwd")
-        sandbox = state.get("sandbox")
-        if sandbox not in {"read-only", "workspace-write"}: return fail("state file has an invalid sandbox")
-        if sandbox == "workspace-write":
-            try: control = resolved_directory(state["control_checkout"])
-            except (KeyError, OSError, argparse.ArgumentTypeError): return fail("state file is missing the control checkout")
-            if is_within(cwd, control): return fail("workspace-write refuses the control checkout")
-        effort = effort_of(state)
-        if effort not in EFFORT_LEVELS: return fail("state file has an invalid effort")
-        fresh = {"version": STATE_VERSION, "lifecycle": "launching", "session_id": state["session_id"], "model": state["model"], "sandbox": sandbox, "cwd": str(cwd)}
-        if effort != DEFAULT_EFFORT: fresh["effort"] = effort
-        if sandbox == "workspace-write": fresh["control_checkout"] = str(control)
-    settings = write_settings_file(sandbox, cwd)
+    fresh, expected, error = lifecycle.prepare_resume(
+        args, effort_levels=EFFORT_LEVELS, default_effort=DEFAULT_EFFORT
+    )
+    if error:
+        return fail(error)
+    assert fresh is not None and expected is not None
+    cwd = Path(fresh["cwd"])
+    effort = effort_of(fresh)
+    settings = write_settings_file(fresh["sandbox"], cwd)
     command = [
         args.claude, "-p", "--resume", fresh["session_id"], "--model", fresh["model"],
         "--effort", effort, "--permission-mode", "dontAsk", "--settings", str(settings),
         "--output-format", "json",
     ]
-    return run_lifecycle(args, command, fresh, expected=state)
-
-
-def family_state(path: Path, expected: Path) -> tuple[dict[str, Any] | None, str | None]:
-    state = read_state(path)
-    if state is None: return None, "state is missing, corrupt, or legacy"
-    version = state.get("version")
-    if "version" not in state or (type(version) is int and version != STATE_VERSION):
-        return None, "state is missing, corrupt, or legacy"
-    if not (valid_family_schema(state) or valid_portable_schema(state)):
-        return None, "state is malformed"
-    if state["cwd"] != str(expected): return None, f"cwd mismatch: recorded={state['cwd']!r} expected={str(expected)!r}"
-    return state, None
-
-
-def matching_leader(state: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
-    # Liveness for a Claude worker is process identity only — there is no
-    # Claude analogue of Codex's rollout file or CPU-time-growth signal; this
-    # adapter must not invent one.
-    observed = live_identity(state["pid"])
-    if observed is None: return None, "leader identity probe failed"
-    recorded = {key: state[key] for key in ("pid", "pgid", "sid", "cwd", "birth")}
-    if observed != recorded: return None, f"identity mismatch: recorded={recorded!r} observed={observed!r}"
-    return observed, None
+    return lifecycle.run_lifecycle(
+        args, command, fresh, expected=expected, parse=parse, emit=emit, fail=fail,
+        stdin_text=args.prompt, effort_levels=EFFORT_LEVELS,
+    )
 
 
 def verify(args: argparse.Namespace) -> int:
-    with state_lock(args.state):
-        state, error = family_state(args.state, args.cwd)
-        if error: return fail(error)
-        if _libproc() is None: return fail(UNSUPPORTED)
-        if valid_portable_schema(state):
-            return fail("state has no recoverable process family")
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if members: return fail(f"worker process group still has members: {members}")
-        if state["lifecycle"] not in TERMINAL:
-            if state["lifecycle"] != "stopping":
-                state = transition(args.state, state, "stopping")
-            state = transition(args.state, state, "stopped")
-    return 0
+    code, error = lifecycle.verify_worker(args, effort_levels=EFFORT_LEVELS)
+    return fail(error) if error else (code or 0)
 
 
 def stop(args: argparse.Namespace) -> int:
-    with state_lock(args.state):
-        state, error = family_state(args.state, args.cwd)
-        if error: return fail(error)
-        if _libproc() is None: return fail(UNSUPPORTED)
-        if valid_portable_schema(state):
-            return fail("state has no recoverable process family")
-        leader, error = matching_leader(state)
-        if error and state["lifecycle"] not in TERMINAL:
-            if "identity mismatch:" in error:
-                return fail(error)
-            # A gone leader is safe only after the recorded PGID is observed empty
-            # or is itself the exact group proved eligible for KILL below.
-            members = group_members(state["pgid"])
-            if members is None: return fail("process-group probe failed")
-            if not members:
-                if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
-                transition(args.state, state, "stopped")
-                return 0
-            state = transition(args.state, state, "stopping") if state["lifecycle"] != "stopping" else state
-            try: os.killpg(state["pgid"], signal.SIGKILL)
-            except OSError as exc: return fail(f"KILL refused: {exc}")
-            return 0
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if not members:
-            if state["lifecycle"] not in TERMINAL:
-                if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
-                transition(args.state, state, "stopped")
-            return 0
-        if state["lifecycle"] in TERMINAL:
-            try: os.killpg(state["pgid"], signal.SIGKILL)
-            except OSError as exc: return fail(f"KILL refused: {exc}")
-            deadline = time.monotonic() + args.grace_seconds
-            while time.monotonic() < deadline:
-                members = group_members(state["pgid"])
-                if members is None: return fail("process-group probe failed")
-                if not members: return verify(args)
-                time.sleep(0.05)
-            return fail(f"worker process group still has members: {members}")
-        if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
-        try: os.killpg(state["pgid"], signal.SIGTERM)
-        except OSError as exc: return fail(f"TERM refused: {exc}")
-    deadline = time.monotonic() + args.grace_seconds
-    while time.monotonic() < deadline:
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if not members:
-            with state_lock(args.state):
-                current = read_state(args.state, family_required=True)
-                if current and current["lifecycle"] == "stopping": transition(args.state, current, "stopped")
-            return 0
-        time.sleep(0.05)
-    members = group_members(state["pgid"])
-    if members is None: return fail("process-group probe failed")
-    if not members: return 0
-    # The leader may have exited; KILL is authorized solely by a successful exact-group enumeration.
-    try: os.killpg(state["pgid"], signal.SIGKILL)
-    except OSError as exc: return fail(f"KILL refused: {exc}")
-    deadline = time.monotonic() + args.grace_seconds
-    while time.monotonic() < deadline:
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if not members: break
-        time.sleep(0.05)
-    return verify(args)
+    code, error = lifecycle.stop_worker(args, effort_levels=EFFORT_LEVELS)
+    return fail(error) if error else (code or 0)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -685,10 +166,10 @@ def parser() -> argparse.ArgumentParser:
     common.add_argument("--claude", default="claude")
     common.add_argument("--state", type=Path, required=True)
     common.add_argument("prompt", nargs="?")
-    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--cwd", type=resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=resolved_directory); start_parser.set_defaults(handler=start)
+    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=lifecycle.resolved_directory); start_parser.set_defaults(handler=start)
     resume_parser = commands.add_parser("resume", parents=[common]); resume_parser.set_defaults(handler=resume)
     for name, handler in (("stop", stop), ("verify", verify)):
-        command = commands.add_parser(name, parents=[common]); command.add_argument("--cwd", type=resolved_directory, required=True); command.add_argument("--grace-seconds", type=float, default=1.0); command.set_defaults(handler=handler)
+        command = commands.add_parser(name, parents=[common]); command.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); command.add_argument("--grace-seconds", type=float, default=1.0); command.set_defaults(handler=handler)
     return result
 
 

--- a/skills/drivers/orchestrate/scripts/codex-worker.py
+++ b/skills/drivers/orchestrate/scripts/codex-worker.py
@@ -4,38 +4,16 @@
 from __future__ import annotations
 
 import argparse
-import ctypes
-import fcntl
 import json
 import os
-import signal
-import struct
 import subprocess
 import sys
-import tempfile
-import time
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-STATE_VERSION = 2
-UNSUPPORTED = "UNSUPPORTED_PROCESS_FAMILY_SEMANTICS"
-FAMILY_SEMANTICS_UNSUPPORTED = "unsupported"
-TERMINAL = {"stopped", "exited"}
-TRANSITIONS = {
-    "launching": {"running", "stopping", "exited"},
-    "running": {"stopping", "exited"},
-    "stopping": {"stopped", "exited"},
-    "stopped": set(),
-    "exited": set(),
-}
-PROC_PIDTBSDINFO = 3
-PROC_PIDVNODEPATHINFO = 9
-BSD_SIZE = 136
-VNODE_SIZE = 2352
-VNODE_CWD_OFFSET = 152
-PID_MAX = 2**31 - 1
-UINT64_MAX = 2**64 - 1
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import worker_lifecycle as lifecycle
+
 
 # Effort enum captured in docs/scope/149-probes/effort-enums.md: the Codex CLI
 # validates nothing locally (a bogus value starts the session and fails at the
@@ -48,203 +26,6 @@ DEFAULT_EFFORT = "medium"
 def fail(message: str, code: int = 1) -> int:
     print(f"codex-worker: {message}", file=sys.stderr)
     return code
-
-
-def resolved_directory(value: str) -> Path:
-    path = Path(value).resolve(strict=True)
-    if not path.is_dir():
-        raise argparse.ArgumentTypeError("must be an existing directory")
-    return path
-
-
-def is_within(path: Path, directory: Path) -> bool:
-    return path == directory or directory in path.parents
-
-
-@contextmanager
-def state_lock(path: Path):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock = path.with_name(path.name + ".lock")
-    with lock.open("a+") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        yield
-
-
-def atomic_write(path: Path, state: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
-            json.dump(state, file, indent=2, sort_keys=True)
-            file.write("\n")
-            file.flush()
-            os.fsync(file.fileno())
-        os.replace(temporary, path)
-        parent = os.open(path.parent, os.O_RDONLY)
-        try:
-            os.fsync(parent)
-        finally:
-            os.close(parent)
-    finally:
-        if os.path.exists(temporary):
-            os.unlink(temporary)
-
-
-def read_state(path: Path, *, family_required: bool = False) -> dict[str, Any] | None:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(value, dict):
-        return None
-    if family_required and value.get("version") != STATE_VERSION:
-        return None
-    return value
-
-
-def transition(path: Path, state: dict[str, Any], lifecycle: str) -> dict[str, Any]:
-    previous = state.get("lifecycle")
-    if previous not in TRANSITIONS or lifecycle not in TRANSITIONS[previous]:
-        raise ValueError(f"illegal lifecycle transition {previous!r} to {lifecycle!r}")
-    updated = dict(state)
-    updated["lifecycle"] = lifecycle
-    atomic_write(path, updated)
-    return updated
-
-
-def _bounded_integer(value: Any, minimum: int, maximum: int) -> bool:
-    return type(value) is int and minimum <= value <= maximum
-
-
-def _canonical_path(value: Any) -> bool:
-    if not isinstance(value, str) or not value or not Path(value).is_absolute():
-        return False
-    try:
-        return str(Path(value).resolve()) == value
-    except (OSError, RuntimeError, ValueError):
-        return False
-
-
-BASE_STATE_FIELDS = {"version", "lifecycle", "session_id", "model", "sandbox", "cwd"}
-
-
-def _valid_common_schema(state: dict[str, Any], allowed: set[str]) -> bool:
-    if not BASE_STATE_FIELDS.issubset(state):
-        return False
-    if not set(state).issubset(allowed):
-        return False
-    if type(state["version"]) is not int or state["version"] != STATE_VERSION:
-        return False
-    if not isinstance(state["lifecycle"], str) or state["lifecycle"] not in TRANSITIONS:
-        return False
-    if not isinstance(state["session_id"], str):
-        return False
-    if not isinstance(state["model"], str) or not state["model"]:
-        return False
-    if not isinstance(state["sandbox"], str) or state["sandbox"] not in {"read-only", "workspace-write"}:
-        return False
-    if not _canonical_path(state["cwd"]):
-        return False
-    if "effort" in state and (not isinstance(state["effort"], str) or state["effort"] not in EFFORT_LEVELS):
-        return False
-    control = state.get("control_checkout")
-    if control is not None and not _canonical_path(control):
-        return False
-    if state["sandbox"] == "workspace-write":
-        if control is None or is_within(Path(state["cwd"]), Path(control)):
-            return False
-    return True
-
-
-def valid_family_schema(state: dict[str, Any]) -> bool:
-    identity = {"pid", "pgid", "sid", "birth"}
-    if not identity.issubset(state):
-        return False
-    if not _valid_common_schema(state, BASE_STATE_FIELDS | identity | {"control_checkout", "effort"}):
-        return False
-    for field in ("pid", "pgid", "sid"):
-        if not _bounded_integer(state[field], 1, PID_MAX):
-            return False
-    birth = state["birth"]
-    if not isinstance(birth, dict) or set(birth) != {"seconds", "microseconds"}:
-        return False
-    if not _bounded_integer(birth["seconds"], 1, UINT64_MAX):
-        return False
-    if not _bounded_integer(birth["microseconds"], 0, 999_999):
-        return False
-    return True
-
-
-def valid_portable_schema(state: dict[str, Any]) -> bool:
-    allowed = BASE_STATE_FIELDS | {"control_checkout", "family_semantics", "generation", "effort"}
-    if not _valid_common_schema(state, allowed):
-        return False
-    if state["lifecycle"] != "exited":
-        return False
-    if state.get("family_semantics") != FAMILY_SEMANTICS_UNSUPPORTED:
-        return False
-    if not _bounded_integer(state.get("generation"), 1, UINT64_MAX):
-        return False
-    return True
-
-
-def _libproc() -> ctypes.CDLL | None:
-    if sys.platform != "darwin":
-        return None
-    try:
-        library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
-        library.proc_pidinfo.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int]
-        library.proc_pidinfo.restype = ctypes.c_int
-        library.proc_listpgrppids.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_int]
-        library.proc_listpgrppids.restype = ctypes.c_int
-        return library
-    except OSError:
-        return None
-
-
-def live_identity(pid: int) -> dict[str, Any] | None:
-    library = _libproc()
-    if library is None:
-        return None
-    bsd = ctypes.create_string_buffer(BSD_SIZE)
-    ctypes.set_errno(0)
-    if library.proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, bsd, BSD_SIZE) != BSD_SIZE:
-        return None
-    cwd = ctypes.create_string_buffer(VNODE_SIZE)
-    ctypes.set_errno(0)
-    if library.proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, cwd, VNODE_SIZE) != VNODE_SIZE:
-        return None
-    try:
-        returned_pid = struct.unpack_from("<I", bsd.raw, 12)[0]
-        pgid = struct.unpack_from("<I", bsd.raw, 100)[0]
-        seconds, microseconds = struct.unpack_from("<QQ", bsd.raw, 120)
-        sid = os.getsid(pid)
-        directory = cwd.raw[VNODE_CWD_OFFSET:].split(b"\0", 1)[0].decode("utf-8")
-        canonical_cwd = str(Path(directory).resolve(strict=True))
-    except (OSError, UnicodeDecodeError, struct.error):
-        return None
-    if returned_pid != pid or not directory:
-        return None
-    return {"pid": pid, "pgid": pgid, "sid": sid, "cwd": canonical_cwd,
-            "birth": {"seconds": seconds, "microseconds": microseconds}}
-
-
-def group_members(pgid: int) -> list[int] | None:
-    library = _libproc()
-    if library is None:
-        return None
-    capacity = 64
-    while capacity <= 65536:
-        values = (ctypes.c_int * capacity)()
-        ctypes.set_errno(0)
-        count = library.proc_listpgrppids(pgid, values, ctypes.sizeof(values))
-        if count < 0 or (count == 0 and ctypes.get_errno()):
-            return None
-        members = list(values[:count])
-        if count < capacity:
-            return members
-        capacity *= 2
-    return None
 
 
 def parse_jsonl(output: str) -> tuple[list[dict[str, Any]], str | None]:
@@ -278,16 +59,22 @@ def latest_rate_limits(session_id: str) -> dict[str, Any] | None:
     root = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "sessions"
     matches = []
     for rollout in root.rglob("*.jsonl") if root.exists() else ():
-        try: entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
-        except OSError: continue
-        if error is None and any(entry.get("type") == "session_meta" and isinstance(entry.get("payload"), dict) and entry["payload"].get("session_id") == session_id for entry in entries): matches.append(rollout)
-    if not matches: return None
+        try:
+            entries, error = parse_jsonl(rollout.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if error is None and any(entry.get("type") == "session_meta" and isinstance(entry.get("payload"), dict) and entry["payload"].get("session_id") == session_id for entry in entries):
+            matches.append(rollout)
+    if not matches:
+        return None
     entries, error = parse_jsonl(max(matches, key=lambda item: item.stat().st_mtime_ns).read_text(encoding="utf-8"))
-    if error: return None
+    if error:
+        return None
     limits = None
     for entry in entries:
         payload = entry.get("payload")
-        if entry.get("type") == "event_msg" and isinstance(payload, dict) and payload.get("type") == "token_count": limits = payload.get("rate_limits") if isinstance(payload.get("rate_limits"), dict) else None
+        if entry.get("type") == "event_msg" and isinstance(payload, dict) and payload.get("type") == "token_count":
+            limits = payload.get("rate_limits") if isinstance(payload.get("rate_limits"), dict) else None
     return limits
 
 
@@ -295,304 +82,62 @@ def effort_of(state: dict[str, Any]) -> str:
     return state.get("effort", DEFAULT_EFFORT)
 
 
-def emit(state: dict[str, Any], final_message: str) -> None:
+def parse(output: str) -> tuple[str | None, str | None, Any, str | None]:
+    items, error = parse_jsonl(output)
+    if error:
+        return None, None, None, error
+    session_id, error = captured_thread_id(items)
+    if error:
+        return None, None, None, error
+    message, error = final_agent_message(items)
+    return session_id, message, None, error
+
+
+def emit(state: dict[str, Any], final_message: str, _metadata: Any = None) -> None:
     limits = latest_rate_limits(state["session_id"])
     primary = limits.get("primary") if isinstance(limits, dict) else None
     remaining = 100 - primary["used_percent"] if isinstance(primary, dict) and isinstance(primary.get("used_percent"), (int, float)) else None
     print(json.dumps({"session_id": state["session_id"], "model": state["model"], "sandbox": state["sandbox"], "cwd": state["cwd"], "effort": effort_of(state), "final_message": final_message, "headroom": remaining, "headroom_status": "known" if remaining is not None else "unknown"}))
 
 
-def gate_wait(fd: int) -> None:
-    if os.read(fd, 1) != b"R":
-        os._exit(125)
-
-
-def gated_process(command: list[str], cwd: Path) -> tuple[subprocess.Popen[str], int]:
-    """Exec a session-leading gate wrapper; Popen can return before the real exec."""
-    gate_read, gate_write = os.pipe()
-    wrapper = (
-        "import json,os,sys; "
-        "os.setsid(); os.chdir(sys.argv[2]); "
-        "os.read(int(sys.argv[1]), 1) == b'R' or os._exit(125); "
-        "os.execvp(json.loads(sys.argv[3])[0], json.loads(sys.argv[3]))"
-    )
-    process = subprocess.Popen(
-        [sys.executable, "-c", wrapper, str(gate_read), str(cwd), json.dumps(command)],
-        text=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        pass_fds=(gate_read,),
-    )
-    os.close(gate_read)
-    return process, gate_write
-
-
-def establish_family(
-    args: argparse.Namespace,
-    command: list[str],
-    state: dict[str, Any],
-) -> tuple[subprocess.Popen[str] | None, int | None]:
-    """Persist and release one gated family while the caller holds the state lock."""
-    process, write_fd = gated_process(command, Path(state["cwd"]))
-    pid = process.pid
-    try:
-        identity = None
-        deadline = time.monotonic() + 1
-        while time.monotonic() < deadline:
-            identity = live_identity(pid)
-            if identity and identity["pgid"] == pid and identity["sid"] == pid and identity["cwd"] == state["cwd"]:
-                break
-            time.sleep(0.01)
-        if identity is None or identity["pgid"] != pid or identity["sid"] != pid or identity["cwd"] != state["cwd"]:
-            os.kill(pid, signal.SIGKILL); process.communicate()
-            return None, fail(f"could not establish dedicated worker process family: observed={identity!r} expected_cwd={state['cwd']!r}")
-        state = {**state, **identity}
-        atomic_write(args.state, state)
-        os.write(write_fd, b"R")
-        state = transition(args.state, state, "running")
-    finally:
-        os.close(write_fd)
-    return process, None
-
-
-def finish_lifecycle(args: argparse.Namespace, process: subprocess.Popen[str]) -> int:
-    stdout, stderr = process.communicate()
-    returncode = process.returncode
-    with state_lock(args.state):
-        current = read_state(args.state, family_required=True)
-        if current and current.get("lifecycle") in {"launching", "running"}:
-            state = transition(args.state, current, "running") if current["lifecycle"] == "launching" else current
-            state = transition(args.state, state, "exited")
-    if returncode:
-        sys.stdout.write(stdout); sys.stderr.write(stderr); return returncode
-    items, error = parse_jsonl(stdout)
-    if error: return fail(error)
-    session_id, error = captured_thread_id(items)
-    if error: return fail(error)
-    message, error = final_agent_message(items)
-    if error: return fail(error)
-    with state_lock(args.state):
-        current = read_state(args.state, family_required=True)
-        if current is None: return fail("state file was lost during worker execution")
-        current["session_id"] = session_id
-        atomic_write(args.state, current)
-    emit(current, message)
-    return 0
-
-
-def run_portable(
-    args: argparse.Namespace,
-    command: list[str],
-    state: dict[str, Any],
-    generation: int,
-) -> int:
-    """Run under the state lock and persist no recoverable process-family claim."""
-    result = subprocess.run(
-        command,
-        cwd=Path(state["cwd"]),
-        text=True,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    terminal = {
-        **state,
-        "lifecycle": "exited",
-        "family_semantics": FAMILY_SEMANTICS_UNSUPPORTED,
-        "generation": generation,
-    }
-    if result.returncode:
-        atomic_write(args.state, terminal)
-        sys.stdout.write(result.stdout)
-        sys.stderr.write(result.stderr)
-        return result.returncode
-    items, error = parse_jsonl(result.stdout)
-    session_id = None
-    message = None
-    if error is None:
-        session_id, error = captured_thread_id(items)
-    if error is None:
-        message, error = final_agent_message(items)
-    if session_id is not None:
-        terminal["session_id"] = session_id
-    atomic_write(args.state, terminal)
-    if error is not None:
-        return fail(error)
-    emit(terminal, message or "")
-    return 0
-
-
-def run_lifecycle(
-    args: argparse.Namespace,
-    command: list[str],
-    state: dict[str, Any],
-    *,
-    expected: dict[str, Any] | None = None,
-) -> int:
-    with state_lock(args.state):
-        if expected is not None and read_state(args.state) != expected:
-            return fail("resume requires an unchanged terminal worker state")
-        if _libproc() is None:
-            previous_generation = expected["generation"] if expected is not None and valid_portable_schema(expected) else 0
-            if previous_generation == UINT64_MAX:
-                return fail("portable state generation exhausted")
-            return run_portable(args, command, state, previous_generation + 1)
-        process, error = establish_family(args, command, state)
-        if error is not None:
-            return error
-    assert process is not None
-    return finish_lifecycle(args, process)
-
-
 def start(args: argparse.Namespace) -> int:
-    if args.sandbox == "workspace-write":
-        if args.control_checkout is None: return fail("workspace-write requires --control-checkout")
-        if is_within(args.cwd, args.control_checkout): return fail("workspace-write refuses the control checkout")
-    effort = getattr(args, "effort", DEFAULT_EFFORT)
-    if effort not in EFFORT_LEVELS:
-        return fail(f"--effort must be one of {sorted(EFFORT_LEVELS)}")
-    state: dict[str, Any] = {"version": STATE_VERSION, "lifecycle": "launching", "model": args.model, "sandbox": args.sandbox, "cwd": str(args.cwd), "session_id": ""}
-    if effort != DEFAULT_EFFORT: state["effort"] = effort
-    if args.control_checkout: state["control_checkout"] = str(args.control_checkout)
+    state, error = lifecycle.prepare_start(
+        args, effort_levels=EFFORT_LEVELS, default_effort=DEFAULT_EFFORT
+    )
+    if error:
+        return fail(error)
+    assert state is not None
+    effort = effort_of(state)
     command = [args.codex, "exec", "-m", args.model, "-c", f"model_reasoning_effort={effort}", "--sandbox", args.sandbox, "--skip-git-repo-check", "-C", str(args.cwd), "--json", args.prompt]
-    return run_lifecycle(args, command, state)
+    return lifecycle.run_lifecycle(
+        args, command, state, parse=parse, emit=emit, fail=fail,
+        stdin_text=None, effort_levels=EFFORT_LEVELS,
+    )
 
 
 def resume(args: argparse.Namespace) -> int:
-    snapshot = read_state(args.state)
-    with state_lock(args.state):
-        state = read_state(args.state)
-        if state != snapshot:
-            return fail("resume requires an unchanged terminal worker state")
-        if state is None: return fail("state file is malformed or incomplete")
-        if "version" not in state:
-            # Legacy completed states are compatible only for ordinary resume.
-            legacy = {"session_id", "model", "sandbox", "cwd"}
-            if not legacy.issubset(state) or not set(state).issubset(legacy | {"control_checkout", "effort"}): return fail("state file is malformed or incomplete")
-            if not all(isinstance(state[key], str) and state[key] for key in legacy): return fail("state file is malformed or incomplete")
-        elif not (valid_family_schema(state) or valid_portable_schema(state)):
-            return fail("state file is malformed or incomplete")
-        elif state["lifecycle"] not in TERMINAL or not state["session_id"]:
-            return fail("resume requires a terminal worker state with a session ID")
-        try: cwd = resolved_directory(state["cwd"])
-        except (OSError, argparse.ArgumentTypeError): return fail("state file has an invalid cwd")
-        sandbox = state.get("sandbox")
-        if sandbox not in {"read-only", "workspace-write"}: return fail("state file has an invalid sandbox")
-        if sandbox == "workspace-write":
-            try: control = resolved_directory(state["control_checkout"])
-            except (KeyError, OSError, argparse.ArgumentTypeError): return fail("state file is missing the control checkout")
-            if is_within(cwd, control): return fail("workspace-write refuses the control checkout")
-        effort = effort_of(state)
-        if effort not in EFFORT_LEVELS: return fail("state file has an invalid effort")
-        fresh = {"version": STATE_VERSION, "lifecycle": "launching", "session_id": state["session_id"], "model": state["model"], "sandbox": sandbox, "cwd": str(cwd)}
-        if effort != DEFAULT_EFFORT: fresh["effort"] = effort
-        if sandbox == "workspace-write": fresh["control_checkout"] = str(control)
+    fresh, expected, error = lifecycle.prepare_resume(
+        args, effort_levels=EFFORT_LEVELS, default_effort=DEFAULT_EFFORT
+    )
+    if error:
+        return fail(error)
+    assert fresh is not None and expected is not None
+    effort = effort_of(fresh)
     command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", "--json", args.prompt]
-    return run_lifecycle(args, command, fresh, expected=state)
-
-
-def family_state(path: Path, expected: Path) -> tuple[dict[str, Any] | None, str | None]:
-    state = read_state(path)
-    if state is None: return None, "state is missing, corrupt, or legacy"
-    version = state.get("version")
-    if "version" not in state or (type(version) is int and version != STATE_VERSION):
-        return None, "state is missing, corrupt, or legacy"
-    if not (valid_family_schema(state) or valid_portable_schema(state)):
-        return None, "state is malformed"
-    if state["cwd"] != str(expected): return None, f"cwd mismatch: recorded={state['cwd']!r} expected={str(expected)!r}"
-    return state, None
-
-
-def matching_leader(state: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
-    observed = live_identity(state["pid"])
-    if observed is None: return None, "leader identity probe failed"
-    recorded = {key: state[key] for key in ("pid", "pgid", "sid", "cwd", "birth")}
-    if observed != recorded: return None, f"identity mismatch: recorded={recorded!r} observed={observed!r}"
-    return observed, None
+    return lifecycle.run_lifecycle(
+        args, command, fresh, expected=expected, parse=parse, emit=emit, fail=fail,
+        stdin_text=None, effort_levels=EFFORT_LEVELS,
+    )
 
 
 def verify(args: argparse.Namespace) -> int:
-    with state_lock(args.state):
-        state, error = family_state(args.state, args.cwd)
-        if error: return fail(error)
-        if _libproc() is None: return fail(UNSUPPORTED)
-        if valid_portable_schema(state):
-            return fail("state has no recoverable process family")
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if members: return fail(f"worker process group still has members: {members}")
-        if state["lifecycle"] not in TERMINAL:
-            if state["lifecycle"] != "stopping":
-                state = transition(args.state, state, "stopping")
-            state = transition(args.state, state, "stopped")
-    return 0
+    code, error = lifecycle.verify_worker(args, effort_levels=EFFORT_LEVELS)
+    return fail(error) if error else (code or 0)
 
 
 def stop(args: argparse.Namespace) -> int:
-    with state_lock(args.state):
-        state, error = family_state(args.state, args.cwd)
-        if error: return fail(error)
-        if _libproc() is None: return fail(UNSUPPORTED)
-        if valid_portable_schema(state):
-            return fail("state has no recoverable process family")
-        leader, error = matching_leader(state)
-        if error and state["lifecycle"] not in TERMINAL:
-            if "identity mismatch:" in error:
-                return fail(error)
-            # A gone leader is safe only after the recorded PGID is observed empty
-            # or is itself the exact group proved eligible for KILL below.
-            members = group_members(state["pgid"])
-            if members is None: return fail("process-group probe failed")
-            if not members:
-                if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
-                transition(args.state, state, "stopped")
-                return 0
-            state = transition(args.state, state, "stopping") if state["lifecycle"] != "stopping" else state
-            try: os.killpg(state["pgid"], signal.SIGKILL)
-            except OSError as exc: return fail(f"KILL refused: {exc}")
-            return 0
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if not members:
-            if state["lifecycle"] not in TERMINAL:
-                if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
-                transition(args.state, state, "stopped")
-            return 0
-        if state["lifecycle"] in TERMINAL:
-            try: os.killpg(state["pgid"], signal.SIGKILL)
-            except OSError as exc: return fail(f"KILL refused: {exc}")
-            deadline = time.monotonic() + args.grace_seconds
-            while time.monotonic() < deadline:
-                members = group_members(state["pgid"])
-                if members is None: return fail("process-group probe failed")
-                if not members: return verify(args)
-                time.sleep(0.05)
-            return fail(f"worker process group still has members: {members}")
-        if state["lifecycle"] != "stopping": state = transition(args.state, state, "stopping")
-        try: os.killpg(state["pgid"], signal.SIGTERM)
-        except OSError as exc: return fail(f"TERM refused: {exc}")
-    deadline = time.monotonic() + args.grace_seconds
-    while time.monotonic() < deadline:
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if not members:
-            with state_lock(args.state):
-                current = read_state(args.state, family_required=True)
-                if current and current["lifecycle"] == "stopping": transition(args.state, current, "stopped")
-            return 0
-        time.sleep(0.05)
-    members = group_members(state["pgid"])
-    if members is None: return fail("process-group probe failed")
-    if not members: return 0
-    # The leader may have exited; KILL is authorized solely by a successful exact-group enumeration.
-    try: os.killpg(state["pgid"], signal.SIGKILL)
-    except OSError as exc: return fail(f"KILL refused: {exc}")
-    deadline = time.monotonic() + args.grace_seconds
-    while time.monotonic() < deadline:
-        members = group_members(state["pgid"])
-        if members is None: return fail("process-group probe failed")
-        if not members: break
-        time.sleep(0.05)
-    return verify(args)
+    code, error = lifecycle.stop_worker(args, effort_levels=EFFORT_LEVELS)
+    return fail(error) if error else (code or 0)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -602,10 +147,10 @@ def parser() -> argparse.ArgumentParser:
     common.add_argument("--codex", default="codex")
     common.add_argument("--state", type=Path, required=True)
     common.add_argument("prompt", nargs="?")
-    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--cwd", type=resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=resolved_directory); start_parser.set_defaults(handler=start)
+    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=lifecycle.resolved_directory); start_parser.set_defaults(handler=start)
     resume_parser = commands.add_parser("resume", parents=[common]); resume_parser.set_defaults(handler=resume)
     for name, handler in (("stop", stop), ("verify", verify)):
-        command = commands.add_parser(name, parents=[common]); command.add_argument("--cwd", type=resolved_directory, required=True); command.add_argument("--grace-seconds", type=float, default=1.0); command.set_defaults(handler=handler)
+        command = commands.add_parser(name, parents=[common]); command.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); command.add_argument("--grace-seconds", type=float, default=1.0); command.set_defaults(handler=handler)
     return result
 
 

--- a/skills/drivers/orchestrate/scripts/worker_lifecycle.py
+++ b/skills/drivers/orchestrate/scripts/worker_lifecycle.py
@@ -250,11 +250,6 @@ def group_members(pgid: int) -> list[int] | None:
     return None
 
 
-def gate_wait(fd: int) -> None:
-    if os.read(fd, 1) != b"R":
-        os._exit(125)
-
-
 def gated_process(
     command: list[str], cwd: Path, *, stdin_text: str | None
 ) -> tuple[subprocess.Popen[str], int]:

--- a/skills/drivers/orchestrate/scripts/worker_lifecycle.py
+++ b/skills/drivers/orchestrate/scripts/worker_lifecycle.py
@@ -1,0 +1,655 @@
+"""Shared durable worker process-family lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import fcntl
+import json
+import os
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable
+
+
+STATE_VERSION = 2
+UNSUPPORTED = "UNSUPPORTED_PROCESS_FAMILY_SEMANTICS"
+FAMILY_SEMANTICS_UNSUPPORTED = "unsupported"
+TERMINAL = {"stopped", "exited"}
+TRANSITIONS = {
+    "launching": {"running", "stopping", "exited"},
+    "running": {"stopping", "exited"},
+    "stopping": {"stopped", "exited"},
+    "stopped": set(),
+    "exited": set(),
+}
+PROC_PIDTBSDINFO = 3
+PROC_PIDVNODEPATHINFO = 9
+BSD_SIZE = 136
+VNODE_SIZE = 2352
+VNODE_CWD_OFFSET = 152
+PID_MAX = 2**31 - 1
+UINT64_MAX = 2**64 - 1
+
+Fail = Callable[[str], int]
+Parse = Callable[[str], tuple]
+Emit = Callable[[dict[str, Any], str, Any], None]
+
+
+def resolved_directory(value: str) -> Path:
+    path = Path(value).resolve(strict=True)
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError("must be an existing directory")
+    return path
+
+
+def is_within(path: Path, directory: Path) -> bool:
+    return path == directory or directory in path.parents
+
+
+def _control_checkout_refusal(cwd: Path, control_checkout: Path) -> str | None:
+    if is_within(cwd, control_checkout):
+        return "workspace-write refuses the control checkout"
+    return None
+
+
+@contextmanager
+def state_lock(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = path.with_name(path.name + ".lock")
+    with lock.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
+
+
+def atomic_write(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            json.dump(state, file, indent=2, sort_keys=True)
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+        parent = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(parent)
+        finally:
+            os.close(parent)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def read_state(path: Path, *, family_required: bool = False) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, dict):
+        return None
+    if family_required and value.get("version") != STATE_VERSION:
+        return None
+    return value
+
+
+def transition(path: Path, state: dict[str, Any], lifecycle: str) -> dict[str, Any]:
+    previous = state.get("lifecycle")
+    if previous not in TRANSITIONS or lifecycle not in TRANSITIONS[previous]:
+        raise ValueError(f"illegal lifecycle transition {previous!r} to {lifecycle!r}")
+    updated = dict(state)
+    updated["lifecycle"] = lifecycle
+    atomic_write(path, updated)
+    return updated
+
+
+def _bounded_integer(value: Any, minimum: int, maximum: int) -> bool:
+    return type(value) is int and minimum <= value <= maximum
+
+
+def _canonical_path(value: Any) -> bool:
+    if not isinstance(value, str) or not value or not Path(value).is_absolute():
+        return False
+    try:
+        return str(Path(value).resolve()) == value
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+BASE_STATE_FIELDS = {"version", "lifecycle", "session_id", "model", "sandbox", "cwd"}
+
+
+def _valid_common_schema(
+    state: dict[str, Any], allowed: set[str], *, effort_levels: set[str]
+) -> bool:
+    if not BASE_STATE_FIELDS.issubset(state):
+        return False
+    if not set(state).issubset(allowed):
+        return False
+    if type(state["version"]) is not int or state["version"] != STATE_VERSION:
+        return False
+    if not isinstance(state["lifecycle"], str) or state["lifecycle"] not in TRANSITIONS:
+        return False
+    if not isinstance(state["session_id"], str):
+        return False
+    if not isinstance(state["model"], str) or not state["model"]:
+        return False
+    if not isinstance(state["sandbox"], str) or state["sandbox"] not in {"read-only", "workspace-write"}:
+        return False
+    if not _canonical_path(state["cwd"]):
+        return False
+    if "effort" in state and (not isinstance(state["effort"], str) or state["effort"] not in effort_levels):
+        return False
+    control = state.get("control_checkout")
+    if control is not None and not _canonical_path(control):
+        return False
+    if state["sandbox"] == "workspace-write":
+        if control is None or is_within(Path(state["cwd"]), Path(control)):
+            return False
+    return True
+
+
+def valid_family_schema(state: dict[str, Any], *, effort_levels: set[str]) -> bool:
+    identity = {"pid", "pgid", "sid", "birth"}
+    if not identity.issubset(state):
+        return False
+    allowed = BASE_STATE_FIELDS | identity | {"control_checkout", "effort"}
+    if not _valid_common_schema(state, allowed, effort_levels=effort_levels):
+        return False
+    for field in ("pid", "pgid", "sid"):
+        if not _bounded_integer(state[field], 1, PID_MAX):
+            return False
+    birth = state["birth"]
+    if not isinstance(birth, dict) or set(birth) != {"seconds", "microseconds"}:
+        return False
+    if not _bounded_integer(birth["seconds"], 1, UINT64_MAX):
+        return False
+    if not _bounded_integer(birth["microseconds"], 0, 999_999):
+        return False
+    return True
+
+
+def valid_portable_schema(state: dict[str, Any], *, effort_levels: set[str]) -> bool:
+    allowed = BASE_STATE_FIELDS | {"control_checkout", "family_semantics", "generation", "effort"}
+    if not _valid_common_schema(state, allowed, effort_levels=effort_levels):
+        return False
+    if state["lifecycle"] != "exited":
+        return False
+    if state.get("family_semantics") != FAMILY_SEMANTICS_UNSUPPORTED:
+        return False
+    if not _bounded_integer(state.get("generation"), 1, UINT64_MAX):
+        return False
+    return True
+
+
+def _libproc() -> ctypes.CDLL | None:
+    if sys.platform != "darwin":
+        return None
+    try:
+        library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        library.proc_pidinfo.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int]
+        library.proc_pidinfo.restype = ctypes.c_int
+        library.proc_listpgrppids.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_int]
+        library.proc_listpgrppids.restype = ctypes.c_int
+        return library
+    except OSError:
+        return None
+
+
+def live_identity(pid: int) -> dict[str, Any] | None:
+    library = _libproc()
+    if library is None:
+        return None
+    bsd = ctypes.create_string_buffer(BSD_SIZE)
+    ctypes.set_errno(0)
+    if library.proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, bsd, BSD_SIZE) != BSD_SIZE:
+        return None
+    cwd = ctypes.create_string_buffer(VNODE_SIZE)
+    ctypes.set_errno(0)
+    if library.proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, cwd, VNODE_SIZE) != VNODE_SIZE:
+        return None
+    try:
+        returned_pid = struct.unpack_from("<I", bsd.raw, 12)[0]
+        pgid = struct.unpack_from("<I", bsd.raw, 100)[0]
+        seconds, microseconds = struct.unpack_from("<QQ", bsd.raw, 120)
+        sid = os.getsid(pid)
+        directory = cwd.raw[VNODE_CWD_OFFSET:].split(b"\0", 1)[0].decode("utf-8")
+        canonical_cwd = str(Path(directory).resolve(strict=True))
+    except (OSError, UnicodeDecodeError, struct.error):
+        return None
+    if returned_pid != pid or not directory:
+        return None
+    return {
+        "pid": pid, "pgid": pgid, "sid": sid, "cwd": canonical_cwd,
+        "birth": {"seconds": seconds, "microseconds": microseconds},
+    }
+
+
+def group_members(pgid: int) -> list[int] | None:
+    library = _libproc()
+    if library is None:
+        return None
+    capacity = 64
+    while capacity <= 65536:
+        values = (ctypes.c_int * capacity)()
+        ctypes.set_errno(0)
+        count = library.proc_listpgrppids(pgid, values, ctypes.sizeof(values))
+        if count < 0 or (count == 0 and ctypes.get_errno()):
+            return None
+        members = list(values[:count])
+        if count < capacity:
+            return members
+        capacity *= 2
+    return None
+
+
+def gate_wait(fd: int) -> None:
+    if os.read(fd, 1) != b"R":
+        os._exit(125)
+
+
+def gated_process(
+    command: list[str], cwd: Path, *, stdin_text: str | None
+) -> tuple[subprocess.Popen[str], int]:
+    """Exec a session-leading gate wrapper; Popen can return before the real exec."""
+    gate_read, gate_write = os.pipe()
+    wrapper = (
+        "import json,os,sys; "
+        "os.setsid(); os.chdir(sys.argv[2]); "
+        "os.read(int(sys.argv[1]), 1) == b'R' or os._exit(125); "
+        "os.execvp(json.loads(sys.argv[3])[0], json.loads(sys.argv[3]))"
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", wrapper, str(gate_read), str(cwd), json.dumps(command)],
+        text=True,
+        stdin=subprocess.PIPE if stdin_text is not None else subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        pass_fds=(gate_read,),
+    )
+    os.close(gate_read)
+    return process, gate_write
+
+
+def establish_family(
+    args: argparse.Namespace,
+    command: list[str],
+    state: dict[str, Any],
+    *,
+    fail: Fail,
+    stdin_text: str | None,
+) -> tuple[subprocess.Popen[str] | None, int | None]:
+    """Persist and release one gated family while the caller holds the state lock."""
+    process, write_fd = gated_process(command, Path(state["cwd"]), stdin_text=stdin_text)
+    pid = process.pid
+    try:
+        identity = None
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            identity = live_identity(pid)
+            if identity and identity["pgid"] == pid and identity["sid"] == pid and identity["cwd"] == state["cwd"]:
+                break
+            time.sleep(0.01)
+        if identity is None or identity["pgid"] != pid or identity["sid"] != pid or identity["cwd"] != state["cwd"]:
+            os.kill(pid, signal.SIGKILL)
+            process.communicate()
+            return None, fail(
+                f"could not establish dedicated worker process family: observed={identity!r} expected_cwd={state['cwd']!r}"
+            )
+        state = {**state, **identity}
+        atomic_write(args.state, state)
+        os.write(write_fd, b"R")
+        transition(args.state, state, "running")
+    finally:
+        os.close(write_fd)
+    return process, None
+
+
+def finish_lifecycle(
+    args: argparse.Namespace,
+    process: subprocess.Popen[str],
+    *,
+    parse: Parse,
+    emit: Emit,
+    fail: Fail,
+    stdin_text: str | None,
+) -> int:
+    stdout, stderr = process.communicate(input=stdin_text) if stdin_text is not None else process.communicate()
+    returncode = process.returncode
+    with state_lock(args.state):
+        current = read_state(args.state, family_required=True)
+        if current and current.get("lifecycle") in {"launching", "running"}:
+            state = transition(args.state, current, "running") if current["lifecycle"] == "launching" else current
+            transition(args.state, state, "exited")
+    if returncode:
+        sys.stdout.write(stdout)
+        sys.stderr.write(stderr)
+        return returncode
+    session_id, message, metadata, error = parse(stdout)
+    if error:
+        return fail(error)
+    with state_lock(args.state):
+        current = read_state(args.state, family_required=True)
+        if current is None:
+            return fail("state file was lost during worker execution")
+        current["session_id"] = session_id
+        atomic_write(args.state, current)
+    emit(current, message or "", metadata)
+    return 0
+
+
+def run_portable(
+    args: argparse.Namespace,
+    command: list[str],
+    state: dict[str, Any],
+    generation: int,
+    *,
+    parse: Parse,
+    emit: Emit,
+    fail: Fail,
+    stdin_text: str | None,
+) -> int:
+    """Run under the state lock and persist no recoverable process-family claim."""
+    run_arguments: dict[str, Any] = {
+        "cwd": Path(state["cwd"]),
+        "text": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "check": False,
+    }
+    if stdin_text is None:
+        run_arguments["stdin"] = subprocess.DEVNULL
+    else:
+        run_arguments["input"] = stdin_text
+    result = subprocess.run(command, **run_arguments)
+    terminal = {
+        **state,
+        "lifecycle": "exited",
+        "family_semantics": FAMILY_SEMANTICS_UNSUPPORTED,
+        "generation": generation,
+    }
+    if result.returncode:
+        atomic_write(args.state, terminal)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        return result.returncode
+    session_id, message, metadata, error = parse(result.stdout)
+    if session_id is not None:
+        terminal["session_id"] = session_id
+    atomic_write(args.state, terminal)
+    if error is not None:
+        return fail(error)
+    emit(terminal, message or "", metadata)
+    return 0
+
+
+def run_lifecycle(
+    args: argparse.Namespace,
+    command: list[str],
+    state: dict[str, Any],
+    *,
+    expected: dict[str, Any] | None = None,
+    parse: Parse,
+    emit: Emit,
+    fail: Fail,
+    stdin_text: str | None,
+    effort_levels: set[str],
+) -> int:
+    with state_lock(args.state):
+        if expected is not None and read_state(args.state) != expected:
+            return fail("resume requires an unchanged terminal worker state")
+        if _libproc() is None:
+            previous_generation = (
+                expected["generation"]
+                if expected is not None and valid_portable_schema(expected, effort_levels=effort_levels)
+                else 0
+            )
+            if previous_generation == UINT64_MAX:
+                return fail("portable state generation exhausted")
+            return run_portable(
+                args, command, state, previous_generation + 1,
+                parse=parse, emit=emit, fail=fail, stdin_text=stdin_text,
+            )
+        process, error = establish_family(
+            args, command, state, fail=fail, stdin_text=stdin_text
+        )
+        if error is not None:
+            return error
+    assert process is not None
+    return finish_lifecycle(
+        args, process, parse=parse, emit=emit, fail=fail, stdin_text=stdin_text
+    )
+
+
+def prepare_start(
+    args: argparse.Namespace, *, effort_levels: set[str], default_effort: str
+) -> tuple[dict[str, Any] | None, str | None]:
+    if args.sandbox == "workspace-write":
+        if args.control_checkout is None:
+            return None, "workspace-write requires --control-checkout"
+        error = _control_checkout_refusal(args.cwd, args.control_checkout)
+        if error:
+            return None, error
+    effort = getattr(args, "effort", default_effort)
+    if effort not in effort_levels:
+        return None, f"--effort must be one of {sorted(effort_levels)}"
+    state: dict[str, Any] = {
+        "version": STATE_VERSION,
+        "lifecycle": "launching",
+        "model": args.model,
+        "sandbox": args.sandbox,
+        "cwd": str(args.cwd),
+        "session_id": "",
+    }
+    if effort != default_effort:
+        state["effort"] = effort
+    if args.control_checkout:
+        state["control_checkout"] = str(args.control_checkout)
+    return state, None
+
+
+def prepare_resume(
+    args: argparse.Namespace, *, effort_levels: set[str], default_effort: str
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, str | None]:
+    snapshot = read_state(args.state)
+    with state_lock(args.state):
+        state = read_state(args.state)
+        if state != snapshot:
+            return None, None, "resume requires an unchanged terminal worker state"
+        if state is None:
+            return None, None, "state file is malformed or incomplete"
+        if "version" not in state:
+            legacy = {"session_id", "model", "sandbox", "cwd"}
+            if not legacy.issubset(state) or not set(state).issubset(legacy | {"control_checkout", "effort"}):
+                return None, None, "state file is malformed or incomplete"
+            if not all(isinstance(state[key], str) and state[key] for key in legacy):
+                return None, None, "state file is malformed or incomplete"
+        elif not (
+            valid_family_schema(state, effort_levels=effort_levels)
+            or valid_portable_schema(state, effort_levels=effort_levels)
+        ):
+            return None, None, "state file is malformed or incomplete"
+        elif state["lifecycle"] not in TERMINAL or not state["session_id"]:
+            return None, None, "resume requires a terminal worker state with a session ID"
+        try:
+            cwd = resolved_directory(state["cwd"])
+        except (OSError, argparse.ArgumentTypeError):
+            return None, None, "state file has an invalid cwd"
+        sandbox = state.get("sandbox")
+        if sandbox not in {"read-only", "workspace-write"}:
+            return None, None, "state file has an invalid sandbox"
+        if sandbox == "workspace-write":
+            try:
+                control = resolved_directory(state["control_checkout"])
+            except (KeyError, OSError, argparse.ArgumentTypeError):
+                return None, None, "state file is missing the control checkout"
+            error = _control_checkout_refusal(cwd, control)
+            if error:
+                return None, None, error
+        effort = state.get("effort", default_effort)
+        if effort not in effort_levels:
+            return None, None, "state file has an invalid effort"
+        fresh = {
+            "version": STATE_VERSION,
+            "lifecycle": "launching",
+            "session_id": state["session_id"],
+            "model": state["model"],
+            "sandbox": sandbox,
+            "cwd": str(cwd),
+        }
+        if effort != default_effort:
+            fresh["effort"] = effort
+        if sandbox == "workspace-write":
+            fresh["control_checkout"] = str(control)
+    return fresh, state, None
+
+
+def family_state(
+    path: Path, expected: Path, *, effort_levels: set[str]
+) -> tuple[dict[str, Any] | None, str | None]:
+    state = read_state(path)
+    if state is None:
+        return None, "state is missing, corrupt, or legacy"
+    version = state.get("version")
+    if "version" not in state or (type(version) is int and version != STATE_VERSION):
+        return None, "state is missing, corrupt, or legacy"
+    if not (
+        valid_family_schema(state, effort_levels=effort_levels)
+        or valid_portable_schema(state, effort_levels=effort_levels)
+    ):
+        return None, "state is malformed"
+    if state["cwd"] != str(expected):
+        return None, f"cwd mismatch: recorded={state['cwd']!r} expected={str(expected)!r}"
+    return state, None
+
+
+def matching_leader(state: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    observed = live_identity(state["pid"])
+    if observed is None:
+        return None, "leader identity probe failed"
+    recorded = {key: state[key] for key in ("pid", "pgid", "sid", "cwd", "birth")}
+    if observed != recorded:
+        return None, f"identity mismatch: recorded={recorded!r} observed={observed!r}"
+    return observed, None
+
+
+def verify_worker(
+    args: argparse.Namespace, *, effort_levels: set[str]
+) -> tuple[int | None, str | None]:
+    with state_lock(args.state):
+        state, error = family_state(args.state, args.cwd, effort_levels=effort_levels)
+        if error:
+            return None, error
+        if _libproc() is None:
+            return None, UNSUPPORTED
+        assert state is not None
+        if valid_portable_schema(state, effort_levels=effort_levels):
+            return None, "state has no recoverable process family"
+        members = group_members(state["pgid"])
+        if members is None:
+            return None, "process-group probe failed"
+        if members:
+            return None, f"worker process group still has members: {members}"
+        if state["lifecycle"] not in TERMINAL:
+            if state["lifecycle"] != "stopping":
+                state = transition(args.state, state, "stopping")
+            transition(args.state, state, "stopped")
+    return 0, None
+
+
+def stop_worker(
+    args: argparse.Namespace, *, effort_levels: set[str]
+) -> tuple[int | None, str | None]:
+    with state_lock(args.state):
+        state, error = family_state(args.state, args.cwd, effort_levels=effort_levels)
+        if error:
+            return None, error
+        if _libproc() is None:
+            return None, UNSUPPORTED
+        assert state is not None
+        if valid_portable_schema(state, effort_levels=effort_levels):
+            return None, "state has no recoverable process family"
+        _, error = matching_leader(state)
+        if error and state["lifecycle"] not in TERMINAL:
+            if "identity mismatch:" in error:
+                return None, error
+            members = group_members(state["pgid"])
+            if members is None:
+                return None, "process-group probe failed"
+            if not members:
+                if state["lifecycle"] != "stopping":
+                    state = transition(args.state, state, "stopping")
+                transition(args.state, state, "stopped")
+                return 0, None
+            state = transition(args.state, state, "stopping") if state["lifecycle"] != "stopping" else state
+            try:
+                os.killpg(state["pgid"], signal.SIGKILL)
+            except OSError as exc:
+                return None, f"KILL refused: {exc}"
+            return 0, None
+        members = group_members(state["pgid"])
+        if members is None:
+            return None, "process-group probe failed"
+        if not members:
+            if state["lifecycle"] not in TERMINAL:
+                if state["lifecycle"] != "stopping":
+                    state = transition(args.state, state, "stopping")
+                transition(args.state, state, "stopped")
+            return 0, None
+        if state["lifecycle"] in TERMINAL:
+            try:
+                os.killpg(state["pgid"], signal.SIGKILL)
+            except OSError as exc:
+                return None, f"KILL refused: {exc}"
+            deadline = time.monotonic() + args.grace_seconds
+            while time.monotonic() < deadline:
+                members = group_members(state["pgid"])
+                if members is None:
+                    return None, "process-group probe failed"
+                if not members:
+                    return verify_worker(args, effort_levels=effort_levels)
+                time.sleep(0.05)
+            return None, f"worker process group still has members: {members}"
+        if state["lifecycle"] != "stopping":
+            state = transition(args.state, state, "stopping")
+        try:
+            os.killpg(state["pgid"], signal.SIGTERM)
+        except OSError as exc:
+            return None, f"TERM refused: {exc}"
+    deadline = time.monotonic() + args.grace_seconds
+    while time.monotonic() < deadline:
+        members = group_members(state["pgid"])
+        if members is None:
+            return None, "process-group probe failed"
+        if not members:
+            with state_lock(args.state):
+                current = read_state(args.state, family_required=True)
+                if current and current["lifecycle"] == "stopping":
+                    transition(args.state, current, "stopped")
+            return 0, None
+        time.sleep(0.05)
+    members = group_members(state["pgid"])
+    if members is None:
+        return None, "process-group probe failed"
+    if not members:
+        return 0, None
+    try:
+        os.killpg(state["pgid"], signal.SIGKILL)
+    except OSError as exc:
+        return None, f"KILL refused: {exc}"
+    deadline = time.monotonic() + args.grace_seconds
+    while time.monotonic() < deadline:
+        members = group_members(state["pgid"])
+        if members is None:
+            return None, "process-group probe failed"
+        if not members:
+            break
+        time.sleep(0.05)
+    return verify_worker(args, effort_levels=effort_levels)

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2420,6 +2420,46 @@ class WorkerEffortDialTests(unittest.TestCase):
         )
         self.assertEqual(CLAUDE_WORKER_MODULE.effort_of(state), "medium")
 
+    def test_claude_max_effort_runs_start_resume_stop_and_verify_through_shared_lifecycle(self):
+        self.environment["FAKE_OUTPUT"] = json.dumps(
+            {"session_id": "worker-1", "result": "started", "is_error": False}
+        )
+        started = self.run_claude(
+            "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "--model", "sonnet", "--sandbox", "read-only", "--effort", "max",
+            "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.assertEqual(json.loads(started.stdout)["final_message"], "started")
+
+        self.environment["FAKE_OUTPUT"] = json.dumps(
+            {"session_id": "worker-1", "result": "resumed", "is_error": False}
+        )
+        resumed = self.run_claude(
+            "resume", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "continue",
+        )
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        self.assertEqual(json.loads(resumed.stdout)["final_message"], "resumed")
+        self.assertEqual(
+            json.loads(self.state.read_text(encoding="utf-8"))["effort"], "max"
+        )
+
+        for command in ("stop", "verify"):
+            with self.subTest(command=command):
+                result = self.run_claude(
+                    command, "--state", str(self.state), "--cwd", str(self.worktree)
+                )
+                if sys.platform == "darwin":
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertEqual(
+                        result.stderr,
+                        f"claude-worker: {LIFECYCLE_MODULE.UNSUPPORTED}\n",
+                    )
+                self.assertNotIn("malformed", result.stderr)
+
 
 class OrchestrateAdapterDispatchTests(unittest.TestCase):
     def test_skill_bans_agent_tool_workflow_tool_and_background_agents_for_dispatch(self):
@@ -2514,8 +2554,8 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             "is_within", "state_lock", "atomic_write", "read_state", "transition",
             "_bounded_integer", "_canonical_path", "BASE_STATE_FIELDS",
             "_valid_common_schema", "valid_family_schema", "valid_portable_schema",
-            "_libproc", "live_identity", "group_members", "gate_wait",
-            "gated_process", "establish_family", "finish_lifecycle", "run_portable",
+            "_libproc", "live_identity", "group_members", "gated_process",
+            "establish_family", "finish_lifecycle", "run_portable",
             "run_lifecycle", "family_state", "matching_leader",
         )
         self.assertTrue(WORKER_LIFECYCLE.exists())

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -29,6 +29,7 @@ CBM_LIFECYCLE = ROOT / "skills" / "tools" / "cbm-onboard" / "scripts" / "cbm-lif
 SPIN_SCRIPT = ROOT / "skills" / "tools" / "spin-worktree" / "scripts" / "spin-worktree.py"
 CODEX_WORKER = ROOT / "skills" / "drivers" / "orchestrate" / "scripts" / "codex-worker.py"
 CLAUDE_WORKER = ROOT / "skills" / "drivers" / "orchestrate" / "scripts" / "claude-worker.py"
+WORKER_LIFECYCLE = ROOT / "skills" / "drivers" / "orchestrate" / "scripts" / "worker_lifecycle.py"
 UI_CRAFT_AUDIT = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "audit.md"
 UI_CRAFT_CRITIQUE = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "critique.md"
 UI_CRAFT_SWEEP = ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "behavior-sweep.md"
@@ -36,6 +37,12 @@ UI_CRAFT_ROUTE = ROOT / "skills" / "drivers" / "ui-craft" / "scripts" / "route.m
 README = ROOT / "README.md"
 BEGIN_IGNORE = "# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
 BEGIN_HOOK = "# >>> cbm-onboard managed reindex >>>"
+
+LIFECYCLE_SPEC = importlib.util.spec_from_file_location("worker_lifecycle", WORKER_LIFECYCLE)
+assert LIFECYCLE_SPEC and LIFECYCLE_SPEC.loader
+LIFECYCLE_MODULE = importlib.util.module_from_spec(LIFECYCLE_SPEC)
+sys.modules["worker_lifecycle"] = LIFECYCLE_MODULE
+LIFECYCLE_SPEC.loader.exec_module(LIFECYCLE_MODULE)
 
 WORKER_SPEC = importlib.util.spec_from_file_location("orchestrate_worker", CODEX_WORKER)
 assert WORKER_SPEC and WORKER_SPEC.loader
@@ -2213,7 +2220,7 @@ class WorkerEffortDialTests(unittest.TestCase):
 
     def test_codex_replays_persisted_effort_on_resume(self):
         legacy = {
-            "version": WORKER_MODULE.STATE_VERSION, "lifecycle": "exited",
+            "version": LIFECYCLE_MODULE.STATE_VERSION, "lifecycle": "exited",
             "session_id": "worker-1", "model": "Terra", "sandbox": "read-only",
             "cwd": str(self.worktree.resolve()), "effort": "high",
             "family_semantics": "unsupported", "generation": 1,
@@ -2279,7 +2286,7 @@ class WorkerEffortDialTests(unittest.TestCase):
 
     def test_claude_replays_persisted_effort_on_resume(self):
         legacy = {
-            "version": CLAUDE_WORKER_MODULE.STATE_VERSION, "lifecycle": "exited",
+            "version": LIFECYCLE_MODULE.STATE_VERSION, "lifecycle": "exited",
             "session_id": "worker-1", "model": "sonnet", "sandbox": "read-only",
             "cwd": str(self.worktree.resolve()), "effort": "high",
             "family_semantics": "unsupported", "generation": 1,
@@ -2337,7 +2344,7 @@ class WorkerEffortDialTests(unittest.TestCase):
             with self.subTest(sandbox=sandbox):
                 self.arguments.unlink(missing_ok=True)
                 legacy = {
-                    "version": CLAUDE_WORKER_MODULE.STATE_VERSION, "lifecycle": "exited",
+                    "version": LIFECYCLE_MODULE.STATE_VERSION, "lifecycle": "exited",
                     "session_id": "worker-1", "model": "sonnet", "sandbox": sandbox,
                     "cwd": str(self.worktree.resolve()),
                     "family_semantics": "unsupported", "generation": 1,
@@ -2392,17 +2399,25 @@ class WorkerEffortDialTests(unittest.TestCase):
         # schema superset, never in BASE_STATE_FIELDS, so a pre-existing state
         # file with no "effort" key stays valid at STATE_VERSION 2 and reads
         # back as the medium default on both adapters.
-        self.assertEqual(WORKER_MODULE.STATE_VERSION, 2)
-        self.assertEqual(CLAUDE_WORKER_MODULE.STATE_VERSION, 2)
+        self.assertEqual(LIFECYCLE_MODULE.STATE_VERSION, 2)
+        self.assertEqual(LIFECYCLE_MODULE.STATE_VERSION, 2)
         state = {
             "version": 2, "lifecycle": "running", "session_id": "s",
             "model": "Terra", "sandbox": "read-only", "cwd": str(self.worktree.resolve()),
             "pid": 1, "pgid": 1, "sid": 1, "birth": {"seconds": 1, "microseconds": 0},
         }
-        self.assertTrue(WORKER_MODULE.valid_family_schema(state))
+        self.assertTrue(
+            LIFECYCLE_MODULE.valid_family_schema(
+                state, effort_levels=WORKER_MODULE.EFFORT_LEVELS
+            )
+        )
         self.assertEqual(WORKER_MODULE.effort_of(state), "medium")
         state["model"] = "sonnet"
-        self.assertTrue(CLAUDE_WORKER_MODULE.valid_family_schema(state))
+        self.assertTrue(
+            LIFECYCLE_MODULE.valid_family_schema(
+                state, effort_levels=CLAUDE_WORKER_MODULE.EFFORT_LEVELS
+            )
+        )
         self.assertEqual(CLAUDE_WORKER_MODULE.effort_of(state), "medium")
 
 
@@ -2463,7 +2478,7 @@ class WorkerLifecycleContractTests(unittest.TestCase):
 
     def family_state(self, lifecycle="running", session_id="worker-1"):
         return {
-            "version": WORKER_MODULE.STATE_VERSION,
+            "version": LIFECYCLE_MODULE.STATE_VERSION,
             "lifecycle": lifecycle,
             "session_id": session_id,
             "model": "Terra",
@@ -2473,13 +2488,13 @@ class WorkerLifecycleContractTests(unittest.TestCase):
 
     def portable_state(self, generation=1):
         return {
-            "version": WORKER_MODULE.STATE_VERSION,
+            "version": LIFECYCLE_MODULE.STATE_VERSION,
             "lifecycle": "exited",
             "session_id": "worker-1",
             "model": "Terra",
             "sandbox": "read-only",
             "cwd": str(self.cwd),
-            "family_semantics": WORKER_MODULE.FAMILY_SEMANTICS_UNSUPPORTED,
+            "family_semantics": LIFECYCLE_MODULE.FAMILY_SEMANTICS_UNSUPPORTED,
             "generation": generation,
         }
 
@@ -2489,31 +2504,158 @@ class WorkerLifecycleContractTests(unittest.TestCase):
     def resume_arguments(self):
         return argparse.Namespace(state=self.state, codex="codex", prompt="continue")
 
+    def test_moved_lifecycle_names_have_one_patchable_owner(self):
+        """A moved-name re-export can make a patch resolve without intercepting."""
+        moved = (
+            "STATE_VERSION", "UNSUPPORTED", "FAMILY_SEMANTICS_UNSUPPORTED",
+            "TERMINAL", "TRANSITIONS", "PROC_PIDTBSDINFO",
+            "PROC_PIDVNODEPATHINFO", "BSD_SIZE", "VNODE_SIZE",
+            "VNODE_CWD_OFFSET", "PID_MAX", "UINT64_MAX", "resolved_directory",
+            "is_within", "state_lock", "atomic_write", "read_state", "transition",
+            "_bounded_integer", "_canonical_path", "BASE_STATE_FIELDS",
+            "_valid_common_schema", "valid_family_schema", "valid_portable_schema",
+            "_libproc", "live_identity", "group_members", "gate_wait",
+            "gated_process", "establish_family", "finish_lifecycle", "run_portable",
+            "run_lifecycle", "family_state", "matching_leader",
+        )
+        self.assertTrue(WORKER_LIFECYCLE.exists())
+        for name in moved:
+            self.assertIn(name, LIFECYCLE_MODULE.__dict__)
+            self.assertNotIn(name, WORKER_MODULE.__dict__)
+            self.assertNotIn(name, CLAUDE_WORKER_MODULE.__dict__)
+        for adapter in (CODEX_WORKER, CLAUDE_WORKER):
+            source = adapter.read_text(encoding="utf-8")
+            for name in moved:
+                self.assertIsNone(
+                    re.search(rf"(?<![.\w]){re.escape(name)}\(", source),
+                    f"{adapter.name} calls moved name {name} without lifecycle qualification",
+                )
+
+    def test_both_adapters_route_all_four_commands_through_shared_lifecycle(self):
+        expected = self.portable_state()
+        fresh = {
+            "version": LIFECYCLE_MODULE.STATE_VERSION,
+            "lifecycle": "launching",
+            "session_id": "worker-1",
+            "model": "model",
+            "sandbox": "read-only",
+            "cwd": str(self.cwd),
+        }
+        for adapter, binary_name, stdin_text in (
+            (WORKER_MODULE, "codex", None),
+            (CLAUDE_WORKER_MODULE, "claude", "continue"),
+        ):
+            with self.subTest(adapter=adapter.__name__):
+                arguments = argparse.Namespace(
+                    state=self.state,
+                    cwd=self.cwd,
+                    sandbox="read-only",
+                    control_checkout=None,
+                    model="model",
+                    effort="medium",
+                    prompt="continue",
+                    codex="codex",
+                    claude="claude",
+                    grace_seconds=0.01,
+                )
+                with (
+                    mock.patch.object(
+                        LIFECYCLE_MODULE, "prepare_start", return_value=(fresh, None)
+                    ) as prepare_start,
+                    mock.patch.object(
+                        LIFECYCLE_MODULE, "run_lifecycle", return_value=0
+                    ) as launch,
+                ):
+                    self.assertEqual(adapter.start(arguments), 0)
+                    prepare_start.assert_called_once()
+                    self.assertEqual(launch.call_args.args[2], fresh)
+                    self.assertIs(launch.call_args.kwargs["parse"], adapter.parse)
+                    self.assertIs(launch.call_args.kwargs["emit"], adapter.emit)
+                    self.assertIs(launch.call_args.kwargs["fail"], adapter.fail)
+                    self.assertEqual(launch.call_args.kwargs["stdin_text"], stdin_text)
+                    self.assertEqual(launch.call_args.args[1][0], getattr(arguments, binary_name))
+                with (
+                    mock.patch.object(
+                        LIFECYCLE_MODULE,
+                        "prepare_resume",
+                        return_value=(fresh, expected, None),
+                    ) as prepare_resume,
+                    mock.patch.object(
+                        LIFECYCLE_MODULE, "run_lifecycle", return_value=0
+                    ) as launch,
+                ):
+                    self.assertEqual(adapter.resume(arguments), 0)
+                    prepare_resume.assert_called_once()
+                    self.assertEqual(launch.call_args.kwargs["expected"], expected)
+                    self.assertEqual(launch.call_args.kwargs["stdin_text"], stdin_text)
+                with mock.patch.object(
+                    LIFECYCLE_MODULE, "stop_worker", return_value=(0, None)
+                ) as stop_worker:
+                    self.assertEqual(adapter.stop(arguments), 0)
+                    stop_worker.assert_called_once()
+                with mock.patch.object(
+                    LIFECYCLE_MODULE, "verify_worker", return_value=(0, None)
+                ) as verify_worker:
+                    self.assertEqual(adapter.verify(arguments), 0)
+                    verify_worker.assert_called_once()
+
+    def test_none_stdin_keeps_the_portable_launch_closed(self):
+        completed = subprocess.CompletedProcess(["worker"], 0, "output", "")
+        state = {
+            "version": LIFECYCLE_MODULE.STATE_VERSION,
+            "lifecycle": "launching",
+            "session_id": "",
+            "model": "model",
+            "sandbox": "read-only",
+            "cwd": str(self.cwd),
+        }
+        with (
+            mock.patch.object(
+                LIFECYCLE_MODULE.subprocess, "run", return_value=completed
+            ) as launch,
+            mock.patch.object(LIFECYCLE_MODULE, "atomic_write"),
+        ):
+            self.assertEqual(
+                LIFECYCLE_MODULE.run_portable(
+                    argparse.Namespace(state=self.state),
+                    ["worker"],
+                    state,
+                    1,
+                    parse=lambda _output: ("session", "done", None, None),
+                    emit=lambda *_args: None,
+                    fail=lambda _message: 1,
+                    stdin_text=None,
+                ),
+                0,
+            )
+        self.assertIs(launch.call_args.kwargs["stdin"], subprocess.DEVNULL)
+        self.assertNotIn("input", launch.call_args.kwargs)
+
     def test_transition_table_and_atomic_replace_fsync_the_state_and_parent(self):
-        self.assertEqual(WORKER_MODULE.TRANSITIONS["launching"], {"running", "stopping", "exited"})
-        self.assertEqual(WORKER_MODULE.TRANSITIONS["running"], {"stopping", "exited"})
-        self.assertEqual(WORKER_MODULE.TRANSITIONS["stopping"], {"stopped", "exited"})
+        self.assertEqual(LIFECYCLE_MODULE.TRANSITIONS["launching"], {"running", "stopping", "exited"})
+        self.assertEqual(LIFECYCLE_MODULE.TRANSITIONS["running"], {"stopping", "exited"})
+        self.assertEqual(LIFECYCLE_MODULE.TRANSITIONS["stopping"], {"stopped", "exited"})
         with mock.patch.object(WORKER_MODULE.os, "fsync", wraps=os.fsync) as fsync, mock.patch.object(WORKER_MODULE.os, "replace", wraps=os.replace) as replace:
-            WORKER_MODULE.atomic_write(self.state, self.family_state("launching"))
+            LIFECYCLE_MODULE.atomic_write(self.state, self.family_state("launching"))
         self.assertEqual(replace.call_count, 1)
         self.assertGreaterEqual(fsync.call_count, 2)
-        state = WORKER_MODULE.read_state(self.state, family_required=True)
-        self.assertEqual(WORKER_MODULE.transition(self.state, state, "running")["lifecycle"], "running")
+        state = LIFECYCLE_MODULE.read_state(self.state, family_required=True)
+        self.assertEqual(LIFECYCLE_MODULE.transition(self.state, state, "running")["lifecycle"], "running")
         with self.assertRaises(ValueError):
-            WORKER_MODULE.transition(self.state, state, "stopped")
+            LIFECYCLE_MODULE.transition(self.state, state, "stopped")
 
     def test_every_legal_transition_is_persisted_and_every_other_edge_is_rejected(self):
-        for source, destinations in WORKER_MODULE.TRANSITIONS.items():
+        for source, destinations in LIFECYCLE_MODULE.TRANSITIONS.items():
             for destination in destinations:
                 with self.subTest(source=source, destination=destination):
-                    WORKER_MODULE.atomic_write(self.state, self.family_state(source))
-                    state = WORKER_MODULE.read_state(self.state, family_required=True)
-                    self.assertEqual(WORKER_MODULE.transition(self.state, state, destination)["lifecycle"], destination)
-            illegal = next(candidate for candidate in WORKER_MODULE.TRANSITIONS if candidate not in destinations)
+                    LIFECYCLE_MODULE.atomic_write(self.state, self.family_state(source))
+                    state = LIFECYCLE_MODULE.read_state(self.state, family_required=True)
+                    self.assertEqual(LIFECYCLE_MODULE.transition(self.state, state, destination)["lifecycle"], destination)
+            illegal = next(candidate for candidate in LIFECYCLE_MODULE.TRANSITIONS if candidate not in destinations)
             with self.subTest(source=source, illegal=illegal):
-                WORKER_MODULE.atomic_write(self.state, self.family_state(source))
+                LIFECYCLE_MODULE.atomic_write(self.state, self.family_state(source))
                 with self.assertRaises(ValueError):
-                    WORKER_MODULE.transition(self.state, WORKER_MODULE.read_state(self.state), illegal)
+                    LIFECYCLE_MODULE.transition(self.state, LIFECYCLE_MODULE.read_state(self.state), illegal)
 
     def test_missing_corrupt_stale_and_legacy_state_are_rejected_by_stop_and_verify(self):
         for name, contents in (
@@ -2522,7 +2664,7 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             ("stale", json.dumps({"version": 1})),
             ("legacy", json.dumps({"session_id": "old", "model": "Terra", "sandbox": "read-only", "cwd": str(self.cwd)})),
         ):
-            with self.subTest(name=name), mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
+            with self.subTest(name=name), mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
                 if contents is None:
                     self.state.unlink(missing_ok=True)
                 else:
@@ -2592,13 +2734,13 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             )
             for operation_name, operation, arguments in operations:
                 with self.subTest(name=name, operation=operation_name):
-                    WORKER_MODULE.atomic_write(self.state, state)
+                    LIFECYCLE_MODULE.atomic_write(self.state, state)
                     error = io.StringIO()
                     with (
-                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()) as libproc,
-                        mock.patch.object(WORKER_MODULE, "gated_process") as gated,
-                        mock.patch.object(WORKER_MODULE, "live_identity") as identity,
-                        mock.patch.object(WORKER_MODULE, "group_members") as members,
+                        mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()) as libproc,
+                        mock.patch.object(LIFECYCLE_MODULE, "gated_process") as gated,
+                        mock.patch.object(LIFECYCLE_MODULE, "live_identity") as identity,
+                        mock.patch.object(LIFECYCLE_MODULE, "group_members") as members,
                         mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
                         redirect_stderr(error),
                     ):
@@ -2632,13 +2774,13 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             )
             for operation_name, operation, arguments in operations:
                 with self.subTest(name=name, operation=operation_name):
-                    WORKER_MODULE.atomic_write(self.state, state)
+                    LIFECYCLE_MODULE.atomic_write(self.state, state)
                     error = io.StringIO()
                     with (
-                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()) as libproc,
-                        mock.patch.object(WORKER_MODULE, "gated_process") as gated,
-                        mock.patch.object(WORKER_MODULE, "live_identity") as identity,
-                        mock.patch.object(WORKER_MODULE, "group_members") as members,
+                        mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()) as libproc,
+                        mock.patch.object(LIFECYCLE_MODULE, "gated_process") as gated,
+                        mock.patch.object(LIFECYCLE_MODULE, "live_identity") as identity,
+                        mock.patch.object(LIFECYCLE_MODULE, "group_members") as members,
                         mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
                         redirect_stderr(error),
                     ):
@@ -2651,19 +2793,19 @@ class WorkerLifecycleContractTests(unittest.TestCase):
                     killpg.assert_not_called()
 
     def test_unsupported_platform_returns_the_exact_code_without_signaling(self):
-        WORKER_MODULE.atomic_write(self.state, self.family_state())
+        LIFECYCLE_MODULE.atomic_write(self.state, self.family_state())
         for operation in (WORKER_MODULE.stop, WORKER_MODULE.verify):
             with self.subTest(operation=operation.__name__):
                 error = io.StringIO()
                 with (
-                    mock.patch.object(WORKER_MODULE, "_libproc", return_value=None),
+                    mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=None),
                     mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
                     redirect_stderr(error),
                 ):
                     self.assertEqual(operation(self.arguments()), 1)
                 self.assertEqual(
                     error.getvalue(),
-                    f"codex-worker: {WORKER_MODULE.UNSUPPORTED}\n",
+                    f"codex-worker: {LIFECYCLE_MODULE.UNSUPPORTED}\n",
                 )
                 killpg.assert_not_called()
 
@@ -2683,17 +2825,17 @@ class WorkerLifecycleContractTests(unittest.TestCase):
         )
         completed = subprocess.CompletedProcess([], 0, stdout=output, stderr="")
         with (
-            mock.patch.object(WORKER_MODULE, "_libproc", return_value=None),
+            mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=None),
             mock.patch.object(WORKER_MODULE.subprocess, "run", return_value=completed) as run_worker,
-            mock.patch.object(WORKER_MODULE, "gated_process") as gated,
+            mock.patch.object(LIFECYCLE_MODULE, "gated_process") as gated,
             mock.patch.object(WORKER_MODULE, "latest_rate_limits", return_value=None),
             redirect_stdout(io.StringIO()),
             redirect_stderr(io.StringIO()),
         ):
             self.assertEqual(WORKER_MODULE.start(arguments), 0)
 
-        state = WORKER_MODULE.read_state(self.state)
-        self.assertEqual(state["version"], WORKER_MODULE.STATE_VERSION)
+        state = LIFECYCLE_MODULE.read_state(self.state)
+        self.assertEqual(state["version"], LIFECYCLE_MODULE.STATE_VERSION)
         self.assertEqual(state["lifecycle"], "exited")
         self.assertEqual(state["session_id"], "worker-1")
         self.assertEqual(state["family_semantics"], "unsupported")
@@ -2704,9 +2846,9 @@ class WorkerLifecycleContractTests(unittest.TestCase):
 
         refusal = io.StringIO()
         with (
-            mock.patch.object(WORKER_MODULE, "_libproc", return_value=None),
+            mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=None),
             mock.patch.object(WORKER_MODULE.subprocess, "run", return_value=completed) as resume_worker,
-            mock.patch.object(WORKER_MODULE, "gated_process") as resume_gate,
+            mock.patch.object(LIFECYCLE_MODULE, "gated_process") as resume_gate,
             mock.patch.object(WORKER_MODULE, "latest_rate_limits", return_value=None),
             mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
             redirect_stdout(io.StringIO()),
@@ -2716,21 +2858,25 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             self.assertEqual(WORKER_MODULE.stop(self.arguments()), 1)
             self.assertEqual(WORKER_MODULE.verify(self.arguments()), 1)
 
-        resumed = WORKER_MODULE.read_state(self.state)
-        self.assertTrue(WORKER_MODULE.valid_portable_schema(resumed))
+        resumed = LIFECYCLE_MODULE.read_state(self.state)
+        self.assertTrue(
+            LIFECYCLE_MODULE.valid_portable_schema(
+                resumed, effort_levels=WORKER_MODULE.EFFORT_LEVELS
+            )
+        )
         self.assertEqual(resumed["generation"], 2)
         self.assertIn("resume", resume_worker.call_args.args[0])
         resume_gate.assert_not_called()
         self.assertEqual(
             refusal.getvalue(),
-            f"codex-worker: {WORKER_MODULE.UNSUPPORTED}\n" * 2,
+            f"codex-worker: {LIFECYCLE_MODULE.UNSUPPORTED}\n" * 2,
         )
         killpg.assert_not_called()
 
         with (
-            mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
-            mock.patch.object(WORKER_MODULE, "live_identity") as identity,
-            mock.patch.object(WORKER_MODULE, "group_members") as members,
+            mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()),
+            mock.patch.object(LIFECYCLE_MODULE, "live_identity") as identity,
+            mock.patch.object(LIFECYCLE_MODULE, "group_members") as members,
             mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
             redirect_stderr(io.StringIO()),
         ):
@@ -2741,24 +2887,25 @@ class WorkerLifecycleContractTests(unittest.TestCase):
         killpg.assert_not_called()
 
     def test_already_exited_leader_with_empty_group_stops_without_a_signal(self):
-        WORKER_MODULE.atomic_write(self.state, self.family_state())
-        with mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()), mock.patch.object(WORKER_MODULE, "live_identity", return_value=None), mock.patch.object(WORKER_MODULE, "group_members", return_value=[]), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
+        LIFECYCLE_MODULE.atomic_write(self.state, self.family_state())
+        with mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()), mock.patch.object(LIFECYCLE_MODULE, "live_identity", return_value=None), mock.patch.object(LIFECYCLE_MODULE, "group_members", return_value=[]), mock.patch.object(WORKER_MODULE.os, "killpg") as killpg:
             self.assertEqual(WORKER_MODULE.stop(self.arguments()), 0)
-            self.assertEqual(WORKER_MODULE.read_state(self.state)["lifecycle"], "stopped")
+            self.assertEqual(LIFECYCLE_MODULE.read_state(self.state)["lifecycle"], "stopped")
             killpg.assert_not_called()
 
     @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_launch_gate_eof_exits_before_exec_with_a_dedicated_session_identity(self):
         marker = self.root / "executed"
-        process, release = WORKER_MODULE.gated_process(
+        process, release = LIFECYCLE_MODULE.gated_process(
             [sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).touch()"],
             self.cwd,
+            stdin_text=None,
         )
         try:
             deadline = time.monotonic() + 1
             identity = None
             while time.monotonic() < deadline:
-                identity = WORKER_MODULE.live_identity(process.pid)
+                identity = LIFECYCLE_MODULE.live_identity(process.pid)
                 if identity and identity["pid"] == identity["pgid"] == identity["sid"]:
                     break
                 time.sleep(0.01)
@@ -2778,20 +2925,20 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             ("before family persistence", "before family persistence"),
         ):
             with self.subTest(name=name):
-                WORKER_MODULE.atomic_write(self.state, terminal)
+                LIFECYCLE_MODULE.atomic_write(self.state, terminal)
                 if cutpoint == "before gate":
                     patches = (
-                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
-                        mock.patch.object(WORKER_MODULE, "gated_process", side_effect=RuntimeError("cutpoint")),
+                        mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()),
+                        mock.patch.object(LIFECYCLE_MODULE, "gated_process", side_effect=RuntimeError("cutpoint")),
                     )
                     read_fd = None
                 else:
                     read_fd, write_fd = os.pipe()
                     process = mock.Mock(pid=41)
                     patches = (
-                        mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
-                        mock.patch.object(WORKER_MODULE, "gated_process", return_value=(process, write_fd)),
-                        mock.patch.object(WORKER_MODULE, "live_identity", side_effect=RuntimeError("cutpoint")),
+                        mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()),
+                        mock.patch.object(LIFECYCLE_MODULE, "gated_process", return_value=(process, write_fd)),
+                        mock.patch.object(LIFECYCLE_MODULE, "live_identity", side_effect=RuntimeError("cutpoint")),
                     )
                 try:
                     with patches[0], patches[1]:
@@ -2805,17 +2952,17 @@ class WorkerLifecycleContractTests(unittest.TestCase):
                 finally:
                     if read_fd is not None:
                         os.close(read_fd)
-                self.assertEqual(WORKER_MODULE.read_state(self.state), terminal)
+                self.assertEqual(LIFECYCLE_MODULE.read_state(self.state), terminal)
 
     def test_resume_cutpoint_after_family_persistence_is_settled_without_signaling(self):
-        WORKER_MODULE.atomic_write(self.state, self.family_state("exited"))
+        LIFECYCLE_MODULE.atomic_write(self.state, self.family_state("exited"))
         read_fd, write_fd = os.pipe()
         process = mock.Mock(pid=41)
         try:
             with (
-                mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
-                mock.patch.object(WORKER_MODULE, "gated_process", return_value=(process, write_fd)),
-                mock.patch.object(WORKER_MODULE, "live_identity", return_value=self.identity),
+                mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()),
+                mock.patch.object(LIFECYCLE_MODULE, "gated_process", return_value=(process, write_fd)),
+                mock.patch.object(LIFECYCLE_MODULE, "live_identity", return_value=self.identity),
                 mock.patch.object(WORKER_MODULE.os, "write", side_effect=RuntimeError("cutpoint")),
             ):
                 with self.assertRaisesRegex(RuntimeError, "cutpoint"):
@@ -2823,16 +2970,16 @@ class WorkerLifecycleContractTests(unittest.TestCase):
         finally:
             os.close(read_fd)
 
-        persisted = WORKER_MODULE.read_state(self.state)
+        persisted = LIFECYCLE_MODULE.read_state(self.state)
         self.assertEqual(persisted["lifecycle"], "launching")
         self.assertEqual(
             {key: persisted[key] for key in self.identity},
             self.identity,
         )
         with (
-            mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
-            mock.patch.object(WORKER_MODULE, "live_identity", return_value=None),
-            mock.patch.object(WORKER_MODULE, "group_members", return_value=[]),
+            mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()),
+            mock.patch.object(LIFECYCLE_MODULE, "live_identity", return_value=None),
+            mock.patch.object(LIFECYCLE_MODULE, "group_members", return_value=[]),
             mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
         ):
             self.assertEqual(WORKER_MODULE.stop(self.arguments()), 0)
@@ -2840,15 +2987,15 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             killpg.assert_not_called()
 
     def test_resume_cutpoint_after_release_before_running_is_settled_without_signaling(self):
-        WORKER_MODULE.atomic_write(self.state, self.family_state("exited"))
+        LIFECYCLE_MODULE.atomic_write(self.state, self.family_state("exited"))
         read_fd, write_fd = os.pipe()
         process = mock.Mock(pid=41)
         try:
             with (
-                mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
-                mock.patch.object(WORKER_MODULE, "gated_process", return_value=(process, write_fd)),
-                mock.patch.object(WORKER_MODULE, "live_identity", return_value=self.identity),
-                mock.patch.object(WORKER_MODULE, "transition", side_effect=RuntimeError("cutpoint")),
+                mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()),
+                mock.patch.object(LIFECYCLE_MODULE, "gated_process", return_value=(process, write_fd)),
+                mock.patch.object(LIFECYCLE_MODULE, "live_identity", return_value=self.identity),
+                mock.patch.object(LIFECYCLE_MODULE, "transition", side_effect=RuntimeError("cutpoint")),
             ):
                 with self.assertRaisesRegex(RuntimeError, "cutpoint"):
                     WORKER_MODULE.resume(self.resume_arguments())
@@ -2856,12 +3003,12 @@ class WorkerLifecycleContractTests(unittest.TestCase):
         finally:
             os.close(read_fd)
 
-        persisted = WORKER_MODULE.read_state(self.state)
+        persisted = LIFECYCLE_MODULE.read_state(self.state)
         self.assertEqual(persisted["lifecycle"], "launching")
         with (
-            mock.patch.object(WORKER_MODULE, "_libproc", return_value=object()),
-            mock.patch.object(WORKER_MODULE, "live_identity", return_value=None),
-            mock.patch.object(WORKER_MODULE, "group_members", return_value=[]),
+            mock.patch.object(LIFECYCLE_MODULE, "_libproc", return_value=object()),
+            mock.patch.object(LIFECYCLE_MODULE, "live_identity", return_value=None),
+            mock.patch.object(LIFECYCLE_MODULE, "group_members", return_value=[]),
             mock.patch.object(WORKER_MODULE.os, "killpg") as killpg,
         ):
             self.assertEqual(WORKER_MODULE.stop(self.arguments()), 0)
@@ -2869,47 +3016,47 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             killpg.assert_not_called()
 
     def test_nonterminal_resume_is_rejected_and_legacy_completed_resume_is_accepted_to_launch(self):
-        WORKER_MODULE.atomic_write(self.state, self.family_state("running"))
-        with mock.patch.object(WORKER_MODULE, "run_lifecycle") as launch:
+        LIFECYCLE_MODULE.atomic_write(self.state, self.family_state("running"))
+        with mock.patch.object(LIFECYCLE_MODULE, "run_lifecycle") as launch:
             self.assertNotEqual(WORKER_MODULE.resume(argparse.Namespace(state=self.state, codex="codex", prompt="continue")), 0)
             launch.assert_not_called()
         legacy = {"session_id": "old", "model": "Terra", "sandbox": "read-only", "cwd": str(self.cwd)}
         self.state.write_text(json.dumps(legacy), encoding="utf-8")
-        with mock.patch.object(WORKER_MODULE, "run_lifecycle", return_value=0) as launch:
+        with mock.patch.object(LIFECYCLE_MODULE, "run_lifecycle", return_value=0) as launch:
             self.assertEqual(WORKER_MODULE.resume(argparse.Namespace(state=self.state, codex="codex", prompt="continue")), 0)
             self.assertEqual(launch.call_args.args[2]["lifecycle"], "launching")
 
     def test_process_family_constants_and_no_global_cleanup_authority(self):
-        self.assertEqual(WORKER_MODULE.BSD_SIZE, 136)
-        self.assertEqual(WORKER_MODULE.VNODE_SIZE, 2352)
-        self.assertEqual(WORKER_MODULE.PROC_PIDTBSDINFO, 3)
-        self.assertEqual(WORKER_MODULE.PROC_PIDVNODEPATHINFO, 9)
-        source = CODEX_WORKER.read_text(encoding="utf-8")
+        self.assertEqual(LIFECYCLE_MODULE.BSD_SIZE, 136)
+        self.assertEqual(LIFECYCLE_MODULE.VNODE_SIZE, 2352)
+        self.assertEqual(LIFECYCLE_MODULE.PROC_PIDTBSDINFO, 3)
+        self.assertEqual(LIFECYCLE_MODULE.PROC_PIDVNODEPATHINFO, 9)
         instructions = (ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md").read_text(encoding="utf-8")
-        self.assertNotIn("pkill", source)
-        self.assertNotIn("proc_listchildpids", source)
-        self.assertNotIn("proc_name", source)
+        for path in (WORKER_LIFECYCLE, CODEX_WORKER, CLAUDE_WORKER):
+            source = path.read_text(encoding="utf-8")
+            self.assertNotIn("pkill", source)
+            self.assertNotIn("proc_listchildpids", source)
+            self.assertNotIn("proc_name", source)
         self.assertIn("Successors never discover or clean", instructions)
 
     def test_claude_worker_process_family_constants_and_no_global_cleanup_authority(self):
-        # The Darwin-constant guard covers both adapters: claude-worker.py
-        # carries its own copy of the same identity-probe constants, not an
-        # import of codex-worker.py's.
-        self.assertEqual(CLAUDE_WORKER_MODULE.BSD_SIZE, 136)
-        self.assertEqual(CLAUDE_WORKER_MODULE.VNODE_SIZE, 2352)
-        self.assertEqual(CLAUDE_WORKER_MODULE.PROC_PIDTBSDINFO, 3)
-        self.assertEqual(CLAUDE_WORKER_MODULE.PROC_PIDVNODEPATHINFO, 9)
-        source = CLAUDE_WORKER.read_text(encoding="utf-8")
-        self.assertNotIn("pkill", source)
-        self.assertNotIn("proc_listchildpids", source)
-        self.assertNotIn("proc_name", source)
+        self.assertIs(WORKER_MODULE.lifecycle, LIFECYCLE_MODULE)
+        self.assertIs(CLAUDE_WORKER_MODULE.lifecycle, LIFECYCLE_MODULE)
+        codex_error = io.StringIO()
+        claude_error = io.StringIO()
+        with redirect_stderr(codex_error):
+            WORKER_MODULE.fail("probe")
+        with redirect_stderr(claude_error):
+            CLAUDE_WORKER_MODULE.fail("probe")
+        self.assertEqual(codex_error.getvalue(), "codex-worker: probe\n")
+        self.assertEqual(claude_error.getvalue(), "claude-worker: probe\n")
 
     @unittest.skipUnless(sys.platform == "darwin", "requires Darwin process-family probes")
     def test_darwin_probe_contract(self):
-        identity = WORKER_MODULE.live_identity(os.getpid())
+        identity = LIFECYCLE_MODULE.live_identity(os.getpid())
         self.assertIsNotNone(identity)
         self.assertEqual(identity["cwd"], str(ROOT.resolve()))
-        self.assertIn(os.getpid(), WORKER_MODULE.group_members(os.getpgrp()))
+        self.assertIn(os.getpid(), LIFECYCLE_MODULE.group_members(os.getpgrp()))
 
 
 class EvidenceEnvelopeTests(unittest.TestCase):


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

The two worker adapters now share one lifecycle module: locking, atomic state, schema validation, family ownership, liveness, stop, and verify live in a single implementation both the Claude and Codex launchers consume. Before this, the Claude adapter carried a deliberate copy of that machinery under a dated exception recorded when it shipped.

* Behavior is unchanged by design: no baseline test was removed, the control-checkout refusal appears exactly once in production code, and each adapter keeps its own effort enum and transport contract (Codex prompt stays positional with stdin closed).
* The extraction closes the recorded evidence gap from the adapter's own review: the shared lifecycle is now exercised unmocked for all four Claude commands, including the Claude-only top effort value, using fake worker binaries.
* Review removed a dead gate function the first cut carried and replaced a routing-only parity test that mocked the functions it claimed to prove; the correction is recorded in the decision record.

The decision record is ADR 150, alongside ADR 149's dated extraction deferral that this change retires.

Closes #150

## Verification

```text
validated 27 skills and 304 files
Ran 388 tests ... OK (skipped=23)
py_compile exit 0
DCO_OK
```
