### PR TITLE
docs(openspec): settle archive and fog homes

### DIFF
--- a/openspec/changes/218-vanilla-openspec/design.md
+++ b/openspec/changes/218-vanilla-openspec/design.md
@@ -45,6 +45,15 @@ Shared specs advance only for merged work. Until this change specifies an
 automation or other enforcement mechanism, a human must remember to archive;
 the archive command does not establish that responsibility itself.
 
+State that repository convention once, as `openspec/config.yaml` advisory
+guidance under `operations.archive`. OpenSpec defines that field for
+operation-specific repository guidance, while its team workflow recommends
+post-merge archive but deliberately leaves Git timing unenforced. Skills may
+tell an adopter to configure the operation; they do not retain parallel copies
+of this repository's timing rule. The convention remains human-enforced: no
+hook, workflow, or agent guard pretends that the Git-unaware CLI can prove the
+merge boundary.
+
 ## ADR 218 — Design files carry new ADRs
 
 Record new load-bearing decisions in each OpenSpec change's `design.md` under
@@ -70,6 +79,18 @@ in the `epic` skill.
 
 An epic retains tracker-native child ownership while OpenSpec retains the
 single checked-in implementation checklist and change history.
+
+The useful ledger concerns move to their vanilla authorities instead of into a
+replacement index. Unsettled questions live under `Open Questions` in the
+epic's `design.md`; task drafting resolves any question that could change the
+build, and a precise investigation becomes a tracker spike when it needs
+independent work. Durable decisions remain in `design.md`; child type, status,
+dependencies, and deferral remain in the tracker; the checked implementation
+sequence and child links remain in `tasks.md`; session cost remains ticket
+telemetry. The ledger's derived status line, pointer-only notes, duplicated
+child summaries, and round narrative are dropped because those facts already
+have authoritative homes. This is the deliberate replacement for `Fog`, not a
+new ledger under another name.
 
 ## ADR 218 — The OpenSpec CLI is repository tooling, not pack runtime
 


### PR DESCRIPTION
> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

## What this is

Epic #218 now records the OpenSpec-standard homes for post-merge archive guidance
and unresolved epic questions. The design previously chose post-merge archive and
ledger removal without saying where those two concerns would live.

## What changed

* Repository archive timing lives once in `openspec/config.yaml` under
  `operations.archive`, the upstream field for operation-specific guidance. The
  design explicitly keeps that convention human-enforced because OpenSpec does
  not inspect Git state.
* Unsettled epic questions live in the change design until resolved. Questions
  that can change the build block task drafting, and precise investigations
  become tracker spikes when they need independent work.
* The remaining useful ledger concerns keep their existing authorities: durable
  decisions in the design, child state and dependencies in the tracker,
  implementation order and child links in tasks, and session cost in ticket
  telemetry. Derived duplicates are dropped rather than renamed.

The upstream grounding and complete disposition live in the parent OpenSpec
change for epic #218.

## What to check

* Structural validation accepts 27 skills and 358 files.
* OpenSpec 1.11.0 strict validation passes all three baseline specs. The all-items
  command also exposes two pre-existing active changes with no delta specs; #228
  owns repairing or explicitly classifying those changes before adding that CI
  gate.
