### PR TITLE
Resolve spin-worktree branch prefixes

### DIFF
--- a/openspec/changes/archive/181-spin-worktree-branch-prefix/design.md
+++ b/openspec/changes/archive/181-spin-worktree-branch-prefix/design.md
@@ -1,0 +1,6 @@
+# Design
+
+`None` represents an omitted `--branch-prefix` flag, preserving an explicitly
+supplied empty string as an instruction to create a bare branch. The helper
+reads its single optional JSON file at the durable-input boundary and treats
+every unavailable or unsuitable value as no prefix.

--- a/openspec/changes/archive/181-spin-worktree-branch-prefix/proposal.md
+++ b/openspec/changes/archive/181-spin-worktree-branch-prefix/proposal.md
@@ -1,0 +1,20 @@
+# Resolve spin-worktree branch prefixes per machine
+
+## Why
+
+The helper currently creates Codex-named branches for every new issue, even for
+operators using another agent or no agent at all.
+
+## What changes
+
+- Resolve a new issue branch prefix from an explicit flag, then per-machine
+  configuration, then no prefix.
+- Document the configuration location and bare branch form.
+- Keep the ticket workflow's nonnumeric branch guidance aligned with the same
+  resolution rule.
+
+## Risk contract
+
+The config file is optional and malformed durable input must not prevent a
+worktree from being created. New behavior is exercised in throwaway Git
+repositories, leaving real checkouts and real user configuration untouched.

--- a/openspec/changes/archive/181-spin-worktree-branch-prefix/tasks.md
+++ b/openspec/changes/archive/181-spin-worktree-branch-prefix/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Resolve new issue branch prefixes from the flag, configuration, then the
+  bare form.
+- [x] Document the config and reconcile the ticket workflow guidance.
+- [x] Cover precedence, explicit empty prefix, bare defaults, and unusable
+  configuration in temporary repositories.
+- [x] Run the repository verification gate and open the pull request.

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -42,8 +42,10 @@ the branch, and its change record already belongs to the parent epic.
    ```
 
    c. `<prefix>` is whatever `spin-worktree` resolves: its `--branch-prefix` flag,
-   else its built-in default. Never invent a prefix here, and keep both paths on the
-   same one so the branch name does not depend on which path ran.
+   then `branchPrefix` in `~/.config/spin-worktree/config.json`, else no prefix.
+   When no prefix resolves, omit `<prefix>/` entirely. Never invent a prefix here,
+   and keep both paths on the same one so the branch name does not depend on which
+   path ran.
 
    d. Use the worktree path the helper printed as the working directory for every
    step below. If the ticket's worktree already exists, verify it is on the

--- a/skills/tools/spin-worktree/SKILL.md
+++ b/skills/tools/spin-worktree/SKILL.md
@@ -50,12 +50,27 @@ Existing branch:
 ```sh
 python3 <spin-worktree-skill-directory>/scripts/spin-worktree.py \
   --repo /path/to/repository \
