### PR TITLE
feat(epic): give epic a tracker bindings seam like ticket's

### DIFF
--- a/openspec/changes/archive/214-epic-bindings-seam/design.md
+++ b/openspec/changes/archive/214-epic-bindings-seam/design.md
@@ -1,0 +1,26 @@
+# Design
+
+## ADR 214 — Epic's tracker seam mirrors ticket's, not a new shape
+
+Epic's GitHub mechanics were a single reference page with no rebind point.
+Rather than invent a different binding shape for epic, the seam mirrors
+`ticket`'s layout exactly: a `references/tracker-contract.md` enumerating the
+operations epic's verbs perform today, and `bindings/github-issues.md` as the
+shipped default binding.
+
+The contract's operation list is derived from what `epic/SKILL.md` already
+does (create a native child, apply the four protocol labels, read children with
+state/type/deferred/closing-PR merge state, file a review follow-up as a
+native child), not expanded or spread. GitHub Issues stays the only binding
+shipped; no binding-selection config is added, since epic has exactly one
+consumer of the seam today (a future Jira binding, out of scope here).
+
+### Consequences
+
+* A future non-GitHub binding for epic has the same shape as a ticket binding
+  and the same four-operation contract discipline.
+* `ticket/references/review-actions.md`'s epic-child follow-up path now reads
+  through the contract, so it does not need to change again if a second
+  binding ships later.
+* No behavior changes for the shipped default: same labels, same native
+  structure, same completion checks.

--- a/openspec/changes/archive/214-epic-bindings-seam/proposal.md
+++ b/openspec/changes/archive/214-epic-bindings-seam/proposal.md
@@ -1,0 +1,33 @@
+# Epic gets a tracker bindings seam
+
+## Why
+
+The epic driver was GitHub-Issues-only: `SKILL.md` said "Use GitHub Issues only"
+and kept all tracker mechanics in one `references/github-tracker.md`, with no
+binding abstraction analogous to `ticket/bindings/*.md`. A consumer binding the
+ticket skill to another tracker had no seam to bind epic against and would have
+had to fork the whole driver.
+
+## What changes
+
+* The epic driver's GitHub mechanics move to `bindings/github-issues.md`,
+  mirroring `ticket`'s layout, behind a new `references/tracker-contract.md`
+  naming the four operations any binding must supply (create a native child,
+  apply the protocol type labels, read the epic's children, file a review
+  follow-up as a native child).
+* `ticket`'s `references/review-actions.md` "Necessary follow-up" disposition
+  points at the epic tracker contract instead of the old GitHub-only reference.
+* Default installs behave identically: GitHub Issues remains the shipped
+  binding, and no binding-selection machinery is added.
+
+## Risk contract
+
+- **Must prevent:** a live document or test pointing at the old
+  `epic/references/github-tracker.md` path.
+- **Must recover:** n/a; this is a path move plus a contract document, not a
+  runtime behavior change.
+- **Accepted failure:** none identified.
+- **Unsupported:** binding-selection config, a second shipped binding, or any
+  change to what epic's tracker operations do.
+- **Evidence owed:** `scripts/validate.py` (skill set and link check) and the
+  full unittest suite passing.

--- a/openspec/changes/archive/214-epic-bindings-seam/tasks.md
+++ b/openspec/changes/archive/214-epic-bindings-seam/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Move epic's GitHub tracker mechanics to `bindings/github-issues.md`.
+- [x] Write `references/tracker-contract.md` naming epic's four tracker operations.
+- [x] Update `epic/SKILL.md` to route through the installed binding.
+- [x] Point `ticket/references/review-actions.md`'s epic-child follow-up at the contract.
+- [x] Fix every remaining live referrer to the old path (tests included).
+- [x] Archive the completed OpenSpec change record.
+- [x] Run the repository gate and record its result in the pull request.

--- a/skills/drivers/epic/SKILL.md
+++ b/skills/drivers/epic/SKILL.md
@@ -11,7 +11,7 @@ description: "Maintain an epic ledger and work clear child tickets through a Git
 
 An epic lives at `openspec/changes/<epic-slug>/`. Its `proposal.md` and `design.md` are authoritative for destination, scope, risk, and durable decisions. Tracker children substitute for `tasks.md`; `ledger.md` rides the standing planning pull request. The epic ledger is a derived index, not another source of truth. Live GitHub is truth whenever it disagrees with the ledger.
 
