### PR TITLE
Review-process tuning: drafting conventions, fix-in-place, depth-floor qualifier

### DIFF
--- a/skills/drivers/ticket/references/drafting-conventions.md
+++ b/skills/drivers/ticket/references/drafting-conventions.md
@@ -1,0 +1,25 @@
+# Drafting conventions
+
+## Drafting conventions
+
+Canonical prose constants name only the bytes strictly between their named opening
+and closing full-heading-line anchors; neither anchor is part of the constant.
+Read source with `Path.read_bytes()` and compare bytes directly. Do not use
+`read_text()`, universal-newline normalization, or a line-oriented surrogate.
+
+Transcribe a target repository's `AGENTS.md` `Test:` entry byte-exact into the
+order. When this host's interpreter substitution matters, state it separately and
+exactly: `Run every python3 above as /opt/homebrew/bin/python3.14; bare python3
+on this host is 3.9.6.`
+
+Adapter prompts are prompt text passed positionally. The coordinator writes each
+complete prompt to session scratch, passes that file's contents as the adapter's
+positional prompt text, and never invents adapter flags or changes. Each dispatch
+has one coordinator-owned state file; state is lifecycle metadata, never the
+worker's result.
+
+An expected diff is a closed allowlist of repository-relative paths. It has no
+escape clause. A generated-facts appendix records deterministic commands and their
+byte-complete literal output; every cited line is regenerated from the checked-out
+tree.
+## Consumer reach

--- a/skills/drivers/ticket/references/review-depth.md
+++ b/skills/drivers/ticket/references/review-depth.md
@@ -35,8 +35,11 @@ touches any of:
 * behavior shared across an organization (a shared library, an organization-level
   setting, a workflow every repo inherits)
 
-These override a lower stamp without discussion.
+For workflow machinery every repo inherits: Full when the change alters contract
+semantics; Targeted for pure relocation, citation repoints, and additive paragraphs
+that no existing consumer's behavior depends on.
 
+These override a lower stamp without discussion.
 ## What blocks
 
 A finding blocks only when it breaks the order's **Done when** clause. That is the

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -84,6 +84,8 @@ Expectation: <what that command must report before the pull request opens>
 Review depth: <focused | targeted | full> (<one-line reason>)
 Profile: <none | hardening>
 
+Drafting conventions: Read `skills/drivers/ticket/references/drafting-conventions.md` before acting on this order.
+
 Context
 <2-5 bullets: what exists today, what constrains this change, decisions already made
  (from the scoping interview or repo history) that the implementation must respect>
@@ -159,6 +161,8 @@ Surface lifecycle: <none | build | revise>
 Review depth: <focused | targeted | full> (<one-line reason>)
 Capability owned: <one coherent capability; exactly one sub-order owns it>
 Shared contracts owned: <none | each named contract this sub-order owns>
+
+Drafting conventions: Read `skills/drivers/ticket/references/drafting-conventions.md` before acting on this order.
 
 Context
 <everything this chunk needs to stand alone in a fresh agent. Never "as established

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -38,9 +38,11 @@ long ago and the pull request is one diff.
    before actioning the round. Absent, say so in one line and continue. This never
    refuses the round.
 
-4. **Collect the round.** Unresolved review comments (human and automated), failing
-   checks, and any new verification output CI posted. List them before touching
-   code.
+4. **Collect the round.** Read
+   [drafting conventions](../references/drafting-conventions.md) before evaluating
+   an order revision. Then collect unresolved review comments (human and automated),
+   failing checks, and any new verification output CI posted. List them before
+   touching code.
 
 5. **Judge, then fix.** Ground every item and classify it with
    [references/review-actions.md](../references/review-actions.md). Never silently

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -68,9 +68,10 @@ Before declaring the change ready, run each check below.
 3. **Boundaries by execution.** Prove a security or confinement claim by attempting the forbidden action in a real run; configuration inspection alone is not evidence.
 4. **Post-fix sweep.** After each late fix, sweep its affected path for uncalled symbols, dead parameters, and prose that still describes the pre-fix behavior.
 
