### PR TITLE
Dispatch codebase-design's parallel design agents through the pack adapters

### DIFF
--- a/skills/tools/codebase-design/references/DESIGN-IT-TWICE.md
+++ b/skills/tools/codebase-design/references/DESIGN-IT-TWICE.md
@@ -12,10 +12,6 @@ when `scope`'s interview mode (`skills/workflows/scope/references/interview.md`)
 interface-shape frontier question, this can run right there, the same way
 that file's `ground it` escape hatch grounds a question before re-asking it.
 
-If coordinator mode (the `orchestrate` skill) is active, route the Step 2
-fan-out through its routing table's novel-solution-brainstorming row instead
-of picking sub-agent models yourself.
-
 ## Process
 
 ### 1. Frame the problem space
@@ -32,36 +28,57 @@ space for the chosen candidate:
 Show this to the user, then immediately proceed to Step 2. The user reads and
 thinks while the sub-agents work in parallel.
 
-### 2. Spawn sub-agents
+### 2. Dispatch parallel design alternatives
 
-Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a
-**radically different** interface for the deepened module.
+The coordinator supplies the selected adapter, explicit design-agent model, and
+explicit design-agent effort. Pass model and effort unchanged to every design
+worker. This procedure does not select an adapter, model, or effort, apply a
+routing table or headroom policy, or add defaults.
 
