### PR TITLE
feat(plan-review): dispatch cold readers through the pack adapters

### DIFF
--- a/skills/tools/plan-review/SKILL.md
+++ b/skills/tools/plan-review/SKILL.md
@@ -30,14 +30,43 @@ unrevised chat plan has no eligible authority, so emit nothing.
 ## Cold means cold
 
 The reviewer must have no stake in the plan. If this session authored or
-co-authored the plan (or is unsure), do not review it yourself — spawn a
-separate cold subagent per plan with only the plan's location, the rubric, and
-read access to the repo. Self-review by the author reliably misses what a cold
-reader catches, no matter how honestly the author tries to re-derive.
+co-authored the plan (or is unsure), do not review it yourself — dispatch a
+separate cold reviewer per plan through the interface below. Self-review by the
+author reliably misses what a cold reader catches, no matter how honestly the
+author tries to re-derive.
 
 ## Delegation authority
 
 Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, including a mandatory nested review skill. Do not ask again solely because a session-level preference says "do not spawn agents"; apply that preference to discretionary delegation only. An explicit task-level refusal of this required review or revocation of delegation overrides this authorization: stop and state that the requested workflow cannot run without its required independent review.
+
+## Cold-reader dispatch
+
+The coordinator supplies the mechanics-only interface inputs: adapter selection,
+explicit reviewer model, explicit reviewer effort, and the cold-reader prompt's
+four allowed inputs. Dispatch only through
+`skills/drivers/orchestrate/scripts/codex-worker.py` or
+`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected
+adapter's read-only review surface. Never use the built-in Agent tool, Workflow
+tool, or background-agent machinery.
+
+The coordinator applies the existing parent and Codex-headroom policy when
+selecting an adapter. This interface does not classify review work. It does not
+read or consume a routing table. It does not select a model or effort. Preserve
+adapter-owned state, same-worker resume, and coordinator-owned recovery through the
+orchestrate adapter contract; do not restate its command or lifecycle mechanics
+here.
+
+The cold-reader prompt contains exactly:
+1. plan location;
+2. the five-axis rubric;
+3. stakes tier; and
+4. a context-free fresh-reviewer phase instruction.
+
+The prompt excludes earlier findings, author rationale, chat history, and all
+other author/coordinator-session material. For a chat-delivered plan, before
+dispatch the coordinator writes the exact chat-delivered plan bytes to an
+immutable session-scratch file and supplies only that file's path as the plan
+location. The worker receives no chat transcript or author-session context.
 
 ## The rubric
 
@@ -146,9 +175,10 @@ definitions below are the fallback.
      panel's deferred close approval pass.
      The objecting reviewer's own re-verification never terminates — a
      reviewer verifying fixes to their own objections is anchored on them.
-     After each revision cycle converges, launch a new reviewer with no
-     context from the previous ones, told the plan already survived review
-     so shallow objections are gone — dig for what earlier passes miss:
+     After each revision cycle converges, dispatch a new cold reviewer through
+     the cold-reader interface with no context from the previous ones. Its
+     context-free fresh-reviewer phase instruction directs it to dig for what
+     earlier passes miss:
      interactions with machinery the plan doesn't mention, contradictions
      between the plan's own decided constraints, and claims that are subtly
      rather than obviously wrong. Its objections loop back through steps 3

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2869,16 +2869,34 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
             "\n\n## The rubric", 1
         )[0]
         self.compact_dispatch = " ".join(self.dispatch.split())
+        self.worker_inputs = self.dispatch.split(
+            "The prompt excludes earlier findings", 1
+        )[1]
 
     def test_dispatch_allows_only_pack_adapters(self):
-        self.assertIn("skills/drivers/orchestrate/scripts/codex-worker.py", self.compact_dispatch)
-        self.assertIn("skills/drivers/orchestrate/scripts/claude-worker.py", self.compact_dispatch)
+        exclusivity = (
+            "Dispatch only through `skills/drivers/orchestrate/scripts/codex-worker.py` or "
+            "`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected "
+            "adapter's read-only review surface."
+        )
+        self.assertIn(exclusivity, self.compact_dispatch)
+        adapter_paths = re.findall(
+            r"(?<![\w.-])(/?(?:[\w.-]+/)+[\w.-]*worker\.py)",
+            self.dispatch,
+        )
+        self.assertEqual(
+            adapter_paths,
+            [
+                "skills/drivers/orchestrate/scripts/codex-worker.py",
+                "skills/drivers/orchestrate/scripts/claude-worker.py",
+            ],
+        )
         self.assertIn("Never use the built-in Agent tool, Workflow tool, or background-agent machinery", self.compact_dispatch)
         self.assertNotIn("built-in Agent tool, Workflow tool, or background-agent machinery may be used", self.compact_dispatch)
 
     def test_dispatch_is_readonly(self):
         self.assertIn("using the selected adapter's read-only review surface", self.compact_dispatch)
