### PR TITLE
Dispatch ticket chunk workers through the pack adapters

### DIFF
--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -35,33 +35,59 @@ epic, the ticket skill's per-ticket change-record rule still applies.
    worktrees together, and serial ones only once their predecessor has merged into
    the ticket branch, because a serial chunk cut early misses the work it depends on.
 
-3. **Dispatch one agent per chunk** at the tier its `Agent:` line names, with the
-   working directory set to that chunk's worktree. Bind that chunk worktree's own
-   graph identity first, per the skill page's graph-identity rule. The prompt is the
-   sub-order fence verbatim, plus the worktree path, the branch name, and that
-   chunk's `root_path` and `project`, which the worker uses as given rather than
-   resolving its own. Nothing else: a sub-order that needs coordinator commentary to
-   be executable is a triage defect, and the fix is to say so, not to patch it in the
-   prompt. A chunk never receives the ticket worktree's identity or a sibling's, and
-   an `unavailable` result is passed on as such.
+## Chunk preparation
 
-   `Surface lifecycle:` is part of that executable interface. Before dispatch,
+Bind each chunk worktree's own graph identity first, per the skill page's
+graph-identity rule.
+
+`Surface lifecycle:` is part of that executable interface. Before dispatch,
    confirm every UI-affecting sub-order says `build` or `revise` and names the lock
    manifest or shipped behavior ledger/replay that mode consumes. On a rendered-
    surface chunk, `none`, a missing legacy field, or a missing contract is a triage
    defect. The worker loads the named UI Craft mode before implementing its `Do`
    section; non-UI chunks keep `none`.
 
-   Once the dispatcher exposes a stable transcript id, claim each unique
-   implementation-worker session through the shared claim rule, passing
-   `--role worker`, `--session <id>`, `--agent <agent>`, and
-   `--project <chunk-worktree>`. The role, agent and project name what the worker
-   did, which agent did it, and its actual working directory, not the
-   coordinator's. `--role worker` is what makes a chunk's cost evidence about
-   chunk size; a worker claimed without it is read as coordinator overhead. Keep identifiers in coordinator bookkeeping; they never
-   enter sub-order prompts or published comments. If the dispatcher exposes no
-   stable transcript id, report the omitted claim in one line and continue. Claim
-   failures use the shared visible, non-blocking rule.
+## Chunk-worker dispatch
+
+3. **Dispatch one agent per chunk** at the tier its `Agent:` line names. The
+   coordinator supplies the selected adapter, the explicit worker model resolved for
+   that tier, and explicit worker effort. Dispatch only through
+   `skills/drivers/orchestrate/scripts/codex-worker.py` or
+   `skills/drivers/orchestrate/scripts/claude-worker.py`. Never use the built-in
+   Agent tool, Workflow tool, background-agent machinery, or native agent dispatch.
+
+   For chunk `<n>` and dispatch attempt `<attempt>`, the coordinator writes the
+   complete prompt bytes to
+   `<session-scratch>/ticket-<ticket-id-lowercase>-chunk-<n>-attempt-<attempt>.prompt`
+   and passes that file's contents as the adapter's positional prompt. The prompt is
+   the sub-order fence verbatim, followed only by that chunk's worktree path, branch
+   name, `root_path`, and `project`; the worker follows the graph-identity rule and
+   uses as given the supplied `root_path` and `project` rather than resolving its
+   own. An `unavailable` identity is passed through as such. A chunk never receives
+   the ticket worktree's identity or a sibling's, and never coordinator commentary.
+
+   Start the worker through the selected adapter in `workspace-write` mode, with its
+   cwd set to that chunk's worktree and the coordinator's checkout supplied as the
+   control checkout. The coordinator owns
+   `<session-scratch>/ticket-<ticket-id-lowercase>-chunk-<n>-attempt-<attempt>.state.json`
+   for that dispatch. Same-worker follow-ups use the adapter's resume surface with
+   that state file. If recovery is required, the coordinator runs the adapter's
+   scoped stop surface and then its scoped verify surface before a successor receives
+   the chunk worktree; a successor uses a new `<attempt>` and state file.
+
+## Worker accounting
+
+Once the dispatcher exposes a stable transcript id, claim each unique
+implementation-worker session through the shared claim rule, passing
+`--role worker`, `--session <id>`, `--agent <agent>`, and
+`--project <chunk-worktree>`. The role, agent and project name what the worker
+did, which agent did it, and its actual working directory, not the
+coordinator's. `--role worker` is what makes a chunk's cost evidence about
+chunk size; a worker claimed without it is read as coordinator overhead. Keep
+identifiers in coordinator bookkeeping; they never enter sub-order prompts or
+published comments. If the dispatcher exposes no stable transcript id, report the
+omitted claim in one line and continue. Claim failures use the shared visible,
+non-blocking rule.
 
 ## Reviewer selection
 

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -434,6 +434,9 @@ class TicketSkillContractTests(unittest.TestCase):
         accounting = coordinator.split("## Worker accounting", 1)[1].split(
             "## Reviewer selection", 1
         )[0]
