### PR TITLE
Give the epic driver a tracker bindings seam

### DIFF
--- a/skills/drivers/epic/SKILL.md
+++ b/skills/drivers/epic/SKILL.md
@@ -11,7 +11,7 @@ description: "Maintain an epic ledger and work clear child tickets through a Git
 
 An epic lives at `openspec/changes/<epic-slug>/`. Its `proposal.md` and `design.md` are authoritative for destination, scope, risk, and durable decisions. Tracker children substitute for `tasks.md`; `ledger.md` rides the standing planning pull request. The epic ledger is a derived index, not another source of truth. Live GitHub is truth whenever it disagrees with the ledger.
 
-Use GitHub Issues only. Read [the tracker reference](references/github-tracker.md) before the first tracker action. A tracker, authentication, or Git failure stops the current operation visibly; do not guess or repair authoritative state from the ledger.
+Tracker operations go through the installed binding; the default binding is GitHub Issues ([bindings/github-issues.md](bindings/github-issues.md)). Read [the tracker contract](references/tracker-contract.md) before the first tracker action. A tracker, authentication, or Git failure stops the current operation visibly; do not guess or repair authoritative state from the ledger.
 
 The home session owns the epic. It stays at planning altitude, files and reads issues, and is the only epic-ledger writer. Build and triage sessions report in their ticket comments and pull requests; the home session syncs the ledger after they return. Coordinators do not nest.
 

--- a/skills/drivers/epic/bindings/github-issues.md
+++ b/skills/drivers/epic/bindings/github-issues.md
@@ -1,6 +1,6 @@
-# GitHub tracker operations
+# Binding: GitHub issues
 
-Epic planning uses authenticated GitHub Issues. Before a mutation, run `gh version` and `gh auth status`; pass `--repo OWNER/REPO` explicitly. The current GitHub CLI must support native sub-issues and dependencies. Live tracker state is truth; re-read it after every mutation that changes relationships or labels.
+The default binding for [the epic tracker contract](../references/tracker-contract.md). Epic planning uses authenticated GitHub Issues. Before a mutation, run `gh version` and `gh auth status`; pass `--repo OWNER/REPO` explicitly. The current GitHub CLI must support native sub-issues and dependencies. Live tracker state is truth; re-read it after every mutation that changes relationships or labels.
 
 ## Bootstrap labels
 

--- a/skills/drivers/epic/references/tracker-contract.md
+++ b/skills/drivers/epic/references/tracker-contract.md
@@ -1,0 +1,71 @@
+# The epic tracker contract
+
+Four operations, and nothing else. `$epic` calls these; it never calls a
+tracker's API directly, and it never reaches a second tracker when the first
+one is unreachable. A verb that cannot reach the contract stops and names what
+is missing.
+
+One binding page supplies all four for one tracker.
+[bindings/github-issues.md](../bindings/github-issues.md) is the default
+binding and ships with the skill.
+
+## 1. Create a native child issue
+
+* **Input:** the epic id, a title, a body, and its type (`spike` or `build`),
+  plus `deferred` when it applies.
+* **Output:** the created child's id and URL, attached to the epic as a native
+  child.
+* **Failure:** the create is rejected or the transport fails. The verb reports
+  the failure and does not treat the child as filed.
+
+## 2. Apply type labels
+
+* **Input:** a child id and one type (`spike` or `build`), plus the epic
+  protocol labels (`epic`, `spike`, `build`, `deferred`) the binding must be
+  able to create idempotently.
+* **Output:** confirmation that the label is attached. The `ticket:*` status
+  axis is independent and this operation must not remove, rename, or
+  reconcile it.
+* **Failure:** the label cannot be created or attached. Report it; do not
+  infer the label is present.
+
+## 3. Read the parent and its children, and their types
+
+* **Input:** the epic id.
+* **Output:** the epic's native child list, and for each child its state,
+  state reason, type label (`spike` or `build`), `deferred` presence, and any
+  closing pull request reference with that pull request's merge state.
+* **Failure:** the epic does not exist, or the tracker is unreachable. The
+  verb stops and names the id and the transport that failed. It never infers
+  a completion predicate from a partial or stale read.
+
+## 4. File a review follow-up as a native child
+
+* **Input:** the epic id, a title, a body, and the follow-up's type (`spike`
+  or `build`), plus `deferred` when the epic destination does not require it.
+* **Output:** the created child's id and URL, attached to the epic as a
+  native child, ready to report on the originating ticket.
+* **Failure:** the create is rejected or the transport fails. The verb
+  reports the failure and does not claim the follow-up was filed.
+
+## What a binding page supplies
+
+One page, per operation:
+
+1. The concrete command or tool call, with its inputs named.
+2. What must be installed and authenticated for that call to work.
+3. What the operation maps onto when the tracker has no equivalent.
+4. The exact message the binding produces when its tracker or its transport
+   is absent.
+
+## Writing a binding for another tracker
+
+One page, the four operations above, in the same order, with the four items
+above filled in for each.
+
+* A binding whose tracker or transport is absent stops with a clear message
+  that names what is missing and how to supply it.
+* It never falls back to a different tracker, and never invents a local
+  substitute for native structure.
+* A binding that cannot implement an operation says so on the page. Create
+  and read are load-bearing: a binding missing either one cannot run `$epic`.

