### PR TITLE
Dispatch persona-review's panel through the pack adapters

### DIFF
--- a/skills/tools/persona-review/SKILL.md
+++ b/skills/tools/persona-review/SKILL.md
@@ -135,12 +135,33 @@ review starts, state the panel and, for each pick, the one-line reason it was ch
 Prefer roster personas; invent only when no roster persona's concerns cover a topic
 the document raises.
 
+## Panelist dispatch
+
+The coordinator supplies the selected adapter, explicit reviewer model, and explicit
+reviewer effort. For each panelist, dispatch only through
+`skills/drivers/orchestrate/scripts/codex-worker.py` or
+`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected adapter's
+read-only review surface. Never use the built-in Agent tool, Workflow tool, or
+background-agent machinery.
+
+Each dispatch has one coordinator-owned state file under the coordinator's
+session-scratch directory. Use the adapter's start, resume, stop, and verify surface;
+adapter state, same-worker resume, and recovery remain adapter-owned.
+
+The coordinator keeps the non-sensitive positional prompt text in session scratch and
+passes that text to the selected adapter. The prompt tells the panelist to read the
+document, its private persona profile, relevant review-log entries, and relevant
+override rulings from their existing locations; review cold without access to another
+panelist's output or the synthesis; and return positions, blocking or note conditions,
+and approval or refusal. The prompt contains no persona name, simulation label, mine
+date, panel narrative, or profile, review-log, or override content.
+
 ## Cold review, per persona
 
 Each panelist reviews independently and cold: no visibility into the document under
 any other panelist's read, and no access to the panel's eventual synthesis while
-forming its own position. Where the harness supports it, run each panelist in its own
-subagent, handing it only:
+forming its own position. Follow [Panelist dispatch](#panelist-dispatch) for each
+panelist, handing it only:
 
 - The document under review.
 - That persona's profile (stances, style, evidence quotes) — the panelist's only
@@ -152,9 +173,8 @@ subagent, handing it only:
   already closed — do not re-raise them unless the document reopens the grounds for
   them).
 
-Where subagents aren't available, review personas serially in the main session,
-deliberately not looking back at an earlier persona's output while forming the next
-one's position.
+Where adapter dispatch isn't available, review personas serially in the main session,
+deliberately not looking back at an earlier persona's output while forming the next one's position.
 
 Each panelist's output: positions taken, conditions imposed (each marked **blocking**
 or **note**), and an approval or refusal — all in the persona's voice, grounded in its

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3225,6 +3225,7 @@ class PersonaReviewAdapterDispatchTests(unittest.TestCase):
         self.assertEqual(dispatch, PERSONA_REVIEW_PANELIST_DISPATCH)
 
     def test_serial_no_lookback_fallback_is_preserved(self):
+        self.assertIn("\n\n## Synthesis\n", self.text)
         cold_review = self.text.split("## Cold review, per persona\n\n", 1)[1].split(
             "\n\n## Synthesis", 1
         )[0]

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3225,10 +3225,9 @@ class PersonaReviewAdapterDispatchTests(unittest.TestCase):
         self.assertEqual(dispatch, PERSONA_REVIEW_PANELIST_DISPATCH)
 
     def test_serial_no_lookback_fallback_is_preserved(self):
-        self.assertIn("\n\n## Synthesis\n", self.text)
-        cold_review = self.text.split("## Cold review, per persona\n\n", 1)[1].split(
-            "\n\n## Synthesis", 1
-        )[0]
+        remainder = self.text.split("## Cold review, per persona\n\n", 1)[1]
+        self.assertIn("\n\n## Synthesis\n", remainder)
+        cold_review = remainder.split("\n\n## Synthesis", 1)[0]
         self.assertIn(
             "Where adapter dispatch isn't available, review personas serially in the main session,",
             cold_review,

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -89,6 +89,26 @@ dispatch the coordinator writes the exact chat-delivered plan bytes to an
 immutable session-scratch file and supplies only that file's path as the plan
 location. The worker receives no chat transcript or author-session context."""
 
+PERSONA_REVIEW_PANELIST_DISPATCH = """\
+The coordinator supplies the selected adapter, explicit reviewer model, and explicit
+reviewer effort. For each panelist, dispatch only through
+`skills/drivers/orchestrate/scripts/codex-worker.py` or
+`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected adapter's
+read-only review surface. Never use the built-in Agent tool, Workflow tool, or
+background-agent machinery.
+
+Each dispatch has one coordinator-owned state file under the coordinator's
+session-scratch directory. Use the adapter's start, resume, stop, and verify surface;
+adapter state, same-worker resume, and recovery remain adapter-owned.
+
+The coordinator keeps the non-sensitive positional prompt text in session scratch and
+passes that text to the selected adapter. The prompt tells the panelist to read the
+document, its private persona profile, relevant review-log entries, and relevant
+override rulings from their existing locations; review cold without access to another
+panelist's output or the synthesis; and return positions, blocking or note conditions,
+and approval or refusal. The prompt contains no persona name, simulation label, mine
+date, panel narrative, or profile, review-log, or override content."""
+
 REVIEW_ROUTING_CONTRACT = """\
 This reference is the sole live authority for reviewer classification, reviewer
 eligibility, and reviewer-model precedence. The benchmark authority remains
