### PR TITLE
docs(epic): rule that the 218 migration selects no OpenSpec tools

### DIFF
--- a/openspec/changes/218-vanilla-openspec/design.md
+++ b/openspec/changes/218-vanilla-openspec/design.md
@@ -87,18 +87,30 @@ whether npx is supported remains unconfirmed and is not assumed here.
 ## ADR 218 — Migrate the OpenSpec tree through v1.x initialization
 
 Replace the pre-1.0 legacy `openspec/AGENTS.md` and `project.md` practice with
-the v1.x tree produced by `openspec init`: `openspec/config.yaml` plus the
-tool-generated skills `openspec-apply-change`, `openspec-archive-change`,
-`openspec-bulk-archive-change`, `openspec-continue-change`,
-`openspec-explore`, `openspec-ff-change`, `openspec-new-change`,
-`openspec-onboard`, `openspec-propose`, `openspec-sync-specs`,
-`openspec-update-change`, and `openspec-verify-change`. Migrate useful
-`project.md` context manually into `config.yaml`; init removes
-`openspec/AGENTS.md` but leaves `project.md` for that manual migration.
+the v1.x tree produced by `openspec init`, whose core artifact is
+`openspec/config.yaml`. Init can also generate twelve per-tool agent skills
+(`openspec-propose`, `openspec-apply-change`, `openspec-archive-change`,
+`openspec-explore`, and the rest of that set); this repository declines them,
+for the reason recorded below. Migrate useful `project.md` context manually
+into `config.yaml`; init removes `openspec/AGENTS.md` but leaves `project.md`
+for that manual migration.
+
+The migration runs `openspec init --tools none`. The CLI is adopted for its
+deterministic checks, `validate --strict` and `archive`, not for its agent
+workflow. Generating the twelve skills would install a second planning
+lifecycle (`/opsx:propose`, `apply`, `archive`) that duplicates what the pack's
+own `ticket` and `epic` drivers already do against the same repository, and a
+duplicated lifecycle is a maintenance liability rather than a convenience.
 
 ### Consequences
 
-Select a tool, or select none, during migration. A selected tool's generated
-skills are untracked, per-machine artifacts under the ignored tool directory;
-contributors regenerate them with `openspec update`. They are not vendored
-pack skills and do not conflict with the pinned-copy hazard.
+`openspec/config.yaml` is the only artifact the migration adds. No `.claude/`,
+`.codex/`, or root `AGENTS.md` content is generated, so no tracked file gains a
+tool marker block and no per-machine artifact needs ignoring. `.claude/` and
+`.agents/` are already ignored, but `.codex/` is not, so selecting a tool later
+would require a `.gitignore` change first.
+
+Agents continue to learn this repository's OpenSpec practice from its own
+instructions and from `config.yaml`'s `context:` and `rules:` fields, which the
+CLI injects into every planning request. Adopting the generated skills later
+remains available and reversible; it is a `--tools` value, not a migration.


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## What this is

Records one decision for epic #218: when the OpenSpec tree is migrated, it will
be set up with no editor integrations generated. Documentation only.

## Why it needed deciding

The setup command can optionally generate twelve helper skills for whichever
editors you name, giving you a `/opsx:` command set for proposing, applying, and
archiving work. The design left that choice open because it looked like a
convenience question.

It is not. Those twelve skills are a second planning lifecycle, pointed at the
same repository your own `ticket` and `epic` drivers already drive. Running both
means two sets of instructions describing how work gets proposed and archived
here, drifting apart on their own schedule.

So the tool is adopted for the part that pays: its deterministic validation and
archiving. Not for its workflow.

## What changed

`openspec/changes/218-vanilla-openspec/design.md` only. The migration decision
now states that no editor integrations are generated and says why, and its
opening no longer promises the twelve skills as part of what the migration
produces.

The consequences section also notes something asymmetric worth knowing: the
directories two of your agents would write into are already ignored by git, but
the third is not. Selecting an editor later would need a `.gitignore` change
first, or it would start committing per-machine files.

## What to check

That the reasoning matches your intent. The decision is reversible, which the
record says explicitly: turning integrations on later is a flag on one command,
not a migration.

This unblocks #222, which could not be triaged while the choice was open.