-        self.assertNotIn("using the selected adapter's workspace-write review surface", self.compact_dispatch)
+        self.assertNotIn("workspace-write", self.compact_dispatch)
 
     def test_coordinator_supplies_explicit_adapter_model_and_effort(self):
         self.assertIn(
@@ -2926,6 +2944,12 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
             "author/coordinator-session material", "chat transcript",
         ):
             self.assertIn(forbidden, self.dispatch)
+        guarantee = "The worker receives no chat transcript or author-session context."
+        self.assertIn(guarantee, self.compact_dispatch)
+        worker_inputs = " ".join(self.worker_inputs.split()).lower()
+        other_worker_inputs = worker_inputs.replace(guarantee.lower(), "")
+        for forbidden_input in ("chat transcript", "author-session context"):
+            self.assertNotIn(forbidden_input, other_worker_inputs)
 
     def test_chat_plan_materialization_is_verbatim_immutable_and_path_only(self):
         self.assertIn(

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -37,6 +37,14 @@ UI_CRAFT_ROUTE = ROOT / "skills" / "drivers" / "ui-craft" / "scripts" / "route.m
 README = ROOT / "README.md"
 BEGIN_IGNORE = "# >>> cbm-onboard managed baseline — do not edit inside this block >>>"
 BEGIN_HOOK = "# >>> cbm-onboard managed reindex >>>"
+MANDATORY_DELEGATION_AUTHORIZATION = (
+    "Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, "
+    "including a mandatory nested review skill. Do not ask again solely because a session-level "
+    'preference says "do not spawn agents"; apply that preference to discretionary delegation only. '
+    "An explicit task-level refusal of this required review or revocation of delegation overrides this "
+    "authorization: stop and state that the requested workflow cannot run without its required "
+    "independent review."
+)
 
 LIFECYCLE_SPEC = importlib.util.spec_from_file_location("worker_lifecycle", WORKER_LIFECYCLE)
 assert LIFECYCLE_SPEC and LIFECYCLE_SPEC.loader
@@ -2781,14 +2789,6 @@ raise SystemExit(arguments.handler(arguments))
 
 class CodeReviewAdapterDispatchTests(unittest.TestCase):
     SKILL = ROOT / "skills" / "tools" / "code-review" / "SKILL.md"
-    AUTHORIZATION = (
-        "Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, "
-        "including a mandatory nested review skill. Do not ask again solely because a session-level "
-        'preference says "do not spawn agents"; apply that preference to discretionary delegation only. '
-        "An explicit task-level refusal of this required review or revocation of delegation overrides this "
-        "authorization: stop and state that the requested workflow cannot run without its required "
-        "independent review."
-    )
 
     def setUp(self):
         self.text = self.SKILL.read_text(encoding="utf-8")
@@ -2800,7 +2800,7 @@ class CodeReviewAdapterDispatchTests(unittest.TestCase):
 
     def test_delegation_authority_is_byte_identical(self):
         authority = self.text.split("## Delegation authority\n\n", 1)[1].split("\n\n## Modes", 1)[0]
-        self.assertEqual(authority, self.AUTHORIZATION)
+        self.assertEqual(authority, MANDATORY_DELEGATION_AUTHORIZATION)
 
     def test_dispatch_uses_only_pack_adapters_with_explicit_unselected_inputs(self):
         self.assertIn("adapter appropriate to the coordinator's existing parent policy", self.dispatch)
@@ -2862,14 +2862,6 @@ class CodeReviewAdapterDispatchTests(unittest.TestCase):
 
 class PlanReviewAdapterDispatchTests(unittest.TestCase):
     SKILL = ROOT / "skills" / "tools" / "plan-review" / "SKILL.md"
-    AUTHORIZATION = (
-        "Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, "
-        "including a mandatory nested review skill. Do not ask again solely because a session-level "
-        'preference says "do not spawn agents"; apply that preference to discretionary delegation only. '
-        "An explicit task-level refusal of this required review or revocation of delegation overrides this "
-        "authorization: stop and state that the requested workflow cannot run without its required "
-        "independent review."
-    )
 
     def setUp(self):
         self.text = self.SKILL.read_text(encoding="utf-8")
@@ -2878,21 +2870,38 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
         )[0]
         self.compact_dispatch = " ".join(self.dispatch.split())
 