-8. **Implement.** Read the repo's `AGENTS.md` or `CLAUDE.md` first; its rules bind
-   everything you write on this branch. Never add or edit one yourself; if the repo
-   has none, work to the user's global standards. Follow the order's Do section.
+8. **Implement.** Read [drafting conventions](../references/drafting-conventions.md)
+   with the locked order, then read the repo's `AGENTS.md` or `CLAUDE.md`; its rules
+   bind everything you write on this branch. Never add or edit one yourself; if the
+   repo has none, work to the user's global standards. Follow the order's Do section.
    Match the repo's existing idioms, reading neighboring code first. Record the
    change where the repo already records changes, on the same branch, per the skill
    page's change-record rule. An epic child creates no change record: the parent

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -165,7 +165,8 @@ the branch, and its change record already belongs to the parent epic.
     say so in the order's Context, and continue with the default workflow. Stamp
     `Profile: none` on every chunked order: the profile is flat-only.
 
-11. **Draft the work order.** Apply
+11. **Draft the work order.** Read
+    [drafting conventions](../references/drafting-conventions.md), apply
     [references/brief-quality.md](../references/brief-quality.md), then fill
     [templates/work-order.md](../templates/work-order.md), the flat shape or the
     chunked shape per step 8, and run that page's two authoring checks before the

--- a/skills/tools/plan-review/SKILL.md
+++ b/skills/tools/plan-review/SKILL.md
@@ -13,8 +13,9 @@ The subject can be anything plan-shaped: a GitHub issue, an agent work order, a
 PRD, a design doc, a chat-message plan. If the user didn't point at one, ask
 what to review — don't guess.
 