-Use GitHub Issues only. Read [the tracker reference](references/github-tracker.md) before the first tracker action. A tracker, authentication, or Git failure stops the current operation visibly; do not guess or repair authoritative state from the ledger.
+Route every tracker operation through the installed binding. [bindings/github-issues.md](bindings/github-issues.md) is the shipped default. Read [the tracker contract](references/tracker-contract.md) before the first tracker action. A tracker, authentication, or Git failure stops the current operation visibly; do not guess or repair authoritative state from the ledger.
 
 The home session owns the epic. It stays at planning altitude, files and reads issues, and is the only epic-ledger writer. Build and triage sessions report in their ticket comments and pull requests; the home session syncs the ledger after they return. Coordinators do not nest.
 

--- a/skills/drivers/epic/bindings/github-issues.md
+++ b/skills/drivers/epic/bindings/github-issues.md
@@ -1,6 +1,6 @@
-# GitHub tracker operations
+# Binding: GitHub issues
 
-Epic planning uses authenticated GitHub Issues. Before a mutation, run `gh version` and `gh auth status`; pass `--repo OWNER/REPO` explicitly. The current GitHub CLI must support native sub-issues and dependencies. Live tracker state is truth; re-read it after every mutation that changes relationships or labels.
+The reference binding for [the epic tracker contract](../references/tracker-contract.md), shipped with the skill. Epic planning uses authenticated GitHub Issues. Before a mutation, run `gh version` and `gh auth status`; pass `--repo OWNER/REPO` explicitly. The current GitHub CLI must support native sub-issues and dependencies. Live tracker state is truth; re-read it after every mutation that changes relationships or labels.
 
 ## Bootstrap labels
 

--- a/skills/drivers/epic/references/tracker-contract.md
+++ b/skills/drivers/epic/references/tracker-contract.md
@@ -1,0 +1,78 @@
+# The epic tracker contract
+
+Four operations, and nothing else. Epic calls these; it never calls a tracker's
+API directly, and it never reaches a second tracker when the first one is
+unreachable. A tracker, authentication, or Git failure stops the current
+operation visibly; epic never guesses or repairs authoritative state from the
+ledger when a call fails.
+
+One binding page supplies all four for one tracker.
+[bindings/github-issues.md](../bindings/github-issues.md) is the reference
+binding and ships with the skill.
+
+## 1. Create a native child
+
+* **Input:** the parent epic's id, a title, a body, and one type (`spike` or
+  `build`), plus `deferred` when the child sits outside the epic's current
+  destination.
+* **Output:** the created child's id and URL, attached to the parent through the
+  tracker's native parent-child relationship.
+* **Failure:** the tracker rejects the creation, the parent id does not exist, or
+  the transport fails. Epic stops, prints the body it was going to file so
+  nothing is lost, and names what happened. It never substitutes prose for
+  native structure.
+
+## 2. Apply the epic protocol type labels
+
+* **Input:** the four protocol labels (`epic`, `spike`, `build`, `deferred`) and
+  the id of the issue receiving one.
+* **Output:** confirmation the label exists and is attached. The bootstrap step
+  creates all four idempotently before first use.
+* **Failure:** a label cannot be created or attached (no permission, or the
+  tracker disallows it). Epic reports this in one line and continues; it never
+  removes, renames, or reconciles the independent `ticket:*` status axis while
+  doing so.
+
+## 3. Read the epic's children
+
+* **Input:** the parent epic's id.
+* **Output:** every child's id, title, state, type label, whether it carries
+  `deferred`, and the merge state of any pull request that closed it.
+* **Failure:** the parent id does not exist, or the transport fails. Epic stops
+  and names the id and the transport that failed; it never proceeds on a partial
+  read, and a ledger line never substitutes for this read.
+
+## 4. File a review follow-up as a native child
+
+* **Input:** the originating ticket's epic (when any), a title, a body carrying
+  evidence and desired outcome, and one type (`spike` or `build`).
+* **Output:** the created child's id and URL, filed in-scope when the epic
+  destination requires it, otherwise filed with its type plus `deferred`, and
+  reported on the originating ticket.
+* **Failure:** same as operation 1. This is operation 1 invoked from ticket's
+  review-actions "Necessary follow-up" disposition, not a fifth operation.
+
+## What a binding page supplies
+
+One page, per operation:
+
+1. The concrete command or tool call, with its inputs named.
+2. What must be installed and authenticated for that call to work.
+3. What the operation maps onto when the tracker has no equivalent (native
+   parent-child structure is the usual case).
+4. The markup comments and issue bodies are written in, since the binding owns
+   markup and epic's templates do not.
+5. The exact message the binding produces when its tracker or its transport is
+   absent.
+
+## Writing a binding for another tracker
+
+One page, the four operations above, in the same order, with the five items
+above filled in for each.
+
+* A binding whose tracker or transport is absent stops with a clear message that
+  names what is missing and how to supply it.
+* It never falls back to a different tracker, and never invents a local
+  substitute for a child issue.
+* A binding that cannot implement an operation says so on the page. Create and
+  read are load-bearing: a binding missing either one cannot run epic.