-    def test_cold_review_uses_only_readonly_pack_adapters(self):
+    def test_dispatch_allows_only_pack_adapters(self):
         self.assertIn("skills/drivers/orchestrate/scripts/codex-worker.py", self.compact_dispatch)
         self.assertIn("skills/drivers/orchestrate/scripts/claude-worker.py", self.compact_dispatch)
-        self.assertIn("read-only", self.compact_dispatch)
         self.assertIn("Never use the built-in Agent tool, Workflow tool, or background-agent machinery", self.compact_dispatch)
+        self.assertNotIn("built-in Agent tool, Workflow tool, or background-agent machinery may be used", self.compact_dispatch)
 
-    def test_coordinator_supplies_adapter_model_and_effort_without_routing(self):
-        for input_name in ("adapter selection", "reviewer model", "reviewer effort"):
-            self.assertIn(input_name, self.compact_dispatch)
+    def test_dispatch_is_readonly(self):
+        self.assertIn("using the selected adapter's read-only review surface", self.compact_dispatch)
+        self.assertNotIn("using the selected adapter's workspace-write review surface", self.compact_dispatch)
+
+    def test_coordinator_supplies_explicit_adapter_model_and_effort(self):
+        self.assertIn(
+            "mechanics-only interface inputs: adapter selection, explicit reviewer model, explicit reviewer effort",
+            self.compact_dispatch,
+        )
+        self.assertNotIn("adapter selection, reviewer model, reviewer effort", self.compact_dispatch)
+
+    def test_adapter_selection_applies_existing_policy_without_classifying_review_work(self):
         self.assertIn("parent and Codex-headroom policy", self.compact_dispatch)
         self.assertIn("does not classify review work", self.compact_dispatch)
+        self.assertNotIn("does classify review work", self.compact_dispatch)
+
+    def test_dispatch_does_not_consume_a_routing_table(self):
         self.assertIn("does not read or consume a routing table", self.compact_dispatch)
+        self.assertNotIn("does read or consume a routing table", self.compact_dispatch)
         self.assertNotIn("routing-table.md", self.dispatch)
 
-    def test_prompt_allowlist_is_exact_and_excludes_session_context(self):
+    def test_dispatch_does_not_select_model_or_effort(self):
+        self.assertIn("does not select a model or effort", self.compact_dispatch)
+        self.assertNotIn("does select a model or effort", self.compact_dispatch)
+
+    def test_prompt_allowlist_is_exact(self):
         allowed = self.dispatch.split("The cold-reader prompt contains exactly:\n", 1)[1].split(
             "\n\n", 1
         )[0]
@@ -2905,23 +2914,38 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
                 "4. a context-free fresh-reviewer phase instruction.",
             ],
         )
+
+    def test_prompt_excludes_author_and_coordinator_context(self):
+        self.assertIn(
+            "The prompt excludes earlier findings, author rationale, chat history, and all other author/coordinator-session material.",
+            self.compact_dispatch,
+        )
+        self.assertNotIn("The prompt includes earlier findings", self.compact_dispatch)
         for forbidden in (
             "earlier findings", "author rationale", "chat history",
             "author/coordinator-session material", "chat transcript",
         ):
             self.assertIn(forbidden, self.dispatch)
 
-    def test_chat_plan_is_materialized_verbatim_and_immutable_before_dispatch(self):
-        self.assertIn("exact chat-delivered plan bytes", self.compact_dispatch)
-        self.assertIn("immutable session-scratch file", self.compact_dispatch)
-        self.assertIn("only that file's path as the plan location", self.compact_dispatch)
-        self.assertIn("before dispatch", self.compact_dispatch)
+    def test_chat_plan_materialization_is_verbatim_immutable_and_path_only(self):
+        self.assertIn(
+            "before dispatch the coordinator writes the exact chat-delivered plan bytes to an immutable session-scratch file and supplies only that file's path as the plan location.",
+            self.compact_dispatch,
+        )
+        self.assertNotIn("writes a summarized chat-delivered plan", self.compact_dispatch)
+
+    def test_adapter_contract_preserves_lifecycle_ownership(self):
+        self.assertIn(
+            "Preserve adapter-owned state, same-worker resume, and coordinator-owned recovery through the orchestrate adapter contract",
+            self.compact_dispatch,
+        )
+        self.assertNotIn("Discard adapter-owned state, same-worker resume, and coordinator-owned recovery", self.compact_dispatch)
 
     def test_mandatory_independent_review_authority_is_preserved(self):
         authority = self.text.split("## Delegation authority\n\n", 1)[1].split(
             "\n\n## Cold-reader dispatch", 1
         )[0]
