### PR TITLE
docs(epic): consolidate the remaining 218 work into one ticket

### DIFF
--- a/openspec/changes/218-vanilla-openspec/tasks.md
+++ b/openspec/changes/218-vanilla-openspec/tasks.md
@@ -1,35 +1,24 @@
 # Tasks
 
-## Independent baseline work
-
 - [x] [#221](https://github.com/ConnorGriffin/skills/issues/221) Reformat and
-  backfill the three baseline specs into the
-  CLI-enforced shape, correcting them against current source. Landed in #227;
-  `openspec validate --specs --strict` now reports 3 passed, 0 failed.
-
-## v1.x migration
+  backfill the three baseline specs into the CLI-enforced shape, correcting
+  them against current source. Landed in #227; `openspec validate --specs
+  --strict` now reports 3 passed, 0 failed.
 
 - [x] [#222](https://github.com/ConnorGriffin/skills/issues/222) Migrate the
-  OpenSpec tree through `openspec init --tools
-  none`, move useful `project.md` content to `config.yaml`, and remove the
-  legacy files. Landed in #226. This also discharged the charter ADR-home
-  contradiction, which lived in the deleted `openspec/AGENTS.md`.
+  OpenSpec tree through `openspec init --tools none`, move useful `project.md`
+  content into `config.yaml`, and remove the legacy files. Landed in #226. This
+  also discharged the charter ADR-home contradiction, which lived in the
+  deleted `openspec/AGENTS.md`.
 
-- [ ] [#228](https://github.com/ConnorGriffin/skills/issues/228) Adopt the CLI
-  as development and CI tooling, including a
-  strict-validation gate in `.github/workflows/validate.yml`. Unblocked.
+- [ ] [#228](https://github.com/ConnorGriffin/skills/issues/228) Finish the
+  adoption in one pass: the deterministic CI gate, `openspec-adopt` scaffolding
+  through `openspec init`, post-merge archiving across `epic`, `ticket`, and
+  `openspec-adopt`, and dropping `ledger.md` from the `epic` skill. Chunked at
+  triage if it needs slicing.
 
-- [ ] [#229](https://github.com/ConnorGriffin/skills/issues/229) Rework
-  `openspec-adopt` to scaffold through `openspec
-  init` rather than by hand. Unblocked. Shares
-  `skills/drivers/openspec-adopt/` with #230; sequence them.
-
-- [ ] [#231](https://github.com/ConnorGriffin/skills/issues/231) Drop
-  `ledger.md` from the `epic` skill and use the vanilla
-  tracker-linked `tasks.md` shape. Unblocked. #218 already runs this way, so it
-  is the worked example.
-
-- [ ] [#230](https://github.com/ConnorGriffin/skills/issues/230) Switch the
-  pack to post-merge OpenSpec archiving across
-  `epic`, `ticket`, and `openspec-adopt`. Blocked by #231, which removes the
-  standing planning pull request the current archiving rule depends on.
+Filed separately and superseded by #228: #229, #230, and #231, each closed as
+not planned. They split the same work by decision number, which forced three
+issues to edit overlapping skill files and serialize against each other. Work
+too large for one context is sliced into sub-orders inside one work order, not
+into separate issues.


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## What this is

Collapses the remaining work on #218 from four open issues into one. Task index
only; no behavior changes.

## Why

The four issues were a bad split, and the symptom was visible on their own
faces: three of them carried notes saying they shared a skill directory with a
sibling and should not run at the same time. Work that has to be serialized
because it edits the same files is one piece of work, not three.

The cause was slicing by decision number, because that is how the epic numbered
its decisions, rather than by which files and behavior each piece owns. The
repo's own slicing rules say the opposite, and say that work too large for one
context becomes sub-orders inside a single work order rather than separate
issues.

## What changed

#228 now carries the whole remaining scope: the CI validation gate, reworking
the adoption skill to scaffold with the tool instead of by hand, moving
archiving to after merge, and removing the hand-rolled epic bookkeeping. Its
content is the four issues' content, unchanged in substance.

#229, #230, and #231 are closed as not planned, each with the reason on the
issue and a pointer to #228.

The task index now reads as two finished items and one open one, with a closing
note recording the consolidation so the decision is legible later.

## What to check

That #228 still covers everything the three closed issues asked for. If
something got dropped in the merge, it is dropped for good, since those issues
are closed.
