### PR TITLE
Stamp the builder self-check into start and the sub-order fence

### DIFF
--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -164,6 +164,15 @@ Context
 <everything this chunk needs to stand alone in a fresh agent. Never "as established
  in chunk 1".>
 
+### Builder self-check
+
+Before declaring the change ready, run each check below.
+
+1. **External surface by execution.** Before coding against a CLI or API surface, run `--help` or a probe call against that surface; do not infer flags, arguments, or behavior from memory.
+2. **Fail-first tests.** Before production edits, run every new test against the pre-change behavior or a deliberately broken variant and observe the expected failure. A fake that accepts every input or a mock of the function under test is not evidence.
+3. **Boundaries by execution.** Prove a security or confinement claim by attempting the forbidden action in a real run; configuration inspection alone is not evidence.
+4. **Post-fix sweep.** After each late fix, sweep its affected path for uncalled symbols, dead parameters, and prose that still describes the pre-fix behavior.
+
 Do
 <numbered, concrete steps scoped to this chunk only>
 

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -59,6 +59,15 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
    before implementing. Absent, say so in one line and continue. This never refuses
    the order.
 
+### Builder self-check
+
+Before declaring the change ready, run each check below.
+
+1. **External surface by execution.** Before coding against a CLI or API surface, run `--help` or a probe call against that surface; do not infer flags, arguments, or behavior from memory.
+2. **Fail-first tests.** Before production edits, run every new test against the pre-change behavior or a deliberately broken variant and observe the expected failure. A fake that accepts every input or a mock of the function under test is not evidence.
+3. **Boundaries by execution.** Prove a security or confinement claim by attempting the forbidden action in a real run; configuration inspection alone is not evidence.
+4. **Post-fix sweep.** After each late fix, sweep its affected path for uncalled symbols, dead parameters, and prose that still describes the pre-fix behavior.
+
 8. **Implement.** Read the repo's `AGENTS.md` or `CLAUDE.md` first; its rules bind
    everything you write on this branch. Never add or edit one yourself; if the repo
    has none, work to the user's global standards. Follow the order's Do section.

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -183,22 +183,22 @@ def assistant_line(
 
 class TicketSkillContractTests(unittest.TestCase):
     def test_builder_self_check_is_pinned_in_flat_and_chunked_builder_guidance(self):
-        start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")
-        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
-            encoding="utf-8"
-        )
-        sub_order = template.split("SUB-ORDER 1/<n>", 1)[1].split("```", 1)[0]
-        start_body = start.split("### Builder self-check\n\n", 1)[1].split(
-            "\n\n8. **Implement.**", 1
+        start = (TICKET_DIRECTORY / "verbs" / "start.md").read_bytes()
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_bytes()
+        sub_order_fence = template.split(b"SUB-ORDER 1/<n>", 1)[1]
+        self.assertEqual(sub_order_fence.count(b"```"), 1)
+        sub_order = sub_order_fence.split(b"```", 1)[0]
+        start_body = start.split(b"### Builder self-check\n\n", 1)[1].split(
+            b"\n\n8. **Implement.**", 1
         )[0]
-        sub_order_body = sub_order.split("### Builder self-check\n\n", 1)[1].split(
-            "\n\nDo\n", 1
+        sub_order_body = sub_order.split(b"### Builder self-check\n\n", 1)[1].split(
+            b"\n\nDo\n", 1
         )[0]
 
-        self.assertEqual(start_body, BUILDER_SELF_CHECK_BODY)
-        self.assertEqual(sub_order_body, BUILDER_SELF_CHECK_BODY)
-        self.assertEqual(start.count("### Builder self-check"), 1)
-        self.assertEqual(sub_order.count("### Builder self-check"), 1)
+        self.assertEqual(start_body, BUILDER_SELF_CHECK_BODY.encode())
+        self.assertEqual(sub_order_body, BUILDER_SELF_CHECK_BODY.encode())
+        self.assertEqual(start.count(b"### Builder self-check"), 1)
+        self.assertEqual(sub_order.count(b"### Builder self-check"), 1)
 
     def test_flat_session_fit_is_produced_and_consumed(self):
         template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -53,6 +53,21 @@ SESSION_FIT_MODEL_CHECK_BODY = (
     "refused. Never run part of it, and never launch an agent smarter than the "
     "coordinator."
 )
+BUILDER_SELF_CHECK_BODY = (
+    "Before declaring the change ready, run each check below.\n"
+    "\n"
+    "1. **External surface by execution.** Before coding against a CLI or API surface, "
+    "run `--help` or a probe call against that surface; do not infer flags, arguments, "
+    "or behavior from memory.\n"
+    "2. **Fail-first tests.** Before production edits, run every new test against the "
+    "pre-change behavior or a deliberately broken variant and observe the expected "
+    "failure. A fake that accepts every input or a mock of the function under test is "
+    "not evidence.\n"
+    "3. **Boundaries by execution.** Prove a security or confinement claim by attempting "
+    "the forbidden action in a real run; configuration inspection alone is not evidence.\n"
+    "4. **Post-fix sweep.** After each late fix, sweep its affected path for uncalled "
+    "symbols, dead parameters, and prose that still describes the pre-fix behavior."
+)
 
 TICKET_CHUNK_WORKER_ADAPTER_DISPATCH = """3. **Dispatch one agent per chunk** at the tier its `Agent:` line names. The
    coordinator supplies the selected adapter, the explicit worker model resolved for
@@ -167,6 +182,24 @@ def assistant_line(
 
 
 class TicketSkillContractTests(unittest.TestCase):
+    def test_builder_self_check_is_pinned_in_flat_and_chunked_builder_guidance(self):
+        start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
+            encoding="utf-8"
+        )
+        sub_order = template.split("SUB-ORDER 1/<n>", 1)[1].split("```", 1)[0]
+        start_body = start.split("### Builder self-check\n\n", 1)[1].split(
+            "\n\n8. **Implement.**", 1
+        )[0]
+        sub_order_body = sub_order.split("### Builder self-check\n\n", 1)[1].split(
+            "\n\nDo\n", 1
+        )[0]
+
+        self.assertEqual(start_body, BUILDER_SELF_CHECK_BODY)
+        self.assertEqual(sub_order_body, BUILDER_SELF_CHECK_BODY)
+        self.assertEqual(start.count("### Builder self-check"), 1)
+        self.assertEqual(sub_order.count("### Builder self-check"), 1)
+
     def test_flat_session_fit_is_produced_and_consumed(self):
         template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
             encoding="utf-8"

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -185,8 +185,10 @@ class TicketSkillContractTests(unittest.TestCase):
     def test_builder_self_check_is_pinned_in_flat_and_chunked_builder_guidance(self):
         start = (TICKET_DIRECTORY / "verbs" / "start.md").read_bytes()
         template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_bytes()
+        start.decode("utf-8")
+        template.decode("utf-8")
         sub_order_fence = template.split(b"SUB-ORDER 1/<n>", 1)[1]
-        self.assertEqual(sub_order_fence.count(b"```"), 1)
+        self.assertGreaterEqual(sub_order_fence.count(b"```"), 1)
         sub_order = sub_order_fence.split(b"```", 1)[0]
         start_body = start.split(b"### Builder self-check\n\n", 1)[1].split(
             b"\n\n8. **Implement.**", 1


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Builders now run a four-item self-check before implementing (external surfaces verified by execution, fail-first tests proven against a broken variant, boundary claims tested by attempting the forbidden action, and a sweep of affected paths after late fixes), stamped into the start verb before implementation begins and into the chunked template's sub-order fence, the one surface a chunk worker actually receives. Before this, the checklist existed only as coordinator lore; one day of reviews produced 21 blockers, and these four patterns covered nearly all of them.

* The checklist body is pinned once and asserted byte-identical in both locations, compared as raw bytes so newline drift fails.
* Placement follows delivery: the flat copy sits before the implement step, the chunk copy inside the fence before its Do section, because the worker prompt carries the fence verbatim and nothing else.
* Review depth is unchanged.

Triage rounds and the review verdicts are on the issue.

Closes #165

## Verification

```text
validated 27 skills and 305 files
Ran 416 tests ... OK
py_compile exit 0
```

The pin was shown red before the production edits, under CRLF mutation, and with the sub-order's closing fence deleted. Whole-file UTF-8 validity is asserted; content outside the pinned bodies is otherwise unpinned.
