### PR TITLE
Run the site-build tests in the documented test command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ ui-surfaces: none
 - Test: `python3 scripts/validate.py && python3 -m unittest tests.test_behavior
   tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench
   tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco
-  tests.test_ci_changed_paths && python3 -m py_compile
+  tests.test_ci_changed_paths tests.test_site_build && python3 -m py_compile
   skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py
   skills/drivers/orchestrate/scripts/worker_lifecycle.py
   skills/drivers/orchestrate/scripts/codex-worker.py


### PR DESCRIPTION
## What changed

Someone following this repo's own written instructions for checking their work now runs the same checks the project runs automatically.

The repo facts list the command a contributor or agent runs before opening a pull request. That list named every group of checks except the one covering the documentation site, so anyone following it verified five fewer checks than the project itself did. The automated checks already covered the documentation site on every pull request — only the written instruction was short.

## Why it matters

Agents working in this repo are told to trust the repo facts and run exactly that command. When the written command is narrower than the real gate, work can look verified locally and still be unverified in the area the command skipped. This session hit that directly: several delegated workers reported the documented command as their evidence of a clean run.

## What to check

The command in the repo facts, run verbatim, should report 439 tests passing rather than 434.

No behavior changes anywhere in the pack — this is a one-line correction to an instruction.