### PR TITLE
docs: name the legal skill categories in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ ui-surfaces: none
   or newer (the worker scripts use `X | None` union syntax).
 - Dev: no app to run. To exercise a skill, install the pack into a scratch
   directory with `npx skills add . --skill '<name>' --copy --yes`.
-- Source: `skills/<category>/<name>/` (SKILL.md plus its own `references/`,
+- Source: `skills/<category>/<name>/`, where `<category>` is exactly one of
+  `drivers`, `tools`, or `workflows` (SKILL.md plus its own `references/`,
   `reference/`, and `scripts/`), with `profile/`, `output-styles/`, `hooks/`, and
   `docs/` alongside.
 - Tests: `tests/`. `scripts/validate.py` is the structural validator and is part


### PR DESCRIPTION
An agent working in this repo went looking for the TDD skill at
`skills/practices/tdd/`, found nothing there, and reported that no work had
changed. There is no `practices` category — the word appears nowhere in the
pack. It guessed, because the repo guide describes the source layout as
`skills/<category>/<name>/` and never says which categories are legal.

This names them: `drivers`, `tools`, `workflows`, and says that list is
exhaustive, so the next agent resolves a skill path instead of inventing one.

Docs only, one line of the repo guide. To check: the categories listed match
the directories that actually exist under `skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)