### PR TITLE
docs(openspec): epic 218 proposal and design for vanilla OpenSpec

### DIFF
--- a/docs/research/openspec-cli.md
+++ b/docs/research/openspec-cli.md
@@ -1,0 +1,98 @@
+# OpenSpec CLI (`@fission-ai/openspec`) — Findings
+
+**Method:** Read directly from a local shallow clone of github.com/Fission-AI/OpenSpec (v1.11.0-era source, not fetched live — network was unavailable this session) and a local npm registry metadata dump for `@fission-ai/openspec`. All citations are repo-relative paths into that clone unless noted. Nothing here was corroborated against the live GitHub repo, live npm registry, or any blog/secondary source — flagged as unconfirmed where the local material doesn't answer.
+
+**Canonical repo:** `github.com/Fission-AI/OpenSpec`, package `@fission-ai/openspec` (`package.json` / npm registry `homepage`/`repository.url`). No successor repo found in the local material — the repo itself *is* mid-rewrite (OPSX, v1.0+), but that's a major version bump, not a fork/successor.
+
+---
+
+## 1. What `openspec validate --strict` enforces
+
+Validation logic lives in `src/core/validation/validator.ts` (class `Validator`), invoked via `src/commands/validate.ts`.
+
+- **Two validation targets:** a `spec` (`validator.validateSpec`, reads `openspec/specs/<id>/spec.md`) and a `change`'s delta specs (`validator.validateChangeDeltaSpecs`, reads `openspec/changes/<id>/specs/**/spec.md`). `openspec validate <name>` auto-detects which; `--type change|spec` overrides (`src/commands/validate.ts:215-236`).
+- **`--strict` semantics:** in `Validator.createReport` (`validator.ts:782-800`), `valid = strictMode ? errors===0 && warnings===0 : errors===0`. Strict mode turns every WARNING into a blocking failure; it adds no new checks of its own — it's a severity gate, not a schema toggle.
+- **Delta spec format enforced** (`validateChangeDeltaSpecs`, `validator.ts:159-467`):
+  - Delta headers recognized: `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`, `## RENAMED Requirements` (case-insensitive matching elsewhere, e.g. `archive.ts:1258`). Non-canonical `###` headers under those sections (missing `### Requirement:` prefix, or a nameless `### Requirement:`) are flagged **INFO**, not an error — they're silently skipped by the parser, not rejected (`validator.ts:205-221`).
+  - **ADDED/MODIFIED**: each block needs requirement text (ERROR if missing) and at least one scenario (ERROR if `countScenarios < 1`, `validator.ts:270-274, 305-309`). Missing SHALL/MUST in the body is only a WARNING (guidance) in normal mode; the header (`constants.ts:63,67`) documents scenarios must be level-4 `#### Scenario:` headers.
+  - **REMOVED**: names only — no scenario/description required (`validator.ts:331-340`).
+  - **RENAMED**: `from`/`to` pairs checked for duplicates within RENAMED and cross-checked against ADDED/MODIFIED/REMOVED for conflicts (`validator.ts:342-396`).
+  - Duplicate requirement names within a section, and cross-section conflicts (same name in both MODIFIED+REMOVED, MODIFIED+ADDED, ADDED+REMOVED, RENAMED collisions) are ERRORs.
+  - **Scenario-loss guard** (`findScenarioLossIssues`, `validator.ts:537-621`): when `mainSpecsDir` is passed (standalone `validate` does pass it — `src/commands/validate.ts:220-223`), a MODIFIED block that drops a scenario the current main spec still has is an ERROR — the same check `archive` enforces before merging, run early at authoring time.
+  - A **`spec.md` sitting directly under `specs/`** (no capability folder) is an ERROR — the merge path ignores it silently, so validate blocks it explicitly (`validator.ts:183-192`).
+  - **Zero deltas total** across all files is an ERROR (`CHANGE_NO_DELTAS`) unless the change declares `skip_specs: true` in `.openspec.yaml` (see below).
+- **Main spec format** (`applySpecRules`, `validator.ts:641-720`): requires `## Purpose` and `## Requirements` sections (structural check via `findMainSpecStructureIssues`); Purpose too brief (<50 chars) or still a placeholder → WARNING; each requirement needs ≥1 scenario (WARNING if none) and SHALL/MUST in the body (WARNING if missing).
+- **`tasks.md` is NOT checked by ordinary `validate`** (direct, bulk, or strict) — it's out of scope for delta/spec validation entirely. It's only checked by the separate `--archived` mode, which lints already-archived changes' `tasks.md` for unchecked boxes (`src/commands/validate.ts:444-533`, `runArchivedTaskValidation`) — a distinct opt-in scope added in v1.9.0 per `CHANGELOG.md:65`, meant for a pre-commit/CI hook. It does not run under a bare `--strict` invocation.
+- **Unknown/extra files are tolerated.** `discoverSpecFiles` (`src/utils/spec-discovery.ts:38-76`) only walks for files literally named `spec.md`; anything else under `specs/` or elsewhere in the change directory (a `ledger.md`, an `evidence/` folder, etc.) is never inspected. The one exception: if `skip_specs: true` is declared in `.openspec.yaml`, `hasAnyFileUnder` (`spec-discovery.ts:93-115`) checks whether *any* non-dot file exists under `specs/` specifically, and flags a conflict if so (`CHANGE_SKIP_SPECS_CONFLICT`, `validator.ts:447-449`) — but files outside `specs/` are never touched by this check either. See Q4 for detail.
+
+## 2. Install / pin story
+
+- **Package name:** `@fission-ai/openspec` (npm scoped package; bin name `openspec` per `package.json` `bin.openspec: "bin/openspec.js"`, confirmed in npm registry dump).
+- **Current version (as of this local snapshot):** `1.11.0` (`dist-tags.latest`), also the newest `## 1.11.0` entry in `CHANGELOG.md`. `dist-tags` also show `next: 0.3.0` (stale/unused tag) and `beta: 1.6.0-beta.1`.
+- **Node requirement:** `"engines": {"node": ">=20.19.0"}` in every published version inspected (0.1.0 through 1.11.0, per npm registry dump) — this has been stable since the first release. **Node 20 is OK** as long as it's ≥20.19.0 specifically (not just "Node 20"); `docs/installation.md:5` states the same floor.
+- **npx vs global install:** the project's own docs (`docs/installation.md`) only document **global install** (`npm install -g @fission-ai/openspec@latest`, plus pnpm/yarn/bun/deno/Nix equivalents) and running `openspec` as a persistent CLI thereafter — there is no documented `npx openspec ...` invocation pattern in the local docs tree. `npx` would presumably work as a one-off since it's a normal npm package with a `bin`, but I found no evidence the maintainers document or recommend it. **Unconfirmed** whether npx is a supported/tested path.
+- **CI suitability/cost:** the CLI supports `--json` output on `validate`, `archive`, `status`, `schemas`, etc. (see below), non-interactive flags (`--yes`, `--no-interactive`, `CI`/`OPEN_SPEC_INTERACTIVE=0` env vars are recognized per `CHANGELOG.md:135`), and machine-readable diagnostics on failure. A **global install** is the documented pattern, meaning CI would run `npm install -g @fission-ai/openspec@<version>` (or pin via lockfile-adjacent tooling) as a setup step — there's no `npx`-style zero-install path documented. `docs/installation.md:173` recommends running `openspec update` after upgrading the global package, but that step is about regenerating AI-tool skill/command files, not relevant to a CI validation job.
+
+## 3. `openspec archive` behavior
+
+Source: `src/core/archive.ts` (class `ArchiveCommand`), ~2100 lines.
+
+- **Yes, it merges delta specs into `openspec/specs/` automatically** (unless `--skip-specs`). Flow (`ArchiveCommand.run`, `archive.ts:1108` onward):
+  1. Validates the change's proposal (informative only) and delta specs (blocking, unless `--no-validate`) — same `Validator` as standalone `validate`.
+  2. Reports task-completion status; incomplete tasks require `--yes` or an interactive confirmation to proceed (not archive-blocking on their own — just a warn-and-confirm gate, `archive.ts:1334-1371`).
+  3. Computes spec updates (`findSpecUpdates`), rebuilds each target main spec from ADDED/MODIFIED/REMOVED/RENAMED deltas (`buildUpdatedSpec`), previews the change, asks for confirmation (or `--yes`), then validates every rebuilt spec before writing any of them.
+  4. Writes the rebuilt main specs, or — if a change removes a capability's last requirement and `retire_capabilities: true` is declared in `.openspec.yaml` — deletes that capability's spec file entirely ("retirement", added v1.8.0 per `CHANGELOG.md:129`).
+  5. Moves the change directory from `openspec/changes/<name>/` to `openspec/changes/archive/<YYYY-MM-DD>-<name>/` (date-prefixed unless the name already carries a date prefix, `ARCHIVE_DATE_PREFIX_PATTERN`).
+  - The whole operation is built to be crash-safe/atomic-ish: content fingerprinting before/after each step, snapshot+rollback on failure, an exclusive `.openspec-archive.lock` claim file, and a fallback copy+verify+delete for cross-device/EPERM moves (`archive.ts:341-570` and surrounding).
+- **Lifecycle timing:** the source treats archive purely as a filesystem operation with **no git awareness at all** — no commit, branch, or PR check anywhere in `archive.ts`. Whether it's meant to run pre-merge or post-merge is a **workflow convention, not something the CLI enforces or checks**; docs (`getting-started.md`) show `/opsx:archive` running as the last step of the AI-driven loop (`propose → apply → sync → archive`) before that work is presumably committed/PR'd, but this is a usage convention documented in prose, not a mechanism. **Unconfirmed** whether upstream has an opinion on pre- vs post-merge beyond "archive after implementation is done."
+- **Flags on `archive`** (`ArchiveOptions` interface, `archive.ts:174-182`):
+  - `--yes` — skips interactive confirmations (spec-update preview, incomplete-tasks warning, skip-validation warning); required in `--json` mode wherever a prompt would otherwise appear (JSON mode never prompts — it throws a machine-readable `ArchiveBlockedError` instead, e.g. `archive_confirmation_required`, `archive_tasks_incomplete`).
+  - `--skip-specs` — skips the spec-merge step entirely (change is archived as-is, no `openspec/specs/` changes).
+  - `--no-validate` / `validate: false` — skips pre-archive validation (prints a warning, requires `--yes` in JSON mode).
+  - `--json` — machine-readable output (`{ archive: {...}, root }` on success, or `{ archive: null, status: [diagnostic] }` on failure) instead of prose/prompts.
+  - `--store` / `--store-path` — for the beta multi-repo "stores" feature (root selection), not spec-merge-specific.
+- Non-interactive/agent-safety was clearly a deliberate design theme (see the extensive comments around `ArchiveBlockedError` and `confirmOrBlock`, `archive.ts:208-324`): a run with no TTY that hits a would-be prompt fails loudly with a named flag to pass, rather than silently succeeding or hanging.
+
+## 4. Tolerance for extra files in a change directory
+
+**Yes — strict validation tolerates extra files.** `discoverSpecFiles` (`src/utils/spec-discovery.ts:38`) is the sole mechanism `validate`/`archive`/`show`/`apply` use to enumerate delta specs, and it only matches files literally named `spec.md` anywhere under `specs/`. A `ledger.md`, an `evidence/` folder, a `notes.md`, etc. — whether at the change root (alongside `proposal.md`/`tasks.md`) or inside `specs/` — is never read, parsed, or validated by `validate --strict`.
+
+The one narrow exception: if the change declares `skip_specs: true` in `.openspec.yaml` (meaning "this change intentionally has zero spec deltas"), `hasAnyFileUnder(specsDir)` (`spec-discovery.ts:93`) checks for *any* non-dot file under `specs/` specifically (not the change root) and raises `CHANGE_SKIP_SPECS_CONFLICT` if one exists — because such a file would be silently ignored by the merge, contradicting the "no spec changes" claim. This check is scoped to `specs/` only; files elsewhere in the change directory are unaffected even under `skip_specs`.
+
+## 5. What `openspec init` generates, and legacy-tree conflict
+
+**This is the biggest surprise relative to the question's premise: current OpenSpec (v1.0+, current 1.11.0) does *not* generate `project.md` or `openspec/AGENTS.md`.** Those were the *pre-1.0* ("legacy") artifacts, and v1.0's "OPSX" rewrite explicitly removed them as a **documented breaking change**:
+
+> "**Config files removed** — Tool-specific instruction files (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, `project.md`) are no longer generated" — `CHANGELOG.md:629` (1.0.0 "Major Changes").
+
+What `openspec init` (`src/core/init.ts`, class `InitCommand`) actually generates today, per-selected-tool:
+
+- `openspec/` directory tree: `specs/`, `changes/`, `changes/archive/` (`init.ts:858-893`, `createDirectoryStructure`).
+- `openspec/config.yaml` (optional, only if it doesn't already exist) — structured config with `schema:` and optional `context:`/`rules:` fields (`init.ts:1107-1133`, `createConfig`). This is the *replacement* for `project.md`'s freeform context — it's actively injected into every planning request rather than passively hoped to be read (`docs/migration-guide.md:67-80`).
+- Per selected AI tool: **Agent Skills** (`SKILL.md` files under e.g. `.claude/skills/openspec-*/`) and/or slash-command files (e.g. `.claude/commands/opsx-*.md` depending on tool/delivery mode) — never a monolithic instruction file (`init.ts:899-1041`, `generateSkillsAndCommands`).
+- Optionally, GitHub Copilot cloud-agent files (`.github/workflows/copilot-setup-steps.yml`, `.github/agents/openspec.agent.md`) — opt-in only, since v1.8.0 (`CHANGELOG.md:123`).
+
+**Legacy-tree conflict:** running `openspec init`/`openspec update` on a repo with a hand-scaffolded (or pre-1.0-generated) tree containing `project.md`, `AGENTS.md`, `specs/`, `changes/archive/` is explicitly handled, not a silent conflict:
+- `specs/` and `changes/archive/` — untouched (they're the same structure today; `docs/migration-guide.md:27-29`).
+- `openspec/AGENTS.md` — auto-deleted (obsolete workflow trigger file), listed under "no user content to preserve" (`src/core/legacy-cleanup.ts:436-608`, `docs/migration-guide.md:39,136`).
+- Root-level `CLAUDE.md`/`AGENTS.md`/etc. (`LEGACY_CONFIG_FILES`, `legacy-cleanup.ts:19-26`, includes `CLAUDE.md`, `CLINE.md`, `AGENTS.md`, `QWEN.md`, etc.) — only the OpenSpec marker block inside them is stripped; the rest of the user's file content is preserved, never deleted.
+- **`openspec/project.md` is the one file the tool deliberately does NOT touch automatically** — it's flagged in the migration prompt ("Needs your attention... We won't delete this file... Review project.md, move any useful content to config.yaml, then delete the file when ready") and left for the user to migrate by hand into `config.yaml`'s `context:`/`rules:` (`docs/migration-guide.md:57-80, 544-546`, `legacy-cleanup.ts:419` docblock references detecting it as a legacy artifact).
+- In non-interactive/CI mode, `openspec init --force` auto-accepts all of the above cleanup except `project.md` deletion, which remains manual regardless (`docs/migration-guide.md:150-160`).
+
+**Is there an `openspec update`?** Yes — confirmed in both docs and changelog. `openspec update` "regenerates the skill and command files for the tools you've configured" (`docs/installation.md:173`), runs the same legacy-detection/cleanup pass as `init` (`docs/migration-guide.md:140-148`), never prompts for destructive choices on its own (e.g. Copilot cloud files are only refreshed if previously opted in, `CHANGELOG.md:125`), and checks whether a newer CLI version is published, offering to upgrade.
+
+---
+
+## Other load-bearing findings
+
+- **JSON output for CI:** widespread and treated as a first-class contract, not an afterthought. `validate`, `archive`, `status` (including new `--all --json` for one-process-many-changes as of 1.11.0, `CHANGELOG.md:7`), `schemas`, and `show` all support `--json`, with structured `{ ..., status: [{severity, code, message, fix}] }` diagnostics on failure rather than free-text stderr (see `ArchiveBlockedError`/`ArchiveDiagnostic` pattern, `archive.ts:184-220`). JSON mode is explicitly designed to never prompt interactively — it fails closed with a machine-actionable diagnostic instead (a repeatedly-cited design goal across changelog entries, e.g. `CHANGELOG.md:135` re: `#1479`).
+- **`openspec show --diff`** (new in 1.11.0, `CHANGELOG.md:9`): renders each MODIFIED delta requirement as a diff against the main-spec version it replaces (colorized unified diff in human mode; `diff`/`warning` fields added to the JSON payload for MODIFIED deltas only).
+- **Config file:** `openspec/config.yaml`, with `schema:` (required, default `spec-driven`), optional `context:` (≤50KB, injected into every planning request) and per-artifact `rules:`. Schema resolution order: `--schema` CLI flag → change's `.openspec.yaml` → project `config.yaml` → default `spec-driven` (`docs/migration-guide.md:475-481`).
+- **Breaking-change history:** the only major (semver-breaking) release in the visible history is **1.0.0** ("OPSX" rewrite — old `/openspec:*` commands removed, `CLAUDE.md`/`.cursorrules`/`AGENTS.md`/`project.md` generation removed, skills replace scattered per-tool config files). Everything from 1.0.0 through 1.11.0 in the local `CHANGELOG.md` is Minor/Patch only — no further major bumps found.
+- **`.openspec.yaml`** (change-level metadata file, distinct from `openspec/config.yaml`) carries `schema:` plus optional markers: `skip_specs: true` (declares zero spec deltas intentionally) and `retire_capabilities: true` (authorizes archive to delete a capability's spec when its last requirement is removed). Both markers are only honored when the metadata file is itself schema-valid; an invalid marker is treated as *not declared* rather than silently accepted (`validator.ts:109-124`, `archive.ts:1390-1394`).
+
+## Unconfirmed (flagged, not answered from primary source)
+
+- Whether `npx @fission-ai/openspec ...` (as opposed to a global install) is a supported/tested invocation path — not documented in the local `docs/installation.md`.
+- Whether upstream has an explicit stance on archiving pre- vs post-merge — the CLI has no git integration at all, so this is purely a workflow convention in the docs, not a mechanism I can confirm as intentional policy either way.
+- Anything published to the live npm registry or GitHub repo *after* this local snapshot (v1.11.0 / npm dump timestamp) — this could not be checked since network access was unavailable this session.

--- a/docs/scope/openspec-cli-adoption.md
+++ b/docs/scope/openspec-cli-adoption.md
@@ -1,0 +1,60 @@
+# Scope: openspec CLI adoption
+
+Adopt the `openspec` CLI in the skills repo so agents validate OpenSpec structure
+against deterministic checks (`openspec validate --strict`, `list`, `archive`)
+instead of following prose conventions. Slots into the broader
+vanilla-OpenSpec standardization effort (spec deltas + baseline backfill,
+post-merge archiving, ADRs in change `design.md`, vanilla epics).
+
+## Decisions
+
+- Route: research — the dominant uncertainty is missing facts about the CLI
+  itself (what strict validation enforces, install/pinning model, whether the
+  repo's current and planned layouts pass, how `archive` composes with
+  post-merge archiving). Why: nothing is buildable until the tool's real
+  contract is known; team has no prior CLI practice to copy. `inline`
+- Standardization decisions already settled upstream of this scope (from the
+  audit session, 2026-08-28): adopt spec deltas + backfill baseline; post-merge
+  archiving; ADRs move into change `design.md` (charter edit, `docs/adr/`
+  frozen as legacy); epics go vanilla (`tasks.md` with tracker-issue links,
+  drop `ledger.md`). Why: operator chose upstream-standard practice over
+  pack-invented conventions. `→ issue` (the standardization epic)
+- Pack constraint: the CLI must not become a pack dependency — pack installs
+  from stock Python 3 + Node 20. CLI is dev/CI tooling for this repo (and
+  optionally the operator's machine), not shipped with the pack. Why:
+  CLAUDE.md portability hazard. `inline`
+
+- Research findings recorded in `docs/research/openspec-cli.md`
+  (primary-source: upstream clone at v1.11.0 + npm registry metadata;
+  citations spot-verified). Key facts: package `@fission-ai/openspec` 1.11.0,
+  Node ≥20.19.0, global install is the documented path (npx unconfirmed);
+  `validate --strict` gates warnings, requires ≥1 scenario per ADDED/MODIFIED
+  delta requirement, never checks `tasks.md`, tolerates extra files
+  (`ledger.md`, evidence); `archive` merges deltas into `specs/`
+  automatically, is git-unaware (pre/post-merge is pure convention), and has
+  first-class `--json`/`--yes` CI modes. Why: answers all five open
+  questions. `inline`
+- Our hand-scaffolded `openspec/AGENTS.md` + `project.md` layout is upstream's
+  **pre-1.0 legacy shape**: v1.0 (OPSX) removed generation of both;
+  `openspec init` now writes `openspec/config.yaml` plus per-tool agent
+  skills/commands, and its migration pass auto-deletes `openspec/AGENTS.md`
+  while leaving `project.md` for manual migration into `config.yaml`. CLI
+  adoption therefore implies migrating our tree to the v1.x shape, and
+  `openspec-adopt` must scaffold via `openspec init`, not by hand. Why:
+  adopting the CLI against a legacy-shaped tree fights the tool's own
+  cleanup. `→ issue` (standardization epic)
+
+## Open questions
+
+- None remaining from this scope. (npx support and pre/post-merge stance are
+  upstream-unconfirmed; both have safe defaults — global install, and the
+  post-merge convention already decided.)
+
+## Spawned tasks
+
+- `docs/research/openspec-cli.md` — findings doc (this session).
+- GitHub issue #217 — orchestrate adapters lack worker network access;
+  research worker had to be resumed against coordinator-fetched sources.
+- GitHub issue #218 — vanilla-OpenSpec standardization epic (all four settled
+  decisions + CLI adoption + legacy-shape migration). Discharges both
+  `→ issue` dispositions above.

--- a/openspec/changes/218-vanilla-openspec/design.md
+++ b/openspec/changes/218-vanilla-openspec/design.md
@@ -1,0 +1,104 @@
+# Design
+
+This change replaces local OpenSpec conventions with the v1.x CLI workflow.
+The tree migration precedes convention edits: `openspec init` deletes
+`openspec/AGENTS.md`, the file the former conventions would otherwise edit.
+It does not wait on tool selection. The baseline backfill is independent
+because init leaves `openspec/specs/` untouched, so it may proceed in parallel.
+
+## ADR 218 — Change-local deltas become the path to the baseline
+
+Adopt `changes/<id>/specs/<capability>/spec.md` delta specs and merge them into
+`openspec/specs/` on archive. Backfill all three current baseline specs, both
+to reflect their lagging behavior and to replace their `## Behavior` shape with
+the CLI-required `## Purpose` and `## Requirements` structure, including
+scenario-bearing requirements.
+
+### Consequences
+
+The baseline becomes the current behavioral source of truth and a qualifying
+behavior change has a reviewable delta. The CLI rejects malformed main specs
+and requires scenarios for added or modified delta requirements; the existing
+baseline cannot pass that contract until the reformat lands.
+
+### Open question — Capability discovery at scale
+
+OpenSpec has no manifest, YAML frontmatter, or cross-linked concept index for
+baseline specs: discovery is by capability directory under
+`openspec/specs/<capability>/`, plus `openspec list`, `openspec show --diff`,
+and the generated `openspec-explore` skill. Upstream uses 35 capability specs
+for one CLI while this repository starts with three. How an agent reliably
+finds the right capability as that count grows remains unresolved; it bears on
+vanilla epics that span many capabilities, but does not block this adoption.
+
+## ADR 218 — Archive after merge
+
+Archive a completed change after its pull request merges, replacing the
+in-PR archival rule in the legacy OpenSpec instructions and the `openspec-adopt`
+and `epic` skills. The CLI is Git-unaware; timing is therefore this repository's
+workflow decision, while `openspec archive --json --yes` performs the validated
+delta merge and move.
+
+### Consequences
+
+Shared specs advance only for merged work. Until this change specifies an
+automation or other enforcement mechanism, a human must remember to archive;
+the archive command does not establish that responsibility itself.
+
+## ADR 218 — Design files carry new ADRs
+
+Record new load-bearing decisions in each OpenSpec change's `design.md` under
+`## ADR <issue> — Title`. `docs/adr/` is frozen as legacy history: its existing
+records, names, and links remain, but no new records land there.
+
+The repository charter already states this OpenSpec ADR-home rule. Only
+`openspec/AGENTS.md` contradicts it by directing ADRs to `docs/adr/`; the
+charter does not require an edit for this decision.
+
+## ADR 218 — Epics use vanilla change task lists
+
+Model an epic as one OpenSpec change whose `tasks.md` entries link the tracker
+child issues. Remove the `ledger.md` convention from the `epic` skill rather
+than preserving a parallel epic state artifact.
+
+Issue #218 applies this decision to itself as the first epic run this way. It
+uses `tasks.md` as its child index and deliberately has neither `ledger.md` nor
+a standing planning pull request, so the decision is exercised before it ships
+in the `epic` skill.
+
+### Consequences
+
+An epic retains tracker-native child ownership while OpenSpec retains the
+single checked-in implementation checklist and change history.
+
+## ADR 218 — The OpenSpec CLI is repository tooling, not pack runtime
+
+Use `@fission-ai/openspec` 1.11.0, which requires Node >=20.19.0, as pinned
+development and CI tooling for this repository. Use its deterministic strict
+validation and non-interactive JSON archive command; do not add it as a pack
+dependency.
+
+### Consequences
+
+The pack continues to install and run on stock Python 3 and Node 20 with no
+package-manager step. The documented CLI installation path is global install;
+whether npx is supported remains unconfirmed and is not assumed here.
+
+## ADR 218 — Migrate the OpenSpec tree through v1.x initialization
+
+Replace the pre-1.0 legacy `openspec/AGENTS.md` and `project.md` practice with
+the v1.x tree produced by `openspec init`: `openspec/config.yaml` plus the
+tool-generated skills `openspec-apply-change`, `openspec-archive-change`,
+`openspec-bulk-archive-change`, `openspec-continue-change`,
+`openspec-explore`, `openspec-ff-change`, `openspec-new-change`,
+`openspec-onboard`, `openspec-propose`, `openspec-sync-specs`,
+`openspec-update-change`, and `openspec-verify-change`. Migrate useful
+`project.md` context manually into `config.yaml`; init removes
+`openspec/AGENTS.md` but leaves `project.md` for that manual migration.
+
+### Consequences
+
+Select a tool, or select none, during migration. A selected tool's generated
+skills are untracked, per-machine artifacts under the ignored tool directory;
+contributors regenerate them with `openspec update`. They are not vendored
+pack skills and do not conflict with the pinned-copy hazard.

--- a/openspec/changes/218-vanilla-openspec/proposal.md
+++ b/openspec/changes/218-vanilla-openspec/proposal.md
@@ -1,0 +1,24 @@
+# Vanilla OpenSpec
+
+## Why
+
+The pack's hand-made OpenSpec conventions let behavior changes bypass
+change-local requirements and leave the baseline stale. They also diverge from
+the current CLI's v1.x tree and lifecycle.
+
+## What changes
+
+- Adopt upstream change-local spec deltas and archive them into the baseline.
+- Backfill and reformat the three baseline specs into the CLI-enforced shape.
+- Migrate the legacy OpenSpec tree, use the pinned CLI as dev/CI tooling, and
+  align the OpenSpec-related skills with vanilla changes, ADRs, and epics.
+- Archive completed changes after merge; freeze `docs/adr/` as legacy history.
+
+## Risk contract
+
+Strict CLI validation makes malformed baseline and delta requirements, including
+missing scenarios, mechanically visible; archive merges validated deltas rather
+than relying on a prose-only baseline convention. The CLI remains repository
+dev/CI tooling, not a pack dependency, so the pack's stock Python 3 and Node
+20 portability contract remains intact. Post-merge archiving still depends on
+a human running it until this change specifies a mechanism.

--- a/openspec/changes/218-vanilla-openspec/tasks.md
+++ b/openspec/changes/218-vanilla-openspec/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## Independent baseline work
+
+- [ ] [#TBD](#TBD) Reformat and backfill the three baseline specs into the
+  CLI-enforced shape, correcting them against current source. This is
+  independent because `openspec init` leaves `openspec/specs/` untouched.
+
+## v1.x migration
+
+- [ ] [#TBD](#TBD) Migrate the OpenSpec tree through `openspec init`, move
+  useful `project.md` content to `config.yaml`, choose whether to select a
+  tool, and remove `project.md` manually. This has no dependency; it also
+  resolves the charter ADR-home contradiction because init deletes the legacy
+  `openspec/AGENTS.md` that contains it.
+
+- [ ] [#TBD](#TBD) Adopt the CLI as development and CI tooling, including a
+  strict-validation gate in `.github/workflows/validate.yml`. This depends on
+  the v1.x tree migration.
+
+- [ ] [#TBD](#TBD) Rework `openspec-adopt` to scaffold through `openspec init`
+  rather than by hand. This depends on the v1.x tree migration.
+
+- [ ] [#TBD](#TBD) Update `openspec-adopt`, `epic`, `ticket`, and the v1.x
+  replacement for the legacy OpenSpec instructions for post-merge archiving.
+  This depends on the v1.x tree migration.
+
+- [ ] [#TBD](#TBD) Drop `ledger.md` from the `epic` skill and use the vanilla
+  tracker-linked `tasks.md` shape. This depends on the v1.x tree migration.


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## What this is

The planning documents for epic #218: the decision to stop maintaining hand-made
OpenSpec conventions and follow upstream OpenSpec instead. Documents only, with
no skill, script, or spec behavior changes in this PR.

## Why now

Three of our conventions have quietly drifted from what OpenSpec actually does.
We archive a change inside the PR that finishes it, while upstream archives
after merge. We send new decision records to `docs/adr/`, while upstream keeps
them with the change that made the decision. We run epics on a hand-rolled
ledger file, while upstream just uses a task list. Each divergence is small, but
together they mean a behavior change can land without anything recording what
behavior changed, which is the one thing spec tracking exists to prevent.

Separately, the tree we scaffolded by hand turns out to be the shape OpenSpec
used before its 1.0 rewrite. Their current tooling actively deletes part of it
on sight. Staying put means fighting the tool every time we touch it.

## What the two documents say

`proposal.md` names the destination: adopt upstream's change-local spec deltas,
migrate the tree to the current shape, use the `openspec` command-line tool for
validation instead of trusting prose conventions, and bring the three existing
baseline specs up to date.

`design.md` records six decisions with their consequences, plus two questions we
deliberately left open.

## What to check

The decisions themselves are already settled. They were made in the session that
filed #218, and this PR only writes them down. Worth your attention instead:

- **The tool stays out of the pack.** It is repository tooling for us, never a
  dependency of the pack itself, which still has to install from stock Python
  and Node with no package step. That constraint is what makes the pack
  portable, and the risk contract says so explicitly.
- **One decision has a soft edge.** Archiving after merge depends on a human
  remembering to do it. The design admits this rather than papering over it,
  and no mechanism is specified yet. If that bothers you, say so now.
- **Two open questions are recorded, not answered.** Whether to let the tool
  generate its helper skills for a chosen editor, and how an agent finds the
  right capability once there are dozens of them rather than three. Upstream
  runs 35 for a single tool, and we start with 3.

Every factual claim about the tool traces to `docs/research/openspec-cli.md`,
also included here, which was read from the upstream source at version 1.11.0.
Two things it could not confirm, whether `npx` works and whether upstream has a
view on archive timing, are carried forward as unconfirmed rather than resolved.

## What happens after this merges

The epic's child issues get filed against these documents. Nothing in the
repository changes behavior until those land.

This closes nothing. #218 stays open as the epic.