--- a/skills/drivers/ticket/references/review-actions.md
+++ b/skills/drivers/ticket/references/review-actions.md
@@ -7,7 +7,7 @@ Ground each finding before choosing exactly one disposition.
 * **Necessary follow-up.** It is real but outside the order; file a ticket with
   evidence, desired outcome, and a checked duplicate search. Keep it out of this
   pull request. Under an epic, read
-  [the epic tracker reference](../../epic/references/github-tracker.md): when the
+  [the epic tracker contract](../../epic/references/tracker-contract.md): when the
   epic destination requires it, file the follow-up as an in-scope native child;
   otherwise file it as a native child with its `spike` or `build` type plus
   `deferred`, and report it on the originating ticket.

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -4123,7 +4123,7 @@ class EpicProtocolContractTests(unittest.TestCase):
         encoding="utf-8"
     )
     TRACKER = (
-        ROOT / "skills" / "drivers" / "epic" / "references" / "github-tracker.md"
+        ROOT / "skills" / "drivers" / "epic" / "bindings" / "github-issues.md"
     ).read_text(encoding="utf-8")
 
     def require(self, text, pattern):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -474,11 +474,11 @@ class TicketSkillContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         tracker_path = (
-            ROOT / "skills" / "drivers" / "epic" / "references" / "github-tracker.md"
+            ROOT / "skills" / "drivers" / "epic" / "bindings" / "github-issues.md"
         )
         tracker = tracker_path.read_text(encoding="utf-8")
 
-        self.assertIn("../../epic/references/github-tracker.md", actions)
+        self.assertIn("../../epic/references/tracker-contract.md", actions)
         self.assertIn("Necessary follow-up", actions)
         self.assertRegex(
             tracker,


### PR DESCRIPTION
## What changed

Epic's tracker operations now go through a binding seam mirroring ticket's: the GitHub mechanics live in `bindings/github-issues.md` as the default binding, and a new `references/tracker-contract.md` enumerates the four operations epic requires from any binding (create a native child, apply type labels, read the parent and children with their types, file a review follow-up as a native child). Previously the driver said "Use GitHub Issues only" and carried the mechanics in a single reference with no rebind point.

* Ticket's review-actions follow-up disposition points at the contract instead of the GitHub-only reference.
* The contract stays scoped to what epic's verbs perform today; no speculative operations.
* Default installs behave identically: GitHub Issues remains the shipped binding and no instruction text beyond the seam wording changed.

## Why it matters

Consumers that bind ticket to another tracker through an overlay had nothing to bind epic against and would have to fork the whole driver. This gives them the same rebind point ticket already provides.

## What to check

The validator reports 27 skills and 350 files. The repository gate reports 440 tests, 1 skip, OK. One caveat on that run: the spin-worktree dirty-checkout test reads the operator's real spin-worktree config, so it fails on a machine that sets `branchPrefix` there; the OK run had that file absent.

Closes #214

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