@@ -3192,6 +3212,32 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
         self.assertEqual(authority, MANDATORY_DELEGATION_AUTHORIZATION)
 
 
+class PersonaReviewAdapterDispatchTests(unittest.TestCase):
+    SKILL = ROOT / "skills" / "tools" / "persona-review" / "SKILL.md"
+
+    def setUp(self):
+        self.text = self.SKILL.read_text(encoding="utf-8")
+
+    def test_panelist_dispatch_section_is_byte_identical(self):
+        dispatch = self.text.split("## Panelist dispatch\n\n", 1)[1].split(
+            "\n\n## Cold review, per persona", 1
+        )[0]
+        self.assertEqual(dispatch, PERSONA_REVIEW_PANELIST_DISPATCH)
+
+    def test_serial_no_lookback_fallback_is_preserved(self):
+        cold_review = self.text.split("## Cold review, per persona\n\n", 1)[1].split(
+            "\n\n## Synthesis", 1
+        )[0]
+        self.assertIn(
+            "Where adapter dispatch isn't available, review personas serially in the main session,",
+            cold_review,
+        )
+        self.assertIn(
+            "deliberately not looking back at an earlier persona's output while forming the next one's position.",
+            cold_review,
+        )
+
+
 class WorkerLifecycleContractTests(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
@@ -4846,7 +4892,7 @@ class DelegationAuthorityContractTests(unittest.TestCase):
     def test_persona_review_keeps_conditional_serial_fallback_without_authority(self):
         self.assertNotIn(self.AUTHORIZATION, self.PERSONA_REVIEW)
         self.assertIn(
-            "Where subagents aren't available, review personas serially in the main session",
+            "Where adapter dispatch isn't available, review personas serially in the main session",
             self.PERSONA_REVIEW,
         )
 


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Persona-review's panel now launches through the pack's worker adapters on a read-only surface, one dispatch per panelist with coordinator-supplied model and effort. Before this, the skill convened panelists through the harness's native sub-agent machinery, with the serial fallback as the only alternative.

* The dispatch block is byte-pinned; the serial no-lookback fallback survives unchanged for sessions without adapter access, and its pin now binds the closing anchor positionally so a moved heading fails the test.
* Persona profiles, review logs, and overrides stay in the private data repository; the prompt file carries only the document, that panelist's profile, and the relevant log entries, and the worker is told to read it rather than receiving repository-identifying commentary.
* Containment is unchanged: persona names and panel narrative still appear in exactly chat and the private repository.

Triage rounds and the review verdicts are on the issue.

Closes #153

## Verification

```text
validated 27 skills and 305 files
Ran 415 tests ... OK (skipped=23)
py_compile exit 0
```

Both pinned blocks were shown red before the production edit and under anchor mutation afterward, including the moved-heading case the review round added. The pins cover the dispatch and fallback blocks only; prose elsewhere in the skill is outside them.
