### PR TITLE
docs(epic): link filed child issues in the 218 task index

### DIFF
--- a/openspec/changes/218-vanilla-openspec/tasks.md
+++ b/openspec/changes/218-vanilla-openspec/tasks.md
@@ -2,17 +2,19 @@
 
 ## Independent baseline work
 
-- [ ] [#TBD](#TBD) Reformat and backfill the three baseline specs into the
-  CLI-enforced shape, correcting them against current source. This is
-  independent because `openspec init` leaves `openspec/specs/` untouched.
+- [ ] [#221](https://github.com/ConnorGriffin/skills/issues/221) Reformat and
+  backfill the three baseline specs into the CLI-enforced shape, correcting
+  them against current source. This is independent because `openspec init`
+  leaves `openspec/specs/` untouched.
 
 ## v1.x migration
 
-- [ ] [#TBD](#TBD) Migrate the OpenSpec tree through `openspec init`, move
-  useful `project.md` content to `config.yaml`, choose whether to select a
-  tool, and remove `project.md` manually. This has no dependency; it also
-  resolves the charter ADR-home contradiction because init deletes the legacy
-  `openspec/AGENTS.md` that contains it.
+- [ ] [#222](https://github.com/ConnorGriffin/skills/issues/222) Migrate the
+  OpenSpec tree through `openspec init`, move useful `project.md` content to
+  `config.yaml`, choose whether to select a tool, and remove `project.md`
+  manually. This has no dependency; it also resolves the charter ADR-home
+  contradiction because init deletes the legacy `openspec/AGENTS.md` that
+  contains it.
 
 - [ ] [#TBD](#TBD) Adopt the CLI as development and CI tooling, including a
   strict-validation gate in `.github/workflows/validate.yml`. This depends on


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## What this is

A two-line bookkeeping update to the task index for epic #218. The first two
child issues are now filed, so their placeholder links become real ones.

## What changed

`openspec/changes/218-vanilla-openspec/tasks.md` gained links to #221 (reformat
and backfill the three baseline specs) and #222 (migrate the OpenSpec tree to
the current shape). The other five items still read `#TBD` because they all wait
on the tree migration and are not filed yet.

The two edited bullets were rewrapped to match the file's existing line width.
No wording changed.

## What to check

Nothing substantive. If you want a spot check: the two linked issues should be
children of #218 and carry the `build` label, and the five remaining items
should still be unfiled.
