### PR TITLE
docs(epic): close out the 218 first wave and file the second

### DIFF
--- a/openspec/changes/218-vanilla-openspec/tasks.md
+++ b/openspec/changes/218-vanilla-openspec/tasks.md
@@ -2,30 +2,34 @@
 
 ## Independent baseline work
 
-- [ ] [#221](https://github.com/ConnorGriffin/skills/issues/221) Reformat and
-  backfill the three baseline specs into the CLI-enforced shape, correcting
-  them against current source. This is independent because `openspec init`
-  leaves `openspec/specs/` untouched.
+- [x] [#221](https://github.com/ConnorGriffin/skills/issues/221) Reformat and
+  backfill the three baseline specs into the
+  CLI-enforced shape, correcting them against current source. Landed in #227;
+  `openspec validate --specs --strict` now reports 3 passed, 0 failed.
 
 ## v1.x migration
 
-- [ ] [#222](https://github.com/ConnorGriffin/skills/issues/222) Migrate the
-  OpenSpec tree through `openspec init`, move useful `project.md` content to
-  `config.yaml`, choose whether to select a tool, and remove `project.md`
-  manually. This has no dependency; it also resolves the charter ADR-home
-  contradiction because init deletes the legacy `openspec/AGENTS.md` that
-  contains it.
+- [x] [#222](https://github.com/ConnorGriffin/skills/issues/222) Migrate the
+  OpenSpec tree through `openspec init --tools
+  none`, move useful `project.md` content to `config.yaml`, and remove the
+  legacy files. Landed in #226. This also discharged the charter ADR-home
+  contradiction, which lived in the deleted `openspec/AGENTS.md`.
 
-- [ ] [#TBD](#TBD) Adopt the CLI as development and CI tooling, including a
-  strict-validation gate in `.github/workflows/validate.yml`. This depends on
-  the v1.x tree migration.
+- [ ] [#228](https://github.com/ConnorGriffin/skills/issues/228) Adopt the CLI
+  as development and CI tooling, including a
+  strict-validation gate in `.github/workflows/validate.yml`. Unblocked.
 
-- [ ] [#TBD](#TBD) Rework `openspec-adopt` to scaffold through `openspec init`
-  rather than by hand. This depends on the v1.x tree migration.
+- [ ] [#229](https://github.com/ConnorGriffin/skills/issues/229) Rework
+  `openspec-adopt` to scaffold through `openspec
+  init` rather than by hand. Unblocked. Shares
+  `skills/drivers/openspec-adopt/` with #230; sequence them.
 
-- [ ] [#TBD](#TBD) Update `openspec-adopt`, `epic`, `ticket`, and the v1.x
-  replacement for the legacy OpenSpec instructions for post-merge archiving.
-  This depends on the v1.x tree migration.
+- [ ] [#231](https://github.com/ConnorGriffin/skills/issues/231) Drop
+  `ledger.md` from the `epic` skill and use the vanilla
+  tracker-linked `tasks.md` shape. Unblocked. #218 already runs this way, so it
+  is the worked example.
 
-- [ ] [#TBD](#TBD) Drop `ledger.md` from the `epic` skill and use the vanilla
-  tracker-linked `tasks.md` shape. This depends on the v1.x tree migration.
+- [ ] [#230](https://github.com/ConnorGriffin/skills/issues/230) Switch the
+  pack to post-merge OpenSpec archiving across
+  `epic`, `ticket`, and `openspec-adopt`. Blocked by #231, which removes the
+  standing planning pull request the current archiving rule depends on.


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## What this is

Bookkeeping for epic #218 after its first two pieces of work landed. Updates the
task index only; no behavior changes.

## What finished

The two builds that shipped in #226 and #227 are marked done, each with what it
actually produced rather than just a checkmark.

Worth recording: the baseline specs now pass the tool's strict validation, three
of three, where all three failed before. And the tree migration quietly settled a
loose end it was not aimed at. The rule that sent decision records to the old
`docs/adr/` folder, which contradicted the charter, lived in the file the
migration deleted. That contradiction is gone as a side effect.

## What is now filed

Four remaining pieces of work, all of which were waiting on the tree migration
and are now unblocked:

- #228 makes spec correctness a CI check rather than something we hope holds.
- #229 stops `openspec-adopt` from building the outdated layout into every repo
  it touches.
- #231 removes the hand-rolled epic bookkeeping in favour of the standard shape.
  This epic already runs the standard way, so it is its own worked example.
- #230 switches archiving to happen after merge rather than inside the finishing
  pull request.

Only one real ordering constraint exists, and it is recorded on the issues
themselves: #230 waits on #231, because the archiving rule it rewrites depends
on the planning pull request that #231 removes. The others can go in any order,
though two pairs touch the same skill directories and should not run
simultaneously.

## What to check

That the four new issues are the right remaining work and nothing is missing.
The task list is the epic's only index now, so a gap here is a gap in the epic.