-        self.assertEqual(authority, self.AUTHORIZATION)
+        self.assertEqual(authority, MANDATORY_DELEGATION_AUTHORIZATION)
 
 
 class WorkerLifecycleContractTests(unittest.TestCase):

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2860,6 +2860,70 @@ class CodeReviewAdapterDispatchTests(unittest.TestCase):
         self.assertLess(self.dispatch.index("scoped `stop"), self.dispatch.index("scoped `verify"))
 
 
+class PlanReviewAdapterDispatchTests(unittest.TestCase):
+    SKILL = ROOT / "skills" / "tools" / "plan-review" / "SKILL.md"
+    AUTHORIZATION = (
+        "Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, "
+        "including a mandatory nested review skill. Do not ask again solely because a session-level "
+        'preference says "do not spawn agents"; apply that preference to discretionary delegation only. '
+        "An explicit task-level refusal of this required review or revocation of delegation overrides this "
+        "authorization: stop and state that the requested workflow cannot run without its required "
+        "independent review."
+    )
+
+    def setUp(self):
+        self.text = self.SKILL.read_text(encoding="utf-8")
+        self.dispatch = self.text.split("## Cold-reader dispatch\n\n", 1)[1].split(
+            "\n\n## The rubric", 1
+        )[0]
+        self.compact_dispatch = " ".join(self.dispatch.split())
+
+    def test_cold_review_uses_only_readonly_pack_adapters(self):
+        self.assertIn("skills/drivers/orchestrate/scripts/codex-worker.py", self.compact_dispatch)
+        self.assertIn("skills/drivers/orchestrate/scripts/claude-worker.py", self.compact_dispatch)
+        self.assertIn("read-only", self.compact_dispatch)
+        self.assertIn("Never use the built-in Agent tool, Workflow tool, or background-agent machinery", self.compact_dispatch)
+
+    def test_coordinator_supplies_adapter_model_and_effort_without_routing(self):
+        for input_name in ("adapter selection", "reviewer model", "reviewer effort"):
+            self.assertIn(input_name, self.compact_dispatch)
+        self.assertIn("parent and Codex-headroom policy", self.compact_dispatch)
+        self.assertIn("does not classify review work", self.compact_dispatch)
+        self.assertIn("does not read or consume a routing table", self.compact_dispatch)
+        self.assertNotIn("routing-table.md", self.dispatch)
+
+    def test_prompt_allowlist_is_exact_and_excludes_session_context(self):
+        allowed = self.dispatch.split("The cold-reader prompt contains exactly:\n", 1)[1].split(
+            "\n\n", 1
+        )[0]
+        self.assertEqual(
+            allowed.splitlines(),
+            [
+                "1. plan location;",
+                "2. the five-axis rubric;",
+                "3. stakes tier; and",
+                "4. a context-free fresh-reviewer phase instruction.",
+            ],
+        )
+        for forbidden in (
+            "earlier findings", "author rationale", "chat history",
+            "author/coordinator-session material", "chat transcript",
+        ):
+            self.assertIn(forbidden, self.dispatch)
+
+    def test_chat_plan_is_materialized_verbatim_and_immutable_before_dispatch(self):
+        self.assertIn("exact chat-delivered plan bytes", self.compact_dispatch)
+        self.assertIn("immutable session-scratch file", self.compact_dispatch)
+        self.assertIn("only that file's path as the plan location", self.compact_dispatch)
+        self.assertIn("before dispatch", self.compact_dispatch)
+
+    def test_mandatory_independent_review_authority_is_preserved(self):
+        authority = self.text.split("## Delegation authority\n\n", 1)[1].split(
+            "\n\n## Cold-reader dispatch", 1
+        )[0]
+        self.assertEqual(authority, self.AUTHORIZATION)
+
+
 class WorkerLifecycleContractTests(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -46,6 +46,39 @@ MANDATORY_DELEGATION_AUTHORIZATION = (
     "independent review."
 )
 
+# The single canonical representation of the plan-review cold-reader dispatch
+# contract: adapter exclusivity, read-only surface, mechanics-only inputs, the
+# closed prompt allowlist, and worker-isolation. The skill's section is pinned
+# byte-for-byte against this constant, so any prose edit inside it — of any
+# phrasing — fails by construction rather than by pattern matching.
+PLAN_REVIEW_COLD_READER_DISPATCH = """\
+The coordinator supplies the mechanics-only interface inputs: adapter selection,
+explicit reviewer model, explicit reviewer effort, and the cold-reader prompt's
+four allowed inputs. Dispatch only through
+`skills/drivers/orchestrate/scripts/codex-worker.py` or
+`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected
+adapter's read-only review surface. Never use the built-in Agent tool, Workflow
+tool, or background-agent machinery.
+
+The coordinator applies the existing parent and Codex-headroom policy when
+selecting an adapter. This interface does not classify review work. It does not
+read or consume a routing table. It does not select a model or effort. Preserve
+adapter-owned state, same-worker resume, and coordinator-owned recovery through the
+orchestrate adapter contract; do not restate its command or lifecycle mechanics
+here.
+
+The cold-reader prompt contains exactly:
+1. plan location;
+2. the five-axis rubric;
+3. stakes tier; and
+4. a context-free fresh-reviewer phase instruction.
+
+The prompt excludes earlier findings, author rationale, chat history, and all
+other author/coordinator-session material. For a chat-delivered plan, before
+dispatch the coordinator writes the exact chat-delivered plan bytes to an
+immutable session-scratch file and supplies only that file's path as the plan
+location. The worker receives no chat transcript or author-session context."""
+
 LIFECYCLE_SPEC = importlib.util.spec_from_file_location("worker_lifecycle", WORKER_LIFECYCLE)
 assert LIFECYCLE_SPEC and LIFECYCLE_SPEC.loader
 LIFECYCLE_MODULE = importlib.util.module_from_spec(LIFECYCLE_SPEC)
@@ -2865,105 +2898,12 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
 
     def setUp(self):
         self.text = self.SKILL.read_text(encoding="utf-8")
-        self.dispatch = self.text.split("## Cold-reader dispatch\n\n", 1)[1].split(
+
+    def test_cold_reader_dispatch_section_is_byte_identical(self):
+        dispatch = self.text.split("## Cold-reader dispatch\n\n", 1)[1].split(
             "\n\n## The rubric", 1
         )[0]
-        self.compact_dispatch = " ".join(self.dispatch.split())
-        self.worker_inputs = self.dispatch.split(
-            "The prompt excludes earlier findings", 1
-        )[1]
-
-    def test_dispatch_allows_only_pack_adapters(self):
-        exclusivity = (
-            "Dispatch only through `skills/drivers/orchestrate/scripts/codex-worker.py` or "
-            "`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected "
-            "adapter's read-only review surface."
-        )
-        self.assertIn(exclusivity, self.compact_dispatch)
-        adapter_paths = re.findall(
-            r"(?<![\w.-])(/?(?:[\w.-]+/)+[\w.-]*worker\.py)",
-            self.dispatch,
-        )
-        self.assertEqual(
-            adapter_paths,
-            [
-                "skills/drivers/orchestrate/scripts/codex-worker.py",
-                "skills/drivers/orchestrate/scripts/claude-worker.py",
-            ],
-        )
-        self.assertIn("Never use the built-in Agent tool, Workflow tool, or background-agent machinery", self.compact_dispatch)
-        self.assertNotIn("built-in Agent tool, Workflow tool, or background-agent machinery may be used", self.compact_dispatch)
-
-    def test_dispatch_is_readonly(self):
-        self.assertIn("using the selected adapter's read-only review surface", self.compact_dispatch)
-        self.assertNotIn("workspace-write", self.compact_dispatch)
-
-    def test_coordinator_supplies_explicit_adapter_model_and_effort(self):
-        self.assertIn(
-            "mechanics-only interface inputs: adapter selection, explicit reviewer model, explicit reviewer effort",
-            self.compact_dispatch,
-        )
-        self.assertNotIn("adapter selection, reviewer model, reviewer effort", self.compact_dispatch)
-
-    def test_adapter_selection_applies_existing_policy_without_classifying_review_work(self):
-        self.assertIn("parent and Codex-headroom policy", self.compact_dispatch)
-        self.assertIn("does not classify review work", self.compact_dispatch)
-        self.assertNotIn("does classify review work", self.compact_dispatch)
-
-    def test_dispatch_does_not_consume_a_routing_table(self):
-        self.assertIn("does not read or consume a routing table", self.compact_dispatch)
-        self.assertNotIn("does read or consume a routing table", self.compact_dispatch)
-        self.assertNotIn("routing-table.md", self.dispatch)
-
-    def test_dispatch_does_not_select_model_or_effort(self):
-        self.assertIn("does not select a model or effort", self.compact_dispatch)
-        self.assertNotIn("does select a model or effort", self.compact_dispatch)
-
-    def test_prompt_allowlist_is_exact(self):
-        allowed = self.dispatch.split("The cold-reader prompt contains exactly:\n", 1)[1].split(
-            "\n\n", 1
-        )[0]
-        self.assertEqual(
-            allowed.splitlines(),
-            [
-                "1. plan location;",
-                "2. the five-axis rubric;",
-                "3. stakes tier; and",
-                "4. a context-free fresh-reviewer phase instruction.",
-            ],
-        )
-
-    def test_prompt_excludes_author_and_coordinator_context(self):
-        self.assertIn(
-            "The prompt excludes earlier findings, author rationale, chat history, and all other author/coordinator-session material.",
-            self.compact_dispatch,
-        )
-        self.assertNotIn("The prompt includes earlier findings", self.compact_dispatch)
-        for forbidden in (
-            "earlier findings", "author rationale", "chat history",
-            "author/coordinator-session material", "chat transcript",
-        ):
-            self.assertIn(forbidden, self.dispatch)
-        guarantee = "The worker receives no chat transcript or author-session context."
-        self.assertIn(guarantee, self.compact_dispatch)
-        worker_inputs = " ".join(self.worker_inputs.split()).lower()
-        other_worker_inputs = worker_inputs.replace(guarantee.lower(), "")
-        for forbidden_input in ("chat transcript", "author-session context"):
-            self.assertNotIn(forbidden_input, other_worker_inputs)
-
-    def test_chat_plan_materialization_is_verbatim_immutable_and_path_only(self):
-        self.assertIn(
-            "before dispatch the coordinator writes the exact chat-delivered plan bytes to an immutable session-scratch file and supplies only that file's path as the plan location.",
-            self.compact_dispatch,
-        )
-        self.assertNotIn("writes a summarized chat-delivered plan", self.compact_dispatch)
-
-    def test_adapter_contract_preserves_lifecycle_ownership(self):
-        self.assertIn(
-            "Preserve adapter-owned state, same-worker resume, and coordinator-owned recovery through the orchestrate adapter contract",
-            self.compact_dispatch,
-        )
-        self.assertNotIn("Discard adapter-owned state, same-worker resume, and coordinator-owned recovery", self.compact_dispatch)
+        self.assertEqual(dispatch, PLAN_REVIEW_COLD_READER_DISPATCH)
 
     def test_mandatory_independent_review_authority_is_preserved(self):
         authority = self.text.split("## Delegation authority\n\n", 1)[1].split(


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Plan review's cold readers now launch through the pack's worker adapters on a read-only surface, with a closed prompt allowlist the tests pin as one exact block. Before this, the skill said "spawn a separate cold subagent" and left both the mechanics and the prompt's contents to the harness.

* The interface is mechanics-only: adapter selection, reviewer model, and reviewer effort are coordinator-supplied inputs. It classifies no review work and reads no routing table; binding routing to this interface is the final integration ticket's job.
* The cold-reader prompt admits exactly four inputs (plan location, the five-axis rubric, stakes tier, and a context-free fresh-reviewer phase instruction). Earlier findings, author rationale, and chat history are excluded, so the fresh reviewer closing each revision cycle takes its framing from the phase instruction rather than from what previous rounds found.
* A chat-delivered plan is written verbatim to an immutable session-scratch file before dispatch and reviewed by path, so a worker never receives the author's transcript.
* The dispatch section is pinned byte for byte against one test constant instead of a list of pattern checks, following the delegation-authority pattern already in the suite. Review capped at round three on exactly this: fresh equivalent mutations kept passing the pattern checks.

Review rounds and the reviewer's ruling are on the issue.

Closes #152

## Verification

```text
validated 27 skills and 304 files
Ran 401 tests ... OK (skipped=23)
py_compile exit 0
```

A ten-mutation sweep over the pinned section (third adapter, custom-adapter escape, author rationale delivered, filesystem writes permitted, routing table consumed, model selected locally, widened allowlist, summarized chat plan, agent tool allowed, resume discarded) fails on every one. The sweep reaches edits inside the pinned block only, so a permissive statement added under some other heading in the skill is not covered by it.
