### PR TITLE
Repoint the proposal pin to the archived path

### DIFF
--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -4971,7 +4971,7 @@ class EpicAdapterDispatchTests(unittest.TestCase):
 
 
 class EpicDelegatedExecutionContractTests(unittest.TestCase):
-    PROPOSAL = ROOT / "openspec" / "changes" / "epic-rework" / "proposal.md"
+    PROPOSAL = ROOT / "openspec" / "changes" / "archive" / "epic-rework" / "proposal.md"
     EPIC = ROOT / "skills" / "drivers" / "epic" / "SKILL.md"
 
     def body_between(self, document: bytes, opening_anchor: bytes, closing_anchor: bytes) -> bytes:


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

The delegated-execution proposal pin now reads the proposal at its archived path, so the behavior suite passes again on main. The epic close-out moved the proposal to the archive folder, and its ledger PR merged before CI reported, leaving main with a pin pointed at a path that no longer exists.

* Test-only path change; the pinned bytes and both assertions are unchanged.

## Verification

```text
Ran EpicDelegatedExecutionContractTests ... OK
validated 27 skills and 307 files
```