--- a/skills/drivers/ticket/references/review-actions.md
+++ b/skills/drivers/ticket/references/review-actions.md
@@ -7,7 +7,7 @@ Ground each finding before choosing exactly one disposition.
 * **Necessary follow-up.** It is real but outside the order; file a ticket with
   evidence, desired outcome, and a checked duplicate search. Keep it out of this
   pull request. Under an epic, read
-  [the epic tracker reference](../../epic/references/github-tracker.md): when the
+  [the epic tracker contract](../../epic/references/tracker-contract.md): when the
   epic destination requires it, file the follow-up as an in-scope native child;
   otherwise file it as a native child with its `spike` or `build` type plus
   `deferred`, and report it on the originating ticket.

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -4123,7 +4123,7 @@ class EpicProtocolContractTests(unittest.TestCase):
         encoding="utf-8"
     )
     TRACKER = (
-        ROOT / "skills" / "drivers" / "epic" / "references" / "github-tracker.md"
+        ROOT / "skills" / "drivers" / "epic" / "bindings" / "github-issues.md"
     ).read_text(encoding="utf-8")
 
     def require(self, text, pattern):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -474,11 +474,11 @@ class TicketSkillContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         tracker_path = (
-            ROOT / "skills" / "drivers" / "epic" / "references" / "github-tracker.md"
+            ROOT / "skills" / "drivers" / "epic" / "bindings" / "github-issues.md"
         )
         tracker = tracker_path.read_text(encoding="utf-8")
 
-        self.assertIn("../../epic/references/github-tracker.md", actions)
+        self.assertIn("../../epic/references/tracker-contract.md", actions)
         self.assertIn("Necessary follow-up", actions)
         self.assertRegex(
             tracker,


### PR DESCRIPTION
## Motivation and Context

Epic's tracker mechanics now live behind an installed binding, the same seam `ticket` already has: `bindings/github-issues.md` plus a `references/tracker-contract.md` naming the four operations any binding must supply. Epic was GitHub-Issues-only with no rebind point, so a consumer binding another tracker had to fork the whole driver.

* The moved binding page keeps the same GitHub mechanics; nothing about label bootstrap, native child creation, or completion checks changed.
* `ticket/references/review-actions.md`'s epic-child follow-up path now links the contract instead of the old GitHub-only reference.
* The old path survives only in `openspec/changes/archive/epic-rework/proposal.md`, an archived historical record left untouched.

Decisions live in `openspec/changes/archive/214-epic-bindings-seam/design.md`.

Fixes #214

## How Has This Been Tested?

* `python3 scripts/validate.py`: 27 skills, 354 files, no findings.
* `python3 -m unittest` across the repo's full named suite: 440 tests, OK (one expected skip from the documented `spin-worktree` config trap, not counted against this change).
* `python3 -m py_compile` on the five pinned scripts: clean.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
