### PR TITLE
Require verbatim command-generated triage evidence blocks

### DIFF
--- a/skills/tools/plan-review/SKILL.md
+++ b/skills/tools/plan-review/SKILL.md
@@ -35,6 +35,13 @@ separate cold reviewer per plan through the interface below. Self-review by the
 author reliably misses what a cold reader catches, no matter how honestly the
 author tries to re-derive.
 
+### Evidence-block spot check
+
+During the cold read, spot-check at least one `command → output` evidence block:
+run its recorded command and compare the complete result to the cited output.
+Treat a manual edit found in any evidence block as independently requiring a
+**BLOCKED** verdict.
+
 ## Delegation authority
 
 Invoking this skill authorizes every sub-agent dispatch that this procedure marks mandatory, including a mandatory nested review skill. Do not ask again solely because a session-level preference says "do not spawn agents"; apply that preference to discretionary delegation only. An explicit task-level refusal of this required review or revocation of delegation overrides this authorization: stop and state that the requested workflow cannot run without its required independent review.

--- a/skills/tools/preflight/SKILL.md
+++ b/skills/tools/preflight/SKILL.md
@@ -43,6 +43,14 @@ re-deriving the number, which is a round.
   flag — is not a grep.** It belongs to move 2. Do not let a grep that finds the
   param's name stand in for evidence that anything reads it.
 
+### Verbatim command output
+
+Every `command → output` evidence block is pasted verbatim from an actual command
+run. To abbreviate output, change the command so it produces the shorter output
+(for example, `grep -m` or `head`); never edit the captured output, insert
+ellipses, or drop matches. Manual edits are prohibited and require a **BLOCKED**
+verdict on their own.
+
 ## 2. First-hour spike
 
 Before any reviewer sees the draft, **execute the plan's opening steps against

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -170,6 +170,19 @@ unavailable alternative. With zero or one successful alternative, report that
 the design-it-twice pass did not produce enough alternatives and return to the
 interface-shape frontier; do not recommend a design."""
 
+PREFLIGHT_VERBATIM_COMMAND_OUTPUT = """\
+Every `command → output` evidence block is pasted verbatim from an actual command
+run. To abbreviate output, change the command so it produces the shorter output
+(for example, `grep -m` or `head`); never edit the captured output, insert
+ellipses, or drop matches. Manual edits are prohibited and require a **BLOCKED**
+verdict on their own."""
+
+PLAN_REVIEW_EVIDENCE_BLOCK_SPOT_CHECK = """\
+During the cold read, spot-check at least one `command → output` evidence block:
+run its recorded command and compare the complete result to the cited output.
+Treat a manual edit found in any evidence block as independently requiring a
+**BLOCKED** verdict."""
+
 PERSONA_REVIEW_PANELIST_DISPATCH = """\
 The coordinator supplies the selected adapter, explicit reviewer model, and explicit
 reviewer effort. For each panelist, dispatch only through
@@ -3312,6 +3325,25 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
             "\n\n## Cold-reader dispatch", 1
         )[0]
         self.assertEqual(authority, MANDATORY_DELEGATION_AUTHORIZATION)
+
+
+class EvidenceBlockContractTests(unittest.TestCase):
+    def test_verbatim_evidence_sections_are_byte_identical(self):
+        preflight = (ROOT / "skills" / "tools" / "preflight" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        preflight_body = preflight.split("### Verbatim command output\n\n", 1)[1].split(
+            "\n\n## 2. First-hour spike", 1
+        )[0]
+        self.assertEqual(preflight_body, PREFLIGHT_VERBATIM_COMMAND_OUTPUT)
+
+        plan_review = (ROOT / "skills" / "tools" / "plan-review" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        plan_review_body = plan_review.split("### Evidence-block spot check\n\n", 1)[1].split(
+            "\n\n## Delegation authority", 1
+        )[0]
+        self.assertEqual(plan_review_body, PLAN_REVIEW_EVIDENCE_BLOCK_SPOT_CHECK)
 
 
 class PersonaReviewAdapterDispatchTests(unittest.TestCase):

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3329,17 +3329,17 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
 
 class EvidenceBlockContractTests(unittest.TestCase):
     def test_verbatim_evidence_sections_are_byte_identical(self):
-        preflight = (ROOT / "skills" / "tools" / "preflight" / "SKILL.md").read_text(
-            encoding="utf-8"
+        preflight = (ROOT / "skills" / "tools" / "preflight" / "SKILL.md").read_bytes().decode(
+            "utf-8"
         )
         preflight_body = preflight.split("### Verbatim command output\n\n", 1)[1].split(
             "\n\n## 2. First-hour spike", 1
         )[0]
         self.assertEqual(preflight_body, PREFLIGHT_VERBATIM_COMMAND_OUTPUT)
 
-        plan_review = (ROOT / "skills" / "tools" / "plan-review" / "SKILL.md").read_text(
-            encoding="utf-8"
-        )
+        plan_review = (
+            ROOT / "skills" / "tools" / "plan-review" / "SKILL.md"
+        ).read_bytes().decode("utf-8")
         plan_review_body = plan_review.split("### Evidence-block spot check\n\n", 1)[1].split(
             "\n\n## Delegation authority", 1
         )[0]


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Preflight now requires verbatim command output in evidence blocks, and plan-review spot-checks a recorded command against its cited output and blocks manual edits. Before this, an agent could paraphrase or truncate output while labeling it literal, which is how stale and silently-shortened evidence survived triage this week.

* Both contract paragraphs are pinned as raw bytes between heading anchors, so CRLF drift fails the pin along with any wording change; the earlier text-mode comparison accepted newline conversion.
* Preflight governs writing an appendix; plan-review spot-checks at least one evidence block per review and blocks manual edits.

Triage round (shipped first pass) and the review verdicts are on the issue.

Closes #164

## Verification

```text
validated 27 skills and 305 files
Ran 416 tests ... OK
py_compile exit 0
```

Both pins were shown red before the production edits and under a CRLF checkout of the pinned files afterward. The pins cover the two contract paragraphs; appendix quality elsewhere still depends on reviewers running the commands.
