### PR TITLE
Clarify worker verification reporting

### DIFF
--- a/openspec/changes/archive/212-worker-verification-reporting/design.md
+++ b/openspec/changes/archive/212-worker-verification-reporting/design.md
@@ -1,0 +1,12 @@
+# Design
+
+## ADR 212 — Truthful verification reporting is a prose contract
+
+The worker-facing rule lives immediately before the existing coordinator
+verification obligation. It distinguishes the named full command from supplemental
+checks, hooks, bypasses, and incomplete runs without changing routing, adapters,
+lifecycle scripts, or coordinator escalation behavior.
+
+The assurance boundary is intentional: a whitespace-normalized prose pin guards the
+load-bearing partial-is-not-full sentence. No parser, evidence protocol, provenance
+record, or runtime enforcement is added.

--- a/openspec/changes/archive/212-worker-verification-reporting/proposal.md
+++ b/openspec/changes/archive/212-worker-verification-reporting/proposal.md
@@ -1,0 +1,24 @@
+# Truthful full-gate worker completion reports
+
+## Why
+
+Worker completion reports have sometimes represented focused, bypassed, failed, or
+interrupted verification as the full verification requested in the brief. The
+coordinator already independently verifies delegated results before shipping; this
+change makes the worker's evidence boundary explicit.
+
+## What changes
+
+Require workers to name and paste the complete output of the brief's exact successful
+verification command before claiming it passed. Label partial checks as supplemental,
+disclose bypasses, and report incomplete commands as unverified.
+
+## Risk contract
+
+- **Must prevent:** a completion report representing a partial, bypassed, failed, or
+  interrupted check as the brief's full successful verification.
+- **Must recover:** workers report the verification as incomplete; the coordinator's
+  existing independent verification decides whether the result can ship.
+- **Accepted failure:** an agent may still misread the prose, costing a rerun.
+- **Unsupported:** parsing, validation, provenance capture, or runtime enforcement.
+- **Evidence owed:** the one prose pin and the repository gate.

--- a/openspec/changes/archive/212-worker-verification-reporting/tasks.md
+++ b/openspec/changes/archive/212-worker-verification-reporting/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] State the worker completion-reporting contract beside coordinator verification.
+- [x] Pin the partial-checks-are-supplemental rule with a focused prose test.
+- [x] Archive the completed OpenSpec change record with its risk contract.
+- [x] Run the repository gate and record its result in the pull request.

--- a/skills/drivers/orchestrate/SKILL.md
+++ b/skills/drivers/orchestrate/SKILL.md
@@ -180,6 +180,8 @@ evidence.
 
 ## Verification and escalation
 
+**Worker completion reports:** A claim that the brief's verification passed names the exact command from the brief, states that it completed successfully, and includes that command's complete, unedited output. Focused, targeted, or subset checks are supplemental evidence and never stand in for the named verification command. A hook run or `git push --no-verify` does not substitute for that command; disclose any bypass with the completion report. Report a command that was not started, failed, or was interrupted as unverified, with its available output and reason, rather than as a successful full-gate result.
+
 Every delegated result is verified by the coordinator before it ships: run the
 tests yourself, spot-check citations, diff against the spec. On failed
 verification:

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3094,11 +3094,15 @@ class PlanReviewAdapterDispatchTests(unittest.TestCase):
 class AssuranceLevelMatchingContractTests(unittest.TestCase):
     PROFILE = ROOT / "profile" / "base.md"
     PLAN_REVIEW = ROOT / "skills" / "tools" / "plan-review" / "SKILL.md"
+    ORCHESTRATE = ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md"
 
     def setUp(self):
         self.profile = " ".join(self.PROFILE.read_text(encoding="utf-8").split())
         self.plan_review = " ".join(
             self.PLAN_REVIEW.read_text(encoding="utf-8").split()
+        )
+        self.orchestrate = " ".join(
+            self.ORCHESTRATE.read_text(encoding="utf-8").split()
         )
 
     def test_working_preference_matches_mechanism_to_requested_assurance(self):
@@ -3129,6 +3133,13 @@ class AssuranceLevelMatchingContractTests(unittest.TestCase):
             "demand and the evidence-block spot check's **BLOCKED** verdict are this skill's own "
             "triage and evidence obligations, not assurance escalation, and are unaffected.",
             self.plan_review,
+        )
+
+    def test_partial_checks_are_supplemental_not_full_verification(self):
+        self.assertIn(
+            "Focused, targeted, or subset checks are supplemental evidence and never stand "
+            "in for the named verification command.",
+            self.orchestrate,
         )
 
     def test_cycle_rereads_settled_decisions_after_compaction(self):


### PR DESCRIPTION
## What changed

Worker completion reports now distinguish the exact full verification requested in a brief from focused, bypassed, failed, or interrupted checks. A successful full-verification claim names the command, says it completed successfully, and carries the command's complete unedited output.

Focused checks remain useful supplemental evidence, but cannot be presented as the full check. Bypasses are disclosed, and an unfinished check is reported as unverified so the coordinator's existing independent verification can decide whether the result ships.

## Why it matters

Delegated work can otherwise appear fully verified when only part of the requested evidence exists. The reporting contract now makes that boundary explicit without changing the coordinator's verification responsibility or adding runtime enforcement.

The completed change record is archived with the accepted risk that an agent can still misread the prose and cost a rerun.

## What to check

The complete repository gate reports 440 tests, 23 skips, and OK. The focused prose check fails when its pinned partial-is-not-full sentence is removed.

Closes #212

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
