### PR TITLE
fix(cbm-onboard): explain local sandbox escalation

### DIFF
--- a/skills/tools/cbm-onboard/SKILL.md
+++ b/skills/tools/cbm-onboard/SKILL.md
@@ -95,6 +95,17 @@ directory containing several repositories.
    exits 2, which is a visible degraded mode rather than permission to use some
    other project. Every other failure exits 1 with nothing on stdout.
 
+   In a workspace-write sandbox, try `ensure` normally first. If it exits 2 with
+   `{"status": "unavailable"}`, confirm that `codebase-memory-mcp` is present and
+   reports a supported version. A usable binary can still be unavailable only
+   inside the sandbox because its local CLI must secure and write
+   `~/.cache/codebase-memory-mcp` and coordinate through a Unix socket under
+   `/private/tmp`. Retry the same `ensure` command with escalated permissions and
+   make those local-only destinations explicit in the approval rationale; state
+   that no repository data is sent to a network destination. Do not request a
+   generic permission to “index a private repository,” which hides the actual
+   boundary and can be correctly rejected when the destination is unspecified.
+
 5. Verify the project through the available Codebase Memory MCP interface with
    `index_status` or `list_projects`.
 6. Report node and edge counts when available.


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Codebase Memory onboarding now tells sandboxed agents how to distinguish a usable local CLI blocked by cache permissions from a missing installation, then request only the local access the index needs. Before this, the machine interface collapsed both cases into `unavailable` while the skill supplied no destination details, so an approval could treat local indexing as a possible private-source export.

* The workflow still tries the machine interface inside the sandbox first and preserves `unavailable` for a genuinely absent or unsupported binary.
* The retry names the user-local SQLite cache and Unix coordination socket, and states that repository data has no network destination; a generic request to index a private repository is explicitly rejected as insufficiently scoped.

## Verification

```text
validated 27 skills and 304 files
Ran 209 tests in 185.488s
OK (skipped=1)
git diff --check exit 0
```
