### PR TITLE
Match review assurance to requested behavior

### DIFF
--- a/docs/scope/199-assurance-level-matching.md
+++ b/docs/scope/199-assurance-level-matching.md
@@ -1,0 +1,27 @@
+# Scope — 199 assurance-level matching
+
+Route: interview mode (a concrete resolution exists in the user's head, untested).
+
+## Decisions
+
+- Ticket classification is `code`: prose changes landing as a pull request. inline
+- Repo records changes with OpenSpec; the change folder is `openspec/changes/`. inline
+- The failure this ticket fixes is mechanism escalation, not a wrong risk decision.
+  plan-review axis 4 already forbids silently prescribing *hardening* when evidence
+  shifts a risk decision; it says nothing about escalating the *mechanism* (parser,
+  provenance record, state machine, content filter, runtime enforcement) above the
+  assurance level the work was admitted at. inline
+
+## Open questions
+
+- Q1: home for the global assurance-matching rule — `profile/base.md` vs `profile/CHARTER.md`.
+- Q2: whether the assurance ceiling becomes a declared field in scope's risk contract
+  or stays freeform prose in plan-review.
+- Q3: whether plan-review needs a `scope expansion` finding disposition beside
+  **blocks countersign** / **note**. Framing depends on Q2.
+- Q4: home for the post-compaction ledger re-read. Defaulted to scope's `## Ledger`
+  section, which already owns fresh-agent resume; state if you want it elsewhere.
+
+## Spawned tasks
+
+- none

--- a/docs/scope/199-assurance-level-matching.md
+++ b/docs/scope/199-assurance-level-matching.md
@@ -1,6 +1,8 @@
 # Scope — 199 assurance-level matching
 
-Route: interview mode (a concrete resolution exists in the user's head, untested).
+Route: interview mode. User declined the design menu and restated the ask: don't let
+work get over-hardened, and don't let a compaction lose the ledger. All four open
+questions were settled by the coordinator toward the smallest change that works.
 
 ## Decisions
 
@@ -11,16 +13,41 @@ Route: interview mode (a concrete resolution exists in the user's head, untested
   shifts a risk decision; it says nothing about escalating the *mechanism* (parser,
   provenance record, state machine, content filter, runtime enforcement) above the
   assurance level the work was admitted at. inline
+- Q1 settled: the rule lands in `profile/base.md` under Working preferences, not in
+  `CHARTER.md`. The charter is the bar for shipped code and its violations are
+  blocking findings; making over-hardening itself a blocking finding gives reviewers
+  one more thing to argue, which is the disease. inline
+- Q2 settled: no new `Assurance ceiling:` field in scope's risk contract. Adding a
+  required field to every risk contract to prevent over-engineering is itself the
+  failure mode. The rule is prose in plan-review, pointing at the risk contract that
+  already exists. inline
+- Q3 settled: no new finding disposition in plan-review. **blocks countersign** /
+  **note** stay as they are; an over-hardening finding is discarded or raised to the
+  user as a scope question, which the existing calibration section already covers. inline
+- Q4 settled: the post-compaction re-read lands in plan-review's cycle, where the
+  rounds happen, rather than in scope's `## Ledger` section. scope's ledger rule is
+  about a *fresh agent* resuming; the observed loss was a *continuing* session that
+  compacted mid-review and kept going. inline
+
+### Risk contract
+
+- **Must prevent:** a review round silently raising the assurance bar above what the
+  admitted work declared, with no user decision.
+- **Must recover:** nothing. There is no runtime here.
+- **Accepted failure:** an agent misreads the rule and still over-hardens; the user
+  says so and the round is redone. Consequence is one wasted round.
+- **Unsupported:** enforcement. This is instruction prose read by agents; nothing
+  parses, validates, or gates on it at runtime.
+- **Evidence owed:** the pinned-prose tests this repo already uses for skill
+  contract text (`tests/test_behavior.py` pattern), and nothing more.
+- **Why:** the subject is agent-instruction prose with no execution surface, so the
+  only real consequence of failure is a wasted review round.
+- **Disposition:** admitted at intent level; a mechanism stronger than prose plus a
+  string-pinning test is out of scope for this ticket by decision, not by oversight.
 
 ## Open questions
 
-- Q1: home for the global assurance-matching rule — `profile/base.md` vs `profile/CHARTER.md`.
-- Q2: whether the assurance ceiling becomes a declared field in scope's risk contract
-  or stays freeform prose in plan-review.
-- Q3: whether plan-review needs a `scope expansion` finding disposition beside
-  **blocks countersign** / **note**. Framing depends on Q2.
-- Q4: home for the post-compaction ledger re-read. Defaulted to scope's `## Ledger`
-  section, which already owns fresh-agent resume; state if you want it elsewhere.
+- none
 
 ## Spawned tasks
 

--- a/openspec/changes/archive/199-assurance-level-matching/proposal.md
+++ b/openspec/changes/archive/199-assurance-level-matching/proposal.md
@@ -1,0 +1,28 @@
+# Match review assurance to the request
+
+## Why
+
+Review rounds can turn prose agreements into unrequested enforcement machinery,
+raising the assurance bar without a user decision.
+
+## What changes
+
+Record assurance-level matching as a standing working preference, bound plan
+reviewers to the requested behavior and admitted risk, and make a coordinator
+session re-read settled decisions after mid-review compaction.
+
+## Risk contract
+
+- **Must prevent:** a review round silently raising the assurance bar above what the
+  admitted work declared, with no user decision.
+- **Must recover:** nothing. There is no runtime here.
+- **Accepted failure:** an agent misreads the rule and still over-hardens; the user
+  says so and the round is redone. Consequence is one wasted round.
+- **Unsupported:** enforcement. This is instruction prose read by agents; nothing
+  parses, validates, or gates on it at runtime.
+- **Evidence owed:** the pinned-prose tests this repo already uses for skill
+  contract text (`tests/test_behavior.py` pattern), and nothing more.
+- **Why:** the subject is agent-instruction prose with no execution surface, so the
+  only real consequence of failure is a wasted review round.
+- **Disposition:** admitted at intent level; a mechanism stronger than prose plus a
+  string-pinning test is out of scope for this ticket by decision, not by oversight.

--- a/openspec/changes/archive/199-assurance-level-matching/tasks.md
+++ b/openspec/changes/archive/199-assurance-level-matching/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] Add the assurance-level matching working preference with its documented-rule
+  and must-prevent carve-out.
+- [x] Bound plan-review axis 4 to the requested behavior and admitted risk without
+  changing finding markers or dispositions.
+- [x] Make the coordinator session re-read settled decisions after mid-review
+  compaction without changing the cold-reader prompt.
+- [x] Pin all three prose contracts with tests that failed before the prose existed.
+- [x] Archive the completed OpenSpec change before the pull request is marked ready.

--- a/profile/base.md
+++ b/profile/base.md
@@ -88,6 +88,15 @@ categories that don't apply.
   something, carry it to done rather than ending on optional follow-ups or
   unverified loose ends. If part of it is genuinely blocked, say which part and
   why — that's different from parking the rest.
+- **Match the mechanism to the assurance level that was asked for.** Do not
+  introduce parsers, formal grammars, provenance records, state machines, content
+  filtering, or runtime enforcement for a prose contract unless explicitly asked.
+  Treat a review finding that demands stronger assurance than the requested
+  behavior, or than the admitted risk contract where one exists, as scope expansion
+  rather than a blocker, except when it names a documented rule of the repo
+  (including `profile/CHARTER.md`) or a must-prevent outcome in the admitted risk
+  contract. Prefer ordinary semantic interpretation and the smallest change that
+  works.
 - **No background-task chips.** Don't use `spawn_task`. File a tracked issue
   instead.
 

--- a/skills/tools/plan-review/SKILL.md
+++ b/skills/tools/plan-review/SKILL.md
@@ -133,8 +133,19 @@ definitions below are the fallback.
    that the risk decision must reopen; do not silently prescribe hardening. Require
    evidence only for acceptance criteria, must-prevent outcomes, enforced invariants,
    and observed regressions — never for a target test count or an exhaustive failure
-   matrix. The right change is the smallest one that meets acceptance and the risk
-   contract.
+   matrix. A reviewer may test whether the proposed mechanism satisfies the stated
+   risk contract, but may not raise that contract or demand a parser, formal grammar,
+   provenance record, state machine, content filtering, or runtime enforcement beyond
+   the requested behavior, or beyond the admitted risk contract where one exists. An
+   objection that only holds if the assurance bar rises is scope expansion and is
+   discarded, unless evidence, not judgment, changes the assumed likelihood,
+   consequence, or recoverability; then the evidence-reopen rule earlier in this axis
+   governs and the objection stands. A finding that names a documented rule of the
+   repo (including `profile/CHARTER.md`) or a must-prevent outcome in the admitted risk
+   contract is never discarded on this ground. The cycle's step 0 generated-facts
+   demand and the evidence-block spot check's **BLOCKED** verdict are this skill's own
+   triage and evidence obligations, not assurance escalation, and are unaffected. The
+   right change is the smallest one that meets acceptance and the risk contract.
 5. **Cost.** Is the effort implied by the plan sane for the ask? Flag a plan
    whose blast radius (files touched, migrations, new machinery) is out of
    proportion to its outcome.
@@ -186,6 +197,15 @@ definitions below are the fallback.
    revisions routinely introduce fresh defects (a fix that patches the
    objected hole and opens a different one), and objections whose "cheapest
    fix" was applied verbatim still need verifying against the real machinery.
+
+   If the coordinator session running the review has its context compacted mid-review,
+   it re-reads the settled decisions in the plan's scope ledger wherever `/scope`
+   placed it (`docs/scope/<slug>.md` or the session scratchpad) and the risk contract
+   copied into the plan before evaluating the reviewer's deltas. It treats decisions
+   recorded there as settled rather than re-deriving them from what survived
+   compaction. Cold reviewers stay cold: this rule adds nothing to the cold-reader
+   prompt, and `plan-review-mechanical-fixes.md` remains the round ledger rather than
+   the settled-decision record.
 5. **Terminate by stakes, not by pass count.**
    - **Ordinary plan** (modest blast radius, downstream review exists as a
      backstop): one panel. If it drew blood, fix and have the same reviewer

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2975,6 +2975,60 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
         )
 
 
+class AssuranceLevelMatchingContractTests(unittest.TestCase):
+    PROFILE = ROOT / "profile" / "base.md"
+    PLAN_REVIEW = ROOT / "skills" / "tools" / "plan-review" / "SKILL.md"
+
+    def setUp(self):
+        self.profile = " ".join(self.PROFILE.read_text(encoding="utf-8").split())
+        self.plan_review = " ".join(
+            self.PLAN_REVIEW.read_text(encoding="utf-8").split()
+        )
+
+    def test_working_preference_matches_mechanism_to_requested_assurance(self):
+        self.assertIn(
+            "**Match the mechanism to the assurance level that was asked for.** Do not introduce "
+            "parsers, formal grammars, provenance records, state machines, content filtering, "
+            "or runtime enforcement for a prose contract unless explicitly asked. Treat a "
+            "review finding that demands stronger assurance than the requested behavior, or "
+            "than the admitted risk contract where one exists, as scope expansion rather than "
+            "a blocker, except when it names a documented rule of the repo (including "
+            "`profile/CHARTER.md`) or a must-prevent outcome in the admitted risk contract. "
+            "Prefer ordinary semantic interpretation and the smallest change that works.",
+            self.profile,
+        )
+
+    def test_axis_four_keeps_the_reviewer_within_the_assurance_boundary(self):
+        self.assertIn(
+            "A reviewer may test whether the proposed mechanism satisfies the stated risk "
+            "contract, but may not raise that contract or demand a parser, formal grammar, "
+            "provenance record, state machine, content filtering, or runtime enforcement beyond "
+            "the requested behavior, or beyond the admitted risk contract where one exists. An "
+            "objection that only holds if the assurance bar rises is scope expansion and is "
+            "discarded, unless evidence, not judgment, changes the assumed likelihood, "
+            "consequence, or recoverability; then the evidence-reopen rule earlier in this axis "
+            "governs and the objection stands. A finding that names a documented rule of the "
+            "repo (including `profile/CHARTER.md`) or a must-prevent outcome in the admitted risk "
+            "contract is never discarded on this ground. The cycle's step 0 generated-facts "
+            "demand and the evidence-block spot check's **BLOCKED** verdict are this skill's own "
+            "triage and evidence obligations, not assurance escalation, and are unaffected.",
+            self.plan_review,
+        )
+
+    def test_cycle_rereads_settled_decisions_after_compaction(self):
+        self.assertIn(
+            "If the coordinator session running the review has its context compacted mid-review, "
+            "it re-reads the settled decisions in the plan's scope ledger wherever `/scope` "
+            "placed it (`docs/scope/<slug>.md` or the session scratchpad) and the risk contract "
+            "copied into the plan before evaluating the reviewer's deltas. It treats decisions "
+            "recorded there as settled rather than re-deriving them from what survived "
+            "compaction. Cold reviewers stay cold: this rule adds nothing to the cold-reader "
+            "prompt, and `plan-review-mechanical-fixes.md` remains the round ledger rather than "
+            "the settled-decision record.",
+            self.plan_review,
+        )
+
+
 class VerbatimEvidenceBlockContractTests(unittest.TestCase):
     """Subject is the command-output-pasting contract, not the retired evidence-v2
     envelope machinery: preflight's and plan-review's own review evidence blocks."""


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## Summary

Review now matches the strength of its solution to the strength that was requested: a prose agreement stays prose unless stronger assurance is explicitly requested. Before this, a reviewer could turn an intent-level rule into parsers, provenance tracking, or runtime enforcement without a user decision.

* Reviewers may test whether a proposal meets its requested behavior and admitted risk. An objection that works only after raising the assurance bar is scope expansion, while evidence that changes likelihood, consequence, or recoverability still reopens the risk decision.
* Documented repository rules and must-prevent outcomes remain binding. The review process's own generated-facts demand and blocked verdict for edited evidence remain unchanged.
* A coordinator that loses context during a review re-reads the settled decisions and copied risk contract before judging the next revision. Cold reviewers receive no additional author context.
* The archived change record carries the settled decisions and the admitted prose-only risk contract.

Closes #199

## Verification

* Validator: 27 skills and 335 files, no errors. Full suite: 420 tests, OK (23 skipped). Compile checks are silent.
* Each of the three instruction pins failed before its prose existed and passes with the final text restored.
* The pins prove that the instructions remain present. They do not enforce how an agent interprets them at runtime.
