### PR TITLE
Fix Codex worker validation and resume

### DIFF
--- a/docs/scope/149-probes/effort-enums.md
+++ b/docs/scope/149-probes/effort-enums.md
@@ -1,4 +1,4 @@
-# Effort enums, captured 2026-08-24
+# Effort enums
 
 Each adapter validates its own set. They are not the same set.
 
@@ -10,7 +10,7 @@ $ claude --help | grep -A1 -- "--effort"
                                         (low, medium, high, xhigh, max)
 ```
 
-## codex
+## codex (live API probe, 2026-08-27)
 
 The codex CLI does NOT validate this value locally — a bogus value starts the
 session and fails at the API:
@@ -21,8 +21,26 @@ reasoning effort: bogus
 ERROR: { ... }   # accepted locally, rejected by the API
 ```
 
-Authoritative set, from the Codex configuration reference
-(https://learn.chatgpt.com/docs/config-file/config-reference):
+The live Codex 5.6 probe exercised `codex-worker.py start --model
+gpt-5.6-luna --sandbox read-only --effort <E>`:
 
-> model_reasoning_effort: "minimal | low | medium | high | xhigh" (Responses API only;
-> "xhigh is model-dependent")
+| Effort | Result |
+| --- | --- |
+| `none` | The adapter previously rejected it locally. The API accepts it. |
+| `max` | The adapter previously rejected it locally. The API accepts it. |
+| `minimal` | The adapter accepted it, then the API rejected it with HTTP 400. |
+| `low` | Works. |
+| `xhigh` | Works. |
+
+The model returned: `Unsupported value: 'minimal' ... Supported values are:
+'none', 'low', 'medium', 'high', 'xhigh', and 'max'.`
+
+The adapter enum is therefore `none|low|medium|high|xhigh|max`. This is the
+adapter's local guard; the Codex CLI itself still sends arbitrary values to the
+API.
+
+### Superseded record (2026-08-24)
+
+The earlier configuration-reference record stated
+`minimal|low|medium|high|xhigh`. It is retained as the historical source of the
+old adapter guard, but is superseded by the 2026-08-27 live API probe above.

--- a/docs/scope/149-probes/run-log.md
+++ b/docs/scope/149-probes/run-log.md
@@ -230,6 +230,10 @@ invoked.
 
 ### Effort outside each adapter's enum
 
+The Codex output below is the 2026-08-24 historical result. It is superseded
+by the 2026-08-27 live API probe in `effort-enums.md`; the current local guard
+accepts `none|low|medium|high|xhigh|max`.
+
 Command:
 
 ```

--- a/openspec/changes/archive/196-codex-effort-enum/design.md
+++ b/openspec/changes/archive/196-codex-effort-enum/design.md
@@ -5,3 +5,7 @@ passes arbitrary effort values to the API. Its literal enum now reflects the
 measured API set. The probe record retains the 2026-08-24 configuration-based
 claim as superseded history so future changes can distinguish it from the live
 2026-08-27 result.
+
+Resume runs through the shared lifecycle in the recorded cwd, so it needs the
+same Codex checkout-check bypass as start. No `-C` is added because the
+lifecycle already supplies that cwd to the child process.

--- a/openspec/changes/archive/196-codex-effort-enum/design.md
+++ b/openspec/changes/archive/196-codex-effort-enum/design.md
@@ -1,0 +1,7 @@
+# Design
+
+`codex-worker.py` owns the local validation boundary because the Codex CLI
+passes arbitrary effort values to the API. Its literal enum now reflects the
+measured API set. The probe record retains the 2026-08-24 configuration-based
+claim as superseded history so future changes can distinguish it from the live
+2026-08-27 result.

--- a/openspec/changes/archive/196-codex-effort-enum/design.md
+++ b/openspec/changes/archive/196-codex-effort-enum/design.md
@@ -9,3 +9,7 @@ claim as superseded history so future changes can distinguish it from the live
 Resume runs through the shared lifecycle in the recorded cwd, so it needs the
 same Codex checkout-check bypass as start. No `-C` is added because the
 lifecycle already supplies that cwd to the child process.
+
+`latest_rate_limits` intentionally scans the configured Codex session store in
+production. Tests that shell out through the adapter therefore set `CODEX_HOME`
+to fixture storage, matching the established worker-test pattern.

--- a/openspec/changes/archive/196-codex-effort-enum/proposal.md
+++ b/openspec/changes/archive/196-codex-effort-enum/proposal.md
@@ -6,6 +6,8 @@ The worker locally accepted `minimal`, which the live Codex 5.6 API rejects,
 and locally rejected `none` and `max`, which that API accepts. Its resume path
 also omitted the checkout-check bypass used by start, making a non-checkout
 worker impossible to resume.
+Worker-effort tests also inherited the operator's session store, turning a
+hermetic adapter test into an unbounded scan of private rollout history.
 
 ## What changes
 
@@ -14,9 +16,11 @@ worker impossible to resume.
   and orchestration references name the live enum.
 - Pin the adapter's enum in behavior tests.
 - Keep resume usable from the recorded non-checkout working directory.
+- Keep worker-adapter tests pointed at fixture-owned session homes.
 
 ## Risk contract
 
 The change only affects local validation before a Codex session launches.
 The worker default remains `medium`; Claude's separate enum is unchanged. Resume
 continues to rely on the lifecycle-owned recorded cwd rather than adding `-C`.
+The production session-store scan is unchanged.

--- a/openspec/changes/archive/196-codex-effort-enum/proposal.md
+++ b/openspec/changes/archive/196-codex-effort-enum/proposal.md
@@ -1,0 +1,18 @@
+# Correct the Codex worker effort enum
+
+## Why
+
+The worker locally accepted `minimal`, which the live Codex 5.6 API rejects,
+and locally rejected `none` and `max`, which that API accepts.
+
+## What changes
+
+- Align the Codex worker's local guard with the 2026-08-27 live API probe.
+- Preserve the superseded probe record while making the current documentation
+  and orchestration references name the live enum.
+- Pin the adapter's enum in behavior tests.
+
+## Risk contract
+
+The change only affects local validation before a Codex session launches.
+The worker default remains `medium`; Claude's separate enum is unchanged.

--- a/openspec/changes/archive/196-codex-effort-enum/proposal.md
+++ b/openspec/changes/archive/196-codex-effort-enum/proposal.md
@@ -1,9 +1,11 @@
-# Correct the Codex worker effort enum
+# Correct Codex worker launch and resume validation
 
 ## Why
 
 The worker locally accepted `minimal`, which the live Codex 5.6 API rejects,
-and locally rejected `none` and `max`, which that API accepts.
+and locally rejected `none` and `max`, which that API accepts. Its resume path
+also omitted the checkout-check bypass used by start, making a non-checkout
+worker impossible to resume.
 
 ## What changes
 
@@ -11,8 +13,10 @@ and locally rejected `none` and `max`, which that API accepts.
 - Preserve the superseded probe record while making the current documentation
   and orchestration references name the live enum.
 - Pin the adapter's enum in behavior tests.
+- Keep resume usable from the recorded non-checkout working directory.
 
 ## Risk contract
 
 The change only affects local validation before a Codex session launches.
-The worker default remains `medium`; Claude's separate enum is unchanged.
+The worker default remains `medium`; Claude's separate enum is unchanged. Resume
+continues to rely on the lifecycle-owned recorded cwd rather than adding `-C`.

--- a/openspec/changes/archive/196-codex-effort-enum/tasks.md
+++ b/openspec/changes/archive/196-codex-effort-enum/tasks.md
@@ -6,3 +6,5 @@
 - [x] Archive the completed change in this pull request.
 - [x] Keep a non-checkout Codex worker resumable with start's checkout-check
   bypass, without duplicating lifecycle cwd handling.
+- [x] Isolate worker-effort tests from the operator's Codex session store and
+  pin that subprocess boundary.

--- a/openspec/changes/archive/196-codex-effort-enum/tasks.md
+++ b/openspec/changes/archive/196-codex-effort-enum/tasks.md
@@ -4,3 +4,5 @@
 - [x] Update the orchestration references and probe history.
 - [x] Add an exact regression pin for the live API enum.
 - [x] Archive the completed change in this pull request.
+- [x] Keep a non-checkout Codex worker resumable with start's checkout-check
+  bypass, without duplicating lifecycle cwd handling.

--- a/openspec/changes/archive/196-codex-effort-enum/tasks.md
+++ b/openspec/changes/archive/196-codex-effort-enum/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] Update the Codex worker guard without changing its default.
+- [x] Update the orchestration references and probe history.
+- [x] Add an exact regression pin for the live API enum.
+- [x] Archive the completed change in this pull request.

--- a/skills/drivers/orchestrate/references/dispatch-claude.md
+++ b/skills/drivers/orchestrate/references/dispatch-claude.md
@@ -82,7 +82,8 @@ Every delegation carries `--effort`, defaulting to `medium` for every model
 because no effort benchmarking exists yet (see `references/routing-table.md`
 Effort notes). `claude-worker.py`'s enum is `low|medium|high|xhigh|max`,
 captured in `docs/scope/149-probes/effort-enums.md` from `claude --help`; it
-is not the same set as `codex-worker.py`'s `minimal|low|medium|high|xhigh`.
+is not the same set as `codex-worker.py`'s `none|low|medium|high|xhigh|max`
+(probed against the live API on 2026-08-27).
 The chosen effort is persisted in state and replayed on `resume`.
 
 ## Liveness is process identity only

--- a/skills/drivers/orchestrate/references/routing-table.md
+++ b/skills/drivers/orchestrate/references/routing-table.md
@@ -51,8 +51,9 @@ surface both failed attempts to the operator.
   effort dial.
 - The two adapters validate different enums, each a literal in its own
   script: `claude-worker.py` accepts `low|medium|high|xhigh|max`;
-  `codex-worker.py` accepts `minimal|low|medium|high|xhigh` (unvalidated
-  locally by the Codex CLI itself). See
+  `codex-worker.py` accepts `none|low|medium|high|xhigh|max` (unvalidated
+  locally by the Codex CLI itself). A live Codex 5.6 API probe recorded this
+  set on 2026-08-27. See
   `docs/scope/149-probes/effort-enums.md`.
 - Spark's value is latency: use for tight edit-test loops and mockup iteration, not judgment.
 - Opus spends ~4–5× Haiku's tokens on the same exploration prompt; route it only where the depth is the point.

--- a/skills/drivers/orchestrate/scripts/codex-worker.py
+++ b/skills/drivers/orchestrate/scripts/codex-worker.py
@@ -123,7 +123,7 @@ def resume(args: argparse.Namespace) -> int:
         return fail(error)
     assert fresh is not None and expected is not None
     effort = effort_of(fresh)
-    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", "--json", args.prompt]
+    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", "--skip-git-repo-check", "--json", args.prompt]
     return lifecycle.run_lifecycle(
         args, command, fresh, expected=expected, parse=parse, emit=emit, fail=fail,
         stdin_text=None, effort_levels=EFFORT_LEVELS,

--- a/skills/drivers/orchestrate/scripts/codex-worker.py
+++ b/skills/drivers/orchestrate/scripts/codex-worker.py
@@ -15,11 +15,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import worker_lifecycle as lifecycle
 
 
-# Effort enum captured in docs/scope/149-probes/effort-enums.md: the Codex CLI
-# validates nothing locally (a bogus value starts the session and fails at the
-# API), so this set is documentation plus this adapter's own guard, not a
-# discovered constraint. Not shared with claude-worker.py's enum.
-EFFORT_LEVELS = {"minimal", "low", "medium", "high", "xhigh"}
+# The 2026-08-27 live API probe recorded in docs/scope/149-probes/effort-enums.md
+# accepted none, low, medium, high, xhigh, and max for Codex 5.6. The Codex CLI
+# validates nothing locally, so this adapter owns the local guard. Not shared
+# with claude-worker.py's enum.
+EFFORT_LEVELS = {"none", "low", "medium", "high", "xhigh", "max"}
 DEFAULT_EFFORT = "medium"
 
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1601,7 +1601,8 @@ class CodexWorkerTests(unittest.TestCase):
         self.assertEqual(payload["final_message"], "worker answer")
         self.assertEqual(payload["headroom_status"], "unknown")
 
-    def test_resume_reapplies_persisted_model_and_sandbox(self):
+    def test_resume_in_a_non_checkout_reapplies_persisted_model_and_sandbox(self):
+        self.assertFalse((self.worktree / ".git").exists())
         started = self.start(
             '{"type":"thread.started","thread_id":"worker-1"}\n',
             sandbox="workspace-write",
@@ -1635,6 +1636,7 @@ class CodexWorkerTests(unittest.TestCase):
                 'sandbox_mode="workspace-write"',
                 "-c",
                 "model_reasoning_effort=medium",
+                "--skip-git-repo-check",
                 "--json",
                 "continue with the failing test",
             ],

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2306,15 +2306,11 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertIn("model_reasoning_effort=high", argv)
         self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["effort"], "high")
 
-    def test_codex_rejects_an_effort_outside_its_own_enum(self):
-        result = self.run_codex(
-            "start", "--codex", str(self.codex_binary), "--state", str(self.state),
-            "--model", "Terra", "--sandbox", "read-only", "--effort", "max",
-            "--cwd", str(self.worktree), "do the work",
+    def test_codex_effort_enum_matches_the_live_api_probe(self):
+        self.assertEqual(
+            WORKER_MODULE.EFFORT_LEVELS,
+            {"none", "low", "medium", "high", "xhigh", "max"},
         )
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("--effort", result.stderr)
-        self.assertFalse(self.state.exists())
 
     def test_codex_replays_persisted_effort_on_resume(self):
         legacy = {
@@ -2371,8 +2367,7 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(json.loads(result.stdout)["effort"], "xhigh")
 
     def test_claude_rejects_an_effort_outside_its_own_enum(self):
-        # "minimal" is valid for codex but not claude — the two adapters do not
-        # share one enum.
+        # "minimal" is invalid for both adapters, although their enums differ.
         result = self.run_claude(
             "start", "--claude", str(self.claude_binary), "--state", str(self.state),
             "--model", "sonnet", "--sandbox", "read-only", "--effort", "minimal",
@@ -2591,7 +2586,7 @@ class OrchestrateAdapterDispatchTests(unittest.TestCase):
             ROOT / "skills" / "drivers" / "orchestrate" / "references" / "routing-table.md"
         ).read_text(encoding="utf-8")
         self.assertIn("low|medium|high|xhigh|max", table)
-        self.assertIn("minimal|low|medium|high|xhigh", table)
+        self.assertIn("none|low|medium|high|xhigh|max", table)
         self.assertIn("defaulting to medium", table)
 
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2246,12 +2246,16 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.state = self.scratch / "worker-state.json"
         self.arguments = self.scratch / "arguments.json"
         self.stdin_capture = self.scratch / "stdin.txt"
+        self.codex_home = self.scratch / "codex-home"
+        self.codex_home_marker = self.scratch / "codex-home-marker"
 
         self.codex_binary = self.scratch / "fake-codex"
         self.codex_binary.write_text(
             "#!/usr/bin/env python3\n"
             "import json, os, pathlib, sys\n"
             "pathlib.Path(os.environ['FAKE_ARGUMENTS']).write_text(json.dumps(sys.argv[1:]))\n"
+            "if os.environ.get('FAKE_EXPECTED_CODEX_HOME'):\n"
+            "    pathlib.Path(os.environ['FAKE_CODEX_HOME_MARKER']).write_text('fixture' if os.environ.get('CODEX_HOME') == os.environ['FAKE_EXPECTED_CODEX_HOME'] else 'wrong')\n"
             "sys.stdout.write(os.environ.get('FAKE_OUTPUT', ''))\n"
             "sys.exit(int(os.environ.get('FAKE_EXIT', '0')))\n",
             encoding="utf-8",
@@ -2271,8 +2275,11 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.claude_binary.chmod(0o755)
 
         self.environment = os.environ.copy()
+        self.environment["CODEX_HOME"] = str(self.codex_home)
         self.environment["FAKE_ARGUMENTS"] = str(self.arguments)
         self.environment["FAKE_STDIN"] = str(self.stdin_capture)
+        self.environment["FAKE_EXPECTED_CODEX_HOME"] = str(self.codex_home)
+        self.environment["FAKE_CODEX_HOME_MARKER"] = str(self.codex_home_marker)
 
     def tearDown(self):
         self.temporary.cleanup()
@@ -2284,6 +2291,15 @@ class WorkerEffortDialTests(unittest.TestCase):
         return run(["python3", str(CLAUDE_WORKER), *arguments], cwd=ROOT, env=self.environment)
 
     # --- codex-worker.py -------------------------------------------------
+
+    def test_codex_worker_subprocess_uses_the_fixture_session_home(self):
+        self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'
+        result = self.run_codex(
+            "start", "--codex", str(self.codex_binary), "--state", str(self.state),
+            "--model", "Terra", "--sandbox", "read-only", "--cwd", str(self.worktree), "do the work",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.codex_home_marker.read_text(encoding="utf-8"), "fixture")
 
     def test_codex_start_defaults_to_medium_effort_in_argv(self):
         self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'


### PR DESCRIPTION
## Summary

This PR ships three correctness fixes to the same Codex worker adapter and its tests: worker delegations accept the live API effort levels, non-checkout workers resume in the same recorded session, and adapter tests no longer scan the operator's private session history.

* The default remains medium, and Claude's separate effort choices are unchanged.
* Resume now carries the same checkout-check bypass as start while continuing to run in the lifecycle-recorded directory.
* The current API probe and the superseded 2026-08-24 record are kept together, so the reason for the update remains visible.
* The archived OpenSpec change records the boundary and its regression coverage.

Closes #196
Closes #204
Closes #210

## Verification

* The worker-effort adapter suite: 17 tests, OK in 2.652 seconds.
* The complete repository gate was started without a `CODEX_HOME` override; this runner terminated it before it produced output or an exit marker after 150 seconds.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