-Prompt each sub-agent with a separate technical brief (file paths, coupling
-details, dependency category from [DEEPENING.md](DEEPENING.md), what sits
-behind the seam). The brief is independent of the user-facing problem-space
-explanation in Step 1. Give each agent a different design constraint:
+Dispatch only through `skills/drivers/orchestrate/scripts/codex-worker.py` or
+`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected
+adapter's read-only surface. Never use the built-in Agent tool, Workflow tool,
+or background-agent machinery.
 
-- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise
-  leverage per entry point."
-- Agent 2: "Maximise flexibility — support many use cases and extension."
-- Agent 3: "Optimise for the most common caller — make the default case
+Create one coordinator-owned `<session-scratch>/design-it-twice/` directory.
+For alternative `<n>`, write its complete independent technical brief to
+`design-<n>.prompt.md`; use `design-<n>.json` as that worker's state file; and
+capture its launcher stdout and stderr in `design-<n>.stdout` and
+`design-<n>.stderr`. The coordinator passes the contents of
+`design-<n>.prompt.md` as the adapter's positional prompt text. State files
+carry lifecycle metadata only; successful design output comes from each
+launcher's stdout `final_message`.
+
+Start alternatives 1, 2, and 3 through the selected adapter before waiting on
+any launcher, retaining each launcher PID and joining each individually. Each
+worker receives its separate technical brief and one different constraint:
+
+- Alternative 1: "Minimize the interface — aim for 1–3 entry points max.
+  Maximise leverage per entry point."
+- Alternative 2: "Maximise flexibility — support many use cases and extension."
+- Alternative 3: "Optimise for the most common caller — make the default case
   trivial."
-- Agent 4 (if applicable): "Design around ports & adapters for cross-seam
-  dependencies."
+- Alternative 4, when applicable: "Design around ports & adapters for
+  cross-seam dependencies."
 
 Include both [../SKILL.md](../SKILL.md) vocabulary and CONTEXT.md vocabulary
-in the brief so each sub-agent names things consistently with the
-architecture language and the project's domain language.
+in every brief. Each worker must not modify, patch, or stash.
 
-Each sub-agent outputs:
+Each worker outputs:
 
-1. Interface (types, methods, params — plus invariants, ordering, error
-   modes)
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
 2. Usage example showing how callers use it
 3. What the implementation hides behind the seam
 4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
 5. Trade-offs — where leverage is high, where it's thin
+
+On one nonzero completion, use the selected adapter's `resume` surface once
+against that alternative's same state file. If it still does not produce a
+successful `final_message`, mark that alternative unavailable. With two or more
+successful alternatives, present and compare the available designs, naming every
+unavailable alternative. With zero or one successful alternative, report that
+the design-it-twice pass did not produce enough alternatives and return to the
+interface-shape frontier; do not recommend a design.
 
 ### 3. Present and compare
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -119,6 +119,57 @@ dispatch the coordinator writes the exact chat-delivered plan bytes to an
 immutable session-scratch file and supplies only that file's path as the plan
 location. The worker receives no chat transcript or author-session context."""
 
+DESIGN_IT_TWICE_ADAPTER_DISPATCH = """\
+The coordinator supplies the selected adapter, explicit design-agent model, and
+explicit design-agent effort. Pass model and effort unchanged to every design
+worker. This procedure does not select an adapter, model, or effort, apply a
+routing table or headroom policy, or add defaults.
+
+Dispatch only through `skills/drivers/orchestrate/scripts/codex-worker.py` or
+`skills/drivers/orchestrate/scripts/claude-worker.py`, using the selected
+adapter's read-only surface. Never use the built-in Agent tool, Workflow tool,
+or background-agent machinery.
+
+Create one coordinator-owned `<session-scratch>/design-it-twice/` directory.
+For alternative `<n>`, write its complete independent technical brief to
+`design-<n>.prompt.md`; use `design-<n>.json` as that worker's state file; and
+capture its launcher stdout and stderr in `design-<n>.stdout` and
+`design-<n>.stderr`. The coordinator passes the contents of
+`design-<n>.prompt.md` as the adapter's positional prompt text. State files
+carry lifecycle metadata only; successful design output comes from each
+launcher's stdout `final_message`.
+
+Start alternatives 1, 2, and 3 through the selected adapter before waiting on
+any launcher, retaining each launcher PID and joining each individually. Each
+worker receives its separate technical brief and one different constraint:
+
+- Alternative 1: "Minimize the interface — aim for 1–3 entry points max.
+  Maximise leverage per entry point."
+- Alternative 2: "Maximise flexibility — support many use cases and extension."
+- Alternative 3: "Optimise for the most common caller — make the default case
+  trivial."
+- Alternative 4, when applicable: "Design around ports & adapters for
+  cross-seam dependencies."
+
+Include both [../SKILL.md](../SKILL.md) vocabulary and CONTEXT.md vocabulary
+in every brief. Each worker must not modify, patch, or stash.
+
+Each worker outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+On one nonzero completion, use the selected adapter's `resume` surface once
+against that alternative's same state file. If it still does not produce a
+successful `final_message`, mark that alternative unavailable. With two or more
+successful alternatives, present and compare the available designs, naming every
+unavailable alternative. With zero or one successful alternative, report that
+the design-it-twice pass did not produce enough alternatives and return to the
+interface-shape frontier; do not recommend a design."""
+
 PERSONA_REVIEW_PANELIST_DISPATCH = """\
 The coordinator supplies the selected adapter, explicit reviewer model, and explicit
 reviewer effort. For each panelist, dispatch only through
@@ -3335,6 +3386,17 @@ class ResearchAdapterDispatchTests(unittest.TestCase):
         job = self.research_job()
         self.assertIn("The coordinator writes the returned findings to a single Markdown file", job)
         self.assertIn("Save it where the repo already keeps such notes; match the existing convention", job)
+
+
+class DesignItTwiceAdapterDispatchTests(unittest.TestCase):
+    REFERENCE = ROOT / "skills" / "tools" / "codebase-design" / "references" / "DESIGN-IT-TWICE.md"
+
+    def test_dispatch_section_is_byte_identical(self):
+        text = self.REFERENCE.read_text(encoding="utf-8")
+        dispatch = text.split("### 2. Dispatch parallel design alternatives\n\n", 1)[1].split(
+            "\n\n### 3. Present and compare\n", 1
+        )[0]
+        self.assertEqual(dispatch, DESIGN_IT_TWICE_ADAPTER_DISPATCH)
 
 
 class WorkerLifecycleContractTests(unittest.TestCase):


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Codebase-design's design-it-twice alternatives now come from workers dispatched through the pack adapters, read-only, one per alternative with coordinator-supplied model and effort. Before this, the reference spawned sub-agents through the harness's Agent tool.

* The dispatch block is byte-pinned, and the closing anchor now requires its terminating newline, so a suffix edit to the heading fails the test rather than silently extending the extraction.
* Comparison and synthesis of the returned designs stay with the dispatching session; the workers never see each other's output.
* Below two successful alternatives the session reports the shortfall and returns to the interface-shape frontier without recommending a design.
* A failed alternative resumes once from its state file; after a second failure it is reported unavailable.

Triage rounds and the review verdicts are on the issue.

Closes #157

## Verification

```text
validated 27 skills and 305 files
Ran 415 tests ... OK (skipped=23)
py_compile exit 0
```

The pin was shown red before the production edit and under body, opening-anchor, and closing-anchor-suffix mutation afterward. It covers the dispatch block in the reference; surrounding design guidance is unpinned.