-  --branch codex/issue-316 \
+  --branch issue-316 \
   --name pr321
 ```
 
 Use `--dry-run` to inspect commands. Override defaults with
 `--worktree-root`, `--remote`, `--base`, or `--branch-prefix`.
+
+## Branch prefix
+
+New issue branches resolve their prefix in this order: an explicitly supplied
+`--branch-prefix` flag, then the string `branchPrefix` in
+`~/.config/spin-worktree/config.json`, then no prefix. For example:
+
+```json
+{"branchPrefix": "my-prefix"}
+```
+
+With no resolved prefix, issue branches are `issue-317` or
+`317-rescue-context`; they never begin with `/`. Pass `--branch-prefix ''` to
+request that bare form for one invocation. Missing, unreadable, malformed, or
+otherwise unsuitable config files silently resolve to no prefix.
 
 ## Guardrails
 

--- a/skills/tools/spin-worktree/scripts/spin-worktree.py
+++ b/skills/tools/spin-worktree/scripts/spin-worktree.py
@@ -176,13 +176,29 @@ def discover_pr_branch(repo: Path, pull_request: int) -> str:
     return str(branch)
 
 
+def configured_branch_prefix() -> str:
+    config_path = Path.home() / ".config" / "spin-worktree" / "config.json"
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return ""
+    prefix = config.get("branchPrefix") if isinstance(config, dict) else None
+    return prefix if isinstance(prefix, str) else ""
+
+
+def issue_branch(issue: int, slug: Optional[str], prefix: str) -> str:
+    branch_slug = slugify(slug or f"issue-{issue}")
+    branch_name = f"{issue}-{branch_slug}" if slug else f"issue-{issue}"
+    return f"{prefix}/{branch_name}" if prefix else branch_name
+
+
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default=".", help="control checkout")
     parser.add_argument("--worktree-root", default=str(DEFAULT_ROOT))
     parser.add_argument("--remote", default=DEFAULT_REMOTE)
     parser.add_argument("--base", help="base branch for new issue work")
-    parser.add_argument("--branch-prefix", default="codex")
+    parser.add_argument("--branch-prefix", default=None)
     parser.add_argument("--issue", type=int)
     parser.add_argument("--slug")
     parser.add_argument("--pr", type=int)
@@ -215,12 +231,12 @@ def main() -> int:
         if arguments.issue is not None:
             git(repo, "fetch", arguments.remote, dry_run=arguments.dry_run)
             base = arguments.base or remote_default_branch(repo, arguments.remote)
-            branch_slug = slugify(arguments.slug or f"issue-{arguments.issue}")
-            branch = (
-                f"{arguments.branch_prefix}/{arguments.issue}-{branch_slug}"
-                if arguments.slug
-                else f"{arguments.branch_prefix}/issue-{arguments.issue}"
+            prefix = (
+                arguments.branch_prefix
+                if arguments.branch_prefix is not None
+                else configured_branch_prefix()
             )
+            branch = issue_branch(arguments.issue, arguments.slug, prefix)
             task_name = safe_leaf(arguments.name or str(arguments.issue))
             start_point = f"{arguments.remote}/{base}"
             new_branch = True

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1338,13 +1338,15 @@ class SpinWorktreeTests(unittest.TestCase):
     def tearDown(self):
         self.temporary.cleanup()
 
-    def spin(self, *arguments: str):
-        return self.spin_from(self.repo, *arguments)
+    def spin(self, *arguments: str, env: Optional[dict[str, str]] = None):
+        return self.spin_from(self.repo, *arguments, env=env)
 
-    def spin_from(self, repo: Path, *arguments: str):
+    def spin_from(
+        self, repo: Path, *arguments: str, env: Optional[dict[str, str]] = None
+    ):
         return run(
             [
-                "python3",
+                sys.executable,
                 str(SPIN_SCRIPT),
                 "--repo",
                 str(repo),
@@ -1353,7 +1355,21 @@ class SpinWorktreeTests(unittest.TestCase):
                 *arguments,
             ],
             cwd=ROOT,
+            env=env,
         )
+
+    def config_environment(
+        self, contents: Optional[str | bytes] = None
+    ) -> dict[str, str]:
+        home = self.scratch / "home"
+        if contents is not None:
+            config = home / ".config" / "spin-worktree" / "config.json"
+            config.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(contents, bytes):
+                config.write_bytes(contents)
+            else:
+                config.write_text(contents, encoding="utf-8")
+        return {**os.environ, "HOME": str(home)}
 
     def configure_origin(self):
         remote = self.scratch / "origin.git"
@@ -1413,7 +1429,7 @@ class SpinWorktreeTests(unittest.TestCase):
         worktree = self.scratch / "worktrees" / "repo" / "13"
         self.assertTrue((worktree / ".git").exists())
         branch = run(["git", "branch", "--show-current"], cwd=worktree)
-        self.assertEqual(branch.stdout.strip(), "codex/13-isf-safety-predicate")
+        self.assertEqual(branch.stdout.strip(), "13-isf-safety-predicate")
         self.assertEqual(untracked.read_text(encoding="utf-8"), "keep me\n")
         status = run(["git", "status", "--short"], cwd=self.repo)
         self.assertEqual(status.stdout, "?? unfinished-notes.md\n")
@@ -1440,6 +1456,93 @@ class SpinWorktreeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue((self.scratch / "worktrees" / "repo" / "13" / ".git").exists())
         self.assertFalse((self.scratch / "worktrees" / "52").exists())
+
+    def test_branch_prefix_flag_wins_over_config(self):
+        self.configure_origin()
+
+        result = self.spin(
+            "--issue",
+            "13",
+            "--slug",
+            "flag-wins",
+            "--branch-prefix",
+            "flag",
+            env=self.config_environment('{"branchPrefix": "config"}'),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        branch = run(
+            ["git", "branch", "--show-current"],
+            cwd=self.scratch / "worktrees" / "repo" / "13",
+        )
+        self.assertEqual(branch.stdout.strip(), "flag/13-flag-wins")
+
+    def test_branch_prefix_uses_config_when_flag_is_absent(self):
+        self.configure_origin()
+
+        result = self.spin(
+            "--issue",
+            "13",
+            "--slug",
+            "from-config",
+            env=self.config_environment('{"branchPrefix": "config"}'),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        branch = run(
+            ["git", "branch", "--show-current"],
+            cwd=self.scratch / "worktrees" / "repo" / "13",
+        )
+        self.assertEqual(branch.stdout.strip(), "config/13-from-config")
+
+    def test_branch_prefix_defaults_to_bare_issue_branch(self):
+        self.configure_origin()
+
+        result = self.spin("--issue", "13", env=self.config_environment())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        branch = run(
+            ["git", "branch", "--show-current"],
+            cwd=self.scratch / "worktrees" / "repo" / "13",
+        )
+        self.assertEqual(branch.stdout.strip(), "issue-13")
+
+    def test_empty_branch_prefix_flag_requests_bare_slug_branch(self):
+        self.configure_origin()
+
+        result = self.spin(
+            "--issue",
+            "13",
+            "--slug",
+            "bare-branch",
+            "--branch-prefix",
+            "",
+            env=self.config_environment('{"branchPrefix": "config"}'),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        branch = run(
+            ["git", "branch", "--show-current"],
+            cwd=self.scratch / "worktrees" / "repo" / "13",
+        )
+        self.assertEqual(branch.stdout.strip(), "13-bare-branch")
+
+    def test_unusable_branch_prefix_config_resolves_to_no_prefix(self):
+        self.configure_origin()
+        for contents in (None, "not json", b"\xff", "{}", '{"branchPrefix": 13}'):
+            with self.subTest(contents=contents):
+                result = self.spin(
+                    "--issue",
+                    "13",
+                    "--slug",
+                    "no-prefix",
+                    "--dry-run",
+                    env=self.config_environment(contents),
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                output = json.loads(result.stdout[result.stdout.index("{") :])
+                self.assertEqual(output["branch"], "13-no-prefix")
 
 
 class CodexWorkerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

New issue worktrees now take a branch prefix from an explicit flag, then optional per-machine configuration, and otherwise use a bare issue branch. Previously every new issue branch started with `codex/`.

* A missing, unreadable, malformed, or unsuitable configuration file falls back silently to the bare branch form.
* An explicit empty prefix creates a bare branch even when machine configuration supplies a prefix.
* The ticket workflow describes the same resolution order for its nonnumeric branch path.
* The completed decision and risk record is archived under `openspec/changes/archive/`.

Closes #181

## Verification

* Repository validation: 27 skills and 332 files accepted.
* Full suite: 422 tests, OK (23 skipped); compilation check exits 0 without output.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
