### PR TITLE
Pack-wide reach: all dispatching skills converted

### DIFF
--- a/skills/drivers/orchestrate/SKILL.md
+++ b/skills/drivers/orchestrate/SKILL.md
@@ -218,21 +218,12 @@ Per ADR 149 (`docs/adr/adr-149-pack-owned-model-dispatch.md`): all model
 dispatch defined by this pack goes through this pack's own adapters
 (`claude-worker.py` / `codex-worker.py`), not the built-in Agent tool, the
 Workflow tool, or background agents. That ruling covers every skill that
-dispatches a model, not only `orchestrate`. `code-review` (issue #151) and
-`plan-review` (issue #152) now use the adapters. The remaining skills convert
-one at a time behind their own issues and keep their current dispatch mechanism
-until converted:
-
-- **persona-review** (issue #153)
-- **ticket**'s chunk agents (issue #154)
-- **epic** (issue #155)
-- **research** (issue #156) — `skills/tools/research/SKILL.md:8` spawns a
-  background agent today
-- **codebase-design** (issue #157) — `references/DESIGN-IT-TWICE.md:37`
-  spawns sub-agents via the Agent tool today
-
-Do not convert any remaining skill above in this ticket; the ban binds each one only
-once its own issue lands.
+dispatches a model, not only `orchestrate`. Every dispatching skill is now
+converted: `code-review` (issue #151), `plan-review` (issue #152),
+`persona-review` (issue #153), `ticket`'s chunk agents (issue #154), `epic`
+(issue #155), `research` (issue #156), and `codebase-design` (issue #157) all
+use the adapters. A future skill that dispatches a model converts behind its
+own issue before the ban binds it.
 
 ## Maintenance
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -302,21 +302,12 @@ Per ADR 149 (`docs/adr/adr-149-pack-owned-model-dispatch.md`): all model
 dispatch defined by this pack goes through this pack's own adapters
 (`claude-worker.py` / `codex-worker.py`), not the built-in Agent tool, the
 Workflow tool, or background agents. That ruling covers every skill that
-dispatches a model, not only `orchestrate`. `code-review` (issue #151) and
-`plan-review` (issue #152) now use the adapters. The remaining skills convert
-one at a time behind their own issues and keep their current dispatch mechanism
-until converted:
-
-- **persona-review** (issue #153)
-- **ticket**'s chunk agents (issue #154)
-- **epic** (issue #155)
-- **research** (issue #156) — `skills/tools/research/SKILL.md:8` spawns a
-  background agent today
-- **codebase-design** (issue #157) — `references/DESIGN-IT-TWICE.md:37`
-  spawns sub-agents via the Agent tool today
-
-Do not convert any remaining skill above in this ticket; the ban binds each one only
-once its own issue lands."""
+dispatches a model, not only `orchestrate`. Every dispatching skill is now
+converted: `code-review` (issue #151), `plan-review` (issue #152),
+`persona-review` (issue #153), `ticket`'s chunk agents (issue #154), `epic`
+(issue #155), `research` (issue #156), and `codebase-design` (issue #157) all
+use the adapters. A future skill that dispatches a model converts behind its
+own issue before the ban binds it."""
 
 DISPATCH_CODEX_ADMISSION = """\
 These are the only validated initial routes in Codex-only mode:


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Orchestrate's pack-wide reach section now states that every dispatching skill uses the pack adapters, closing the conversion ledger that #153 through #157 completed. Before this, the section still listed those five skills as unconverted, so a coordinator reading it received the opposite of what each converted skill now mandates.

* The five per-skill conversion orders were forbidden from touching this shared block to avoid a five-way conflict on one pinned region; this integration commit updates the block and its byte-pinned test constant together, once.
* A future dispatching skill converts behind its own issue before the ban binds it; that rule survives from the old wording.

Closes no issue; integration commit for the #153-#157 subtree recorded on the epic ledger.

## Verification

```text
validated 27 skills and 305 files
Ran 416 tests ... OK (skipped=1 in module run)
```

The pinned constant and the production block were edited from one shared string, so drift between them was impossible in this change; the equality test exercises the pairing.