+        operative_arguments = accounting.split(
+            "through the shared claim rule, passing\n", 1
+        )[1].split(". The role", 1)[0]
         normalized = " ".join(accounting.split())
 
         self.assertIn("stable transcript id", accounting)
@@ -443,7 +446,7 @@ class TicketSkillContractTests(unittest.TestCase):
             "--agent <agent>",
             "--project <chunk-worktree>",
         ):
-            self.assertIn(argument, accounting)
+            self.assertIn(argument, operative_arguments)
         self.assertIn("report the omitted claim in one line and continue", normalized)
         self.assertIn("shared visible, non-blocking rule", normalized)
 
@@ -452,9 +455,12 @@ class TicketSkillContractTests(unittest.TestCase):
             TICKET_DIRECTORY / "references" / "coordinator-mode.md"
         ).read_text(encoding="utf-8")
         reviewer_selection = coordinator.split("## Reviewer selection", 1)[1]
+        review_instruction = reviewer_selection.split("   a. ", 1)[1].split(
+            "\n\n   b.", 1
+        )[0]
 
-        self.assertIn("/review", reviewer_selection)
-        self.assertIn("review-routing.md", reviewer_selection)
+        self.assertIn("Run `/review` for the chunk diff", review_instruction)
+        self.assertIn("review-routing.md", review_instruction)
 
     def test_every_ticket_authored_worktree_removal_tears_the_graph_down_first(self):
         pages = {

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -54,6 +54,46 @@ SESSION_FIT_MODEL_CHECK_BODY = (
     "coordinator."
 )
 
+TICKET_CHUNK_WORKER_ADAPTER_DISPATCH = """3. **Dispatch one agent per chunk** at the tier its `Agent:` line names. The
+   coordinator supplies the selected adapter, the explicit worker model resolved for
+   that tier, and explicit worker effort. Dispatch only through
+   `skills/drivers/orchestrate/scripts/codex-worker.py` or
+   `skills/drivers/orchestrate/scripts/claude-worker.py`. Never use the built-in
+   Agent tool, Workflow tool, background-agent machinery, or native agent dispatch.
+
+   For chunk `<n>` and dispatch attempt `<attempt>`, the coordinator writes the
+   complete prompt bytes to
+   `<session-scratch>/ticket-<ticket-id-lowercase>-chunk-<n>-attempt-<attempt>.prompt`
+   and passes that file's contents as the adapter's positional prompt. The prompt is
+   the sub-order fence verbatim, followed only by that chunk's worktree path, branch
+   name, `root_path`, and `project`; the worker follows the graph-identity rule and
+   uses as given the supplied `root_path` and `project` rather than resolving its
+   own. An `unavailable` identity is passed through as such. A chunk never receives
+   the ticket worktree's identity or a sibling's, and never coordinator commentary.
+
+   Start the worker through the selected adapter in `workspace-write` mode, with its
+   cwd set to that chunk's worktree and the coordinator's checkout supplied as the
+   control checkout. The coordinator owns
+   `<session-scratch>/ticket-<ticket-id-lowercase>-chunk-<n>-attempt-<attempt>.state.json`
+   for that dispatch. Same-worker follow-ups use the adapter's resume surface with
+   that state file. If recovery is required, the coordinator runs the adapter's
+   scoped stop surface and then its scoped verify surface before a successor receives
+   the chunk worktree; a successor uses a new `<attempt>` and state file."""
+
+
+class TicketChunkWorkerAdapterDispatchTests(unittest.TestCase):
+    # Opening anchor: ## Chunk-worker dispatch
+    # Closing anchor: ## Worker accounting
+    def test_chunk_worker_adapter_dispatch_is_canonical(self):
+        coordinator = (
+            TICKET_DIRECTORY / "references" / "coordinator-mode.md"
+        ).read_text(encoding="utf-8")
+        dispatch = coordinator.split("## Chunk-worker dispatch\n\n", 1)[1].split(
+            "\n\n## Worker accounting", 1
+        )[0]
+
+        self.assertEqual(dispatch, TICKET_CHUNK_WORKER_ADAPTER_DISPATCH)
+
 
 def run(command: list[str], *, cwd: Path, env: Optional[dict[str, str]] = None):
     return subprocess.run(
@@ -360,8 +400,8 @@ class TicketSkillContractTests(unittest.TestCase):
         coordinator = (
             TICKET_DIRECTORY / "references" / "coordinator-mode.md"
         ).read_text(encoding="utf-8")
-        dispatch = coordinator.split("3. **Dispatch one agent per chunk", 1)[1].split(
-            "\n4. **", 1
+        dispatch = coordinator.split("## Chunk-worker dispatch", 1)[1].split(
+            "## Worker accounting", 1
         )[0]
 
         self.assertIn("graph-identity rule", dispatch)
@@ -370,6 +410,51 @@ class TicketSkillContractTests(unittest.TestCase):
         normalized = " ".join(dispatch.lower().split())
         self.assertIn("uses as given", normalized)
         self.assertIn("never receives the ticket worktree's identity or a sibling's", normalized)
+
+    def test_chunk_preparation_retains_ui_lifecycle_validation(self):
+        coordinator = (
+            TICKET_DIRECTORY / "references" / "coordinator-mode.md"
+        ).read_text(encoding="utf-8")
+        preparation = coordinator.split("## Chunk preparation", 1)[1].split(
+            "## Chunk-worker dispatch", 1
+        )[0]
+
+        self.assertIn("`Surface lifecycle:`", preparation)
+        self.assertIn("`build` or `revise`", preparation)
+        self.assertIn(
+            "names the lock manifest or shipped behavior ledger/replay that mode consumes",
+            " ".join(preparation.split()),
+        )
+        self.assertIn("non-UI chunks keep `none`", preparation)
+
+    def test_worker_accounting_remains_after_dispatch(self):
+        coordinator = (
+            TICKET_DIRECTORY / "references" / "coordinator-mode.md"
+        ).read_text(encoding="utf-8")
+        accounting = coordinator.split("## Worker accounting", 1)[1].split(
+            "## Reviewer selection", 1
+        )[0]
+        normalized = " ".join(accounting.split())
+
+        self.assertIn("stable transcript id", accounting)
+        for argument in (
+            "--role worker",
+            "--session <id>",
+            "--agent <agent>",
+            "--project <chunk-worktree>",
+        ):
+            self.assertIn(argument, accounting)
+        self.assertIn("report the omitted claim in one line and continue", normalized)
+        self.assertIn("shared visible, non-blocking rule", normalized)
+
+    def test_reviewer_selection_retains_the_existing_review_route(self):
+        coordinator = (
+            TICKET_DIRECTORY / "references" / "coordinator-mode.md"
+        ).read_text(encoding="utf-8")
+        reviewer_selection = coordinator.split("## Reviewer selection", 1)[1]
+
+        self.assertIn("/review", reviewer_selection)
+        self.assertIn("review-routing.md", reviewer_selection)
 
     def test_every_ticket_authored_worktree_removal_tears_the_graph_down_first(self):
         pages = {


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Chunked-ticket coordinators now launch every chunk worker through the pack's own adapters, with the prompt written to a per-attempt scratch file and one state file per dispatch. Before this, the coordinator reference left chunk dispatch to the harness's native agent machinery, the last implementation path the adapter ruling had not reached.

* The dispatch block is byte-pinned: adapter-only launch, explicit worker model and effort supplied by the coordinator, workspace-write with the chunk worktree as cwd, and resume/stop/verify through the same state file on recovery, a successor taking a fresh attempt number.
* The worker still receives only the sub-order fence and its own worktree identity, passed through as given; the ticket worktree's identity and siblings' stay excluded, as the existing test requires.
* Preservation tests were tightened while converting: the worker-accounting and per-chunk review checks now bind to their operative sentences, where before a deletion could pass on wording that survived in links and asides.
* Reviewer selection, merging, and whole-diff review keep their existing rules; per-chunk review still routes through the review front door.

Triage rounds and the review verdicts are on the issue.

Closes #154

## Verification

```text
validated 27 skills and 305 files
Ran 415 tests ... OK (skipped=23)
py_compile exit 0
```

Chain rerun after rebasing over the session-fit merge; the one conflict was additive test constants, kept both. Pins were shown red before the reference edit and under anchor mutation afterward; a contradictory instruction in an unpinned file is outside their reach.