-**Read-only.** A plan review never edits code and never fixes the plan itself.
-It produces objections and a verdict; revising the plan is the author's job.
+**Read-only reviewer.** A plan review never edits code, and the reviewer never
+independently edits the order. It produces objections and a verdict. The caller-owned
+exception is defined in [Mechanical fix in place](#mechanical-fix-in-place).
 
 ## Evidence v2
 
@@ -77,7 +78,8 @@ The cold-reader prompt contains exactly:
 1. plan location;
 2. the five-axis rubric;
 3. stakes tier; and
-4. a context-free fresh-reviewer phase instruction.
+4. a context-free fresh-reviewer phase instruction that requires the reviewer
+   to read [drafting conventions](../../drivers/ticket/references/drafting-conventions.md).
 
 The prompt excludes earlier findings, author rationale, chat history, and all
 other author/coordinator-session material. For a chat-delivered plan, before
@@ -85,6 +87,27 @@ dispatch the coordinator writes the exact chat-delivered plan bytes to an
 immutable session-scratch file and supplies only that file's path as the plan
 location. The worker receives no chat transcript or author-session context.
 
+For every review invocation, the caller creates one coordinator-owned
+session-scratch file named `plan-review-mechanical-fixes.md`. For a durable plan,
+place it in that review invocation's session scratch and record the durable plan
+locator and immutable revision. For a chat-delivered plan, place it beside the
+immutable session-scratch plan file and record that plan file path.
+
+Each entry has exactly: finding; exact correction; reviewer re-check result. The
+file is review-round evidence, never a worker result or a committed repository
+artifact.
+## Mechanical fix in place
+
+A coordinator may correct a cold-review finding in the order without opening a
+rewrite-plus-review round only when both the finding and its correction are
+deterministic and mechanical: for example, a wrong heading anchor, a missing exact
+string, or nondeterministic command ordering.
+
+Record the finding and the exact correction in the round ledger, then have the
+current reviewer re-check the changed order bytes in that same round. A correction
+that requires judgment, changes a decision, changes scope, or reopens a settled
+ruling stays in the panel-or-operator path and does consume the ordinary revision
+cycle.
 ## The rubric
 
 Judge the plan on exactly these five axes. For axes 3 and 4, ground in the

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -140,7 +140,7 @@ after the applicable routing ladder is exhausted; do not retry past that ladder.
 # closed prompt allowlist, and worker-isolation. The skill's section is pinned
 # byte-for-byte against this constant, so any prose edit inside it — of any
 # phrasing — fails by construction rather than by pattern matching.
-PLAN_REVIEW_COLD_READER_DISPATCH = """\
+PLAN_REVIEW_COLD_READER_DISPATCH = b"""
 At the standard skill root, when `orchestrate` is installed, read its
 `references/review-routing.md` and `references/routing-table.md` directly before
 dispatch. Use the four-row reviewer matrix and apply its Claude-parent Codex
@@ -170,13 +170,38 @@ The cold-reader prompt contains exactly:
 1. plan location;
 2. the five-axis rubric;
 3. stakes tier; and
-4. a context-free fresh-reviewer phase instruction.
+4. a context-free fresh-reviewer phase instruction that requires the reviewer
+   to read [drafting conventions](../../drivers/ticket/references/drafting-conventions.md).
 
 The prompt excludes earlier findings, author rationale, chat history, and all
 other author/coordinator-session material. For a chat-delivered plan, before
 dispatch the coordinator writes the exact chat-delivered plan bytes to an
 immutable session-scratch file and supplies only that file's path as the plan
-location. The worker receives no chat transcript or author-session context."""
+location. The worker receives no chat transcript or author-session context.
+
+For every review invocation, the caller creates one coordinator-owned
+session-scratch file named `plan-review-mechanical-fixes.md`. For a durable plan,
+place it in that review invocation's session scratch and record the durable plan
+locator and immutable revision. For a chat-delivered plan, place it beside the
+immutable session-scratch plan file and record that plan file path.
+
+Each entry has exactly: finding; exact correction; reviewer re-check result. The
+file is review-round evidence, never a worker result or a committed repository
+artifact.
+"""
+
+MECHANICAL_FIX_IN_PLACE_BODY = b"""
+A coordinator may correct a cold-review finding in the order without opening a
+rewrite-plus-review round only when both the finding and its correction are
+deterministic and mechanical: for example, a wrong heading anchor, a missing exact
+string, or nondeterministic command ordering.
+
+Record the finding and the exact correction in the round ledger, then have the
+current reviewer re-check the changed order bytes in that same round. A correction
+that requires judgment, changes a decision, changes scope, or reopens a settled
+ruling stays in the panel-or-operator path and does consume the ordinary revision
+cycle.
+"""
 
 DESIGN_IT_TWICE_ADAPTER_DISPATCH = """\
 The coordinator supplies the selected adapter, explicit design-agent model, and
@@ -3412,19 +3437,39 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
     SKILL = ROOT / "skills" / "tools" / "plan-review" / "SKILL.md"
 
     def setUp(self):
-        self.text = self.SKILL.read_text(encoding="utf-8")
+        self.source = self.SKILL.read_bytes()
 
     def test_cold_reader_dispatch_section_is_byte_identical(self):
-        dispatch = self.text.split("## Cold-reader dispatch\n\n", 1)[1].split(
-            "\n\n## The rubric", 1
-        )[0]
+        opening = b"## Cold-reader dispatch\n"
+        closing = b"## Mechanical fix in place\n"
+        self.assertEqual(self.source.count(opening), 1)
+        self.assertEqual(self.source.count(closing), 1)
+        dispatch = self.source.split(opening, 1)[1].split(closing, 1)[0]
         self.assertEqual(dispatch, PLAN_REVIEW_COLD_READER_DISPATCH)
 
-    def test_mandatory_independent_review_authority_is_preserved(self):
-        authority = self.text.split("## Delegation authority\n\n", 1)[1].split(
-            "\n\n## Cold-reader dispatch", 1
+    def test_mechanical_fix_in_place_section_is_byte_identical(self):
+        opening = b"## Mechanical fix in place\n"
+        closing = b"## The rubric\n"
+        self.assertEqual(self.source.count(opening), 1)
+        self.assertEqual(self.source.count(closing), 1)
+        body = self.source.split(opening, 1)[1].split(closing, 1)[0]
+        self.assertEqual(body, MECHANICAL_FIX_IN_PLACE_BODY)
+
+    def test_caller_owned_round_ledger_covers_both_plan_locations(self):
+        dispatch = self.source.split(b"## Cold-reader dispatch\n", 1)[1].split(
+            b"## Mechanical fix in place\n", 1
         )[0]
-        self.assertEqual(authority, MANDATORY_DELEGATION_AUTHORIZATION)
+        self.assertIn(b"For a durable plan", dispatch)
+        self.assertIn(b"durable plan\nlocator and immutable revision", dispatch)
+        self.assertIn(b"For a chat-delivered plan", dispatch)
+        self.assertIn(b"record that plan file path", dispatch)
+        self.assertIn(b"plan-review-mechanical-fixes.md", dispatch)
+
+    def test_mandatory_independent_review_authority_is_preserved(self):
+        authority = self.source.split(b"## Delegation authority\n\n", 1)[1].split(
+            b"\n\n## Cold-reader dispatch", 1
+        )[0]
+        self.assertEqual(authority, MANDATORY_DELEGATION_AUTHORIZATION.encode())
 
 
 class EvidenceBlockContractTests(unittest.TestCase):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -69,6 +69,54 @@ BUILDER_SELF_CHECK_BODY = (
     "symbols, dead parameters, and prose that still describes the pre-fix behavior."
 )
 
+DRAFTING_CONVENTIONS_BODY = b"""
+Canonical prose constants name only the bytes strictly between their named opening
+and closing full-heading-line anchors; neither anchor is part of the constant.
+Read source with `Path.read_bytes()` and compare bytes directly. Do not use
+`read_text()`, universal-newline normalization, or a line-oriented surrogate.
+
+Transcribe a target repository's `AGENTS.md` `Test:` entry byte-exact into the
+order. When this host's interpreter substitution matters, state it separately and
+exactly: `Run every python3 above as /opt/homebrew/bin/python3.14; bare python3
+on this host is 3.9.6.`
+
+Adapter prompts are prompt text passed positionally. The coordinator writes each
+complete prompt to session scratch, passes that file's contents as the adapter's
+positional prompt text, and never invents adapter flags or changes. Each dispatch
+has one coordinator-owned state file; state is lifecycle metadata, never the
+worker's result.
+
+An expected diff is a closed allowlist of repository-relative paths. It has no
+escape clause. A generated-facts appendix records deterministic commands and their
+byte-complete literal output; every cited line is regenerated from the checked-out
+tree.
+"""
+
+REVIEW_DEPTH_SENSITIVITY_FLOOR_BODY = b"""
+Judgment, not a keyword match. A change is **Full**, non-negotiably, when it
+touches any of:
+
+* authentication, authorization, or identity (trust policies, role assumption,
+  single sign-on, token scope)
+* secrets: creation, rotation, scope, or exposure surface
+* destructive or irreversible operations (deletes, replaces, force-applies,
+  data-bearing resources)
+* behavior shared across an organization (a shared library, an organization-level
+  setting, a workflow every repo inherits)
+
+For workflow machinery every repo inherits: Full when the change alters contract
+semantics; Targeted for pure relocation, citation repoints, and additive paragraphs
+that no existing consumer's behavior depends on.
+
+These override a lower stamp without discussion.
+"""
+
+DRAFTING_CONVENTIONS_INSTRUCTION = (
+    b"Drafting conventions: Read "
+    b"`skills/drivers/ticket/references/drafting-conventions.md` "
+    b"before acting on this order."
+)
+
 TICKET_CHUNK_WORKER_ADAPTER_DISPATCH = """3. **Dispatch one agent per chunk** at the tier its `Agent:` line names. The
    coordinator supplies the selected adapter, the explicit worker model resolved for
    that tier, and explicit worker effort. Dispatch only through
@@ -182,6 +230,44 @@ def assistant_line(
 
 
 class TicketSkillContractTests(unittest.TestCase):
+    def test_drafting_conventions_are_canonical_raw_bytes(self):
+        path = TICKET_DIRECTORY / "references" / "drafting-conventions.md"
+        source = path.read_bytes()
+        opening = b"## Drafting conventions\n"
+        closing = b"## Consumer reach\n"
+
+        self.assertEqual(source.count(opening), 1)
+        self.assertEqual(source.count(closing), 1)
+        body = source.split(opening, 1)[1].split(closing, 1)[0]
+        self.assertEqual(body, DRAFTING_CONVENTIONS_BODY)
+
+    def test_review_depth_sensitivity_floor_is_canonical_raw_bytes(self):
+        source = (TICKET_DIRECTORY / "references" / "review-depth.md").read_bytes()
+        opening = b"## Sensitivity floor\n"
+        closing = b"## What blocks\n"
+
+        self.assertEqual(source.count(opening), 1)
+        self.assertEqual(source.count(closing), 1)
+        body = source.split(opening, 1)[1].split(closing, 1)[0]
+        self.assertEqual(body, REVIEW_DEPTH_SENSITIVITY_FLOOR_BODY)
+
+    def test_drafting_conventions_instruction_is_inside_flat_and_sub_order_fences(self):
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_bytes()
+
+        flat_region = template.split(b"## Flat\n", 1)[1].split(b"## Chunked\n", 1)[0]
+        flat_fence = flat_region.split(b"```\n", 1)[1].split(b"\n```", 1)[0]
+        sub_region = template.split(b"SUB-ORDER 1/<n>", 1)[1]
+        sub_order_fence = b"SUB-ORDER 1/<n>" + sub_region.split(b"\n```", 1)[0]
+
+        self.assertIn(DRAFTING_CONVENTIONS_INSTRUCTION, flat_fence)
+        self.assertIn(DRAFTING_CONVENTIONS_INSTRUCTION, sub_order_fence)
+
+    def test_ticket_verb_consumers_point_to_drafting_conventions(self):
+        for verb in ("triage", "start", "revise"):
+            source = (TICKET_DIRECTORY / "verbs" / f"{verb}.md").read_bytes()
+            with self.subTest(verb=verb):
+                self.assertIn(b"drafting-conventions.md", source)
+
     def test_builder_self_check_is_pinned_in_flat_and_chunked_builder_guidance(self):
         start = (TICKET_DIRECTORY / "verbs" / "start.md").read_bytes()
         template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_bytes()


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

The ticket driver now ships a drafting-conventions reference that reaches every order author and every worker: triage, revise, and plan-review point at it, and both executable fences (flat orders and sub-orders) carry its path inside the fence, the one surface a dispatched worker actually receives. The review process also gains the coordinator fix-in-place rule and the depth-floor qualifier. Before this, the settled conventions lived in one session's memory and were relearned by review rounds; a day's triage burned most of a round rediscovering them.

* The conventions page pins the recurring rules: raw-byte canonical constants between full-heading-line anchors, byte-exact test-line transcription with the documented interpreter substitution, positional prompt transport, per-dispatch state files, closed diff allowlists, deterministic evidence blocks.
* A deterministic, mechanical review finding (wrong anchor, missing exact string, nondeterministic command) may be fixed in the order by the coordinator without a new review round; judgment findings still go through the panel or the operator.
* Each plan-review invocation keeps a coordinator-owned mechanical-fix ledger recording the plan locator, the correction, and the reviewer re-check, so fix-in-place stays auditable.
* The sensitivity floor now reads: Full when the change alters contract semantics; Targeted for pure relocation, citation repoints, and additive paragraphs no existing consumer's behavior depends on (operator ruling on the issue).
* The fence reference is a backticked path rather than a Markdown link; the structural validator resolves links file-relative, so the link form fails validation (amendment recorded on the issue).

Triage rounds, the ruling, and the review verdicts are on the issue.

Closes #171

## Verification

```text
validated 27 skills and 305 files
Ran 438 tests ... OK
py_compile exit 0
```

The conventions, fix-in-place, qualifier, and fence pins were each shown red under in-body mutation and pass restored; anchors carry uniqueness guards.
