### PR TITLE
Quiet unchanged coordinator waits

### DIFF
--- a/docs/scope/235-coordinator-poll-narration.md
+++ b/docs/scope/235-coordinator-poll-narration.md
@@ -1,0 +1,71 @@
+# Scope ledger: coordinator poll narration
+
+## Decisions
+
+- Treat elapsed time and re-polled unchanged state as no news, including after
+  three unchanged wait batches; speak on outcomes, operator-relevant
+  external-state or decision/action milestones, and coordinator-authored state
+  changes. A time interval alone is not a milestone. The issue already settles
+  this behavior, so `/scope` returned with nothing to interview. `inline`
+- Put the general rule in `profile/base.md` and the dispatch-specific form in
+  ticket coordinator mode. This reaches all wait loops while keeping the
+  standalone coordinator reference executable. `→ ADR`
+- Keep the assurance level at prose plus normalized contract pins. Runtime polling
+  machinery is outside the requested behavior and the admitted risk. `inline`
+- Leave orchestrate's existing result-collection contract and the Codebase Memory
+  Claude hooks unchanged. They govern durable result locators and code discovery,
+  not user-facing poll narration. `inline`
+
+### Risk contract
+
+- **Must prevent:** routine unchanged polls flooding the operator while also
+  suppressing a worker failure, completion, abandoned wait, operator-relevant
+  external-state or decision milestone, or state change the coordinator caused.
+- **Must recover:** none; this is an instruction contract with no runtime state to
+  repair.
+- **Accepted failure:** an agent may still misread the prose and narrate an
+  unchanged poll; the consequence is noisy output and a corrected wait loop.
+- **Unsupported:** runtime enforcement, timer or milestone machinery, telemetry
+  changes, and inference about worker health from elapsed time.
+- **Evidence owed:** normalized prose pins for the global and ticket-specific
+  rules, plus the repository's documented verification gate.
+- **Why:** the observed harm is output noise, and the repository explicitly matches
+  mechanisms to the requested assurance level.
+- **Disposition:** admitted at intent level.
+
+## Open questions
+
+None.
+
+## Spawned tasks
+
+None.
+
+## Triage review rounds
+
+- Round 1 cold pass (unvalidated Terra): one `authoring` blocker. The draft
+  omitted the closed expected-diff allowlist required by
+  `skills/drivers/ticket/references/drafting-conventions.md`. Reproduced against
+  the cited source; corrected mechanically in the draft. The same reviewer
+  confirmed the blocker resolved with no injected defect.
+- Round 2 fresh cold pass (unvalidated Terra): no blockers; Appendix A1 was
+  reproduced byte-for-byte and the order was countersigned.
+- Round 2 load-bearing review lenses: two `authoring` blockers, both reproduced.
+  The draft did not state precedence over the existing three-batch fallback, and
+  a freely declared elapsed-time threshold could masquerade as a milestone. The
+  draft and active change now preserve the fallback outside wait loops, make
+  unchanged waits silent after three batches, limit milestones to
+  operator-relevant external-state or decision/action points, and exclude time
+  intervals alone. One review lens otherwise approved the order; both objecting
+  lenses approved the corrections and reported no injected defect.
+- Round 3 final fresh cold pass: one `authoring` blocker. The authoritative
+  OpenSpec delta named unchanged worker state but omitted the order's unchanged
+  result locators, files, and result sets. Reproduced directly; corrected
+  mechanically in the requirement and scenario and returned to the same reviewer
+  for re-check. The reviewer confirmed the acceptance contract now matches, strict
+  validation passes, and no defect was injected. The order is countersigned.
+- Final handoff audit: one `authoring` self-containment defect. The executable
+  fence cited the private preflight appendix, which will not be posted. The
+  citations were removed and the active OpenSpec folder and scope ledger were
+  named directly. The final reviewer confirmed the fence stands alone, both
+  artifacts exist, strict validation passes, and no defect was injected.

--- a/openspec/changes/235-coordinator-poll-narration/design.md
+++ b/openspec/changes/235-coordinator-poll-narration/design.md
@@ -1,0 +1,17 @@
+# Design
+
+## ADR 235 — Unchanged wait state is silence, not a status update
+
+The global profile owns the general communication rule so it reaches orchestrate
+and every other wait loop. Ticket coordinator mode repeats only the
+dispatch-specific application needed by an executor who reads that reference in
+isolation. Both distinguish state transitions and predeclared operator-relevant
+external-state or decision/action milestones from unchanged observations; elapsed
+time alone never promotes an unchanged poll into news or a milestone. For wait
+loops this rule takes precedence over the profile's general instruction to say
+once after three no-news batches; that fallback remains available outside waits.
+
+The contract remains prose plus normalized string pins. It does not add a poll
+parser, a state machine, a timer, or runtime enforcement. Existing instructions to
+collect child results from durable locators and to report coordinator-authored
+external state changes remain authoritative and unchanged.

--- a/openspec/changes/235-coordinator-poll-narration/proposal.md
+++ b/openspec/changes/235-coordinator-poll-narration/proposal.md
@@ -1,0 +1,34 @@
+# Quiet unchanged coordinator waits
+
+## Why
+
+The global communication contract requires a new-fact sentence after tool-result
+batches, but it does not say that a fresh timestamp or a re-check of unchanged
+worker state is still no news. Coordinators therefore narrate every poll while a
+worker runs, burying the eventual outcome in status prose the operator does not
+use.
+
+## What changes
+
+- Treat elapsed time and re-polled unchanged state as no new fact in every wait
+  loop governed by the shared profile.
+- Give ticket coordinator mode the same dispatch-specific silence rule while
+  preserving immediate reports of completion, failure, abandonment,
+  operator-relevant external-state or decision milestones, and
+  coordinator-authored state changes. A time interval alone is not a milestone.
+- Pin both instruction surfaces with the repository's existing normalized-prose
+  test style; add no polling parser or runtime enforcement.
+
+## Risk contract
+
+- **Must prevent:** routine unchanged polls flooding the operator while also
+  suppressing a worker failure, completion, abandoned wait, operator-relevant
+  external-state or decision milestone, or state change the coordinator caused.
+- **Must recover:** none; this is an instruction contract with no runtime state to
+  repair.
+- **Accepted failure:** an agent may still misread the prose and narrate an
+  unchanged poll; the consequence is noisy output and a corrected wait loop.
+- **Unsupported:** runtime enforcement, timer or milestone machinery, telemetry
+  changes, and inference about worker health from elapsed time.
+- **Evidence owed:** normalized prose pins for the global and ticket-specific
+  rules, plus the repository's documented verification gate.

--- a/openspec/changes/235-coordinator-poll-narration/specs/planning-and-review/spec.md
+++ b/openspec/changes/235-coordinator-poll-narration/specs/planning-and-review/spec.md
@@ -1,0 +1,25 @@
+# Planning and review routing delta
+
+## ADDED Requirements
+
+### Requirement: Coordinator wait narration follows state changes
+
+A coordinator governed by the shared communication contract MUST emit no update
+for re-polled unchanged external state, result locators or files, result sets, or
+elapsed time alone, including after three no-news batches. It MUST report worker
+completion, worker failure, an abandoned wait, an operator-relevant external-state
+or coordinator decision/action milestone declared before the wait, and any state
+change the coordinator itself caused. A time interval alone MUST NOT qualify as a
+milestone.
+
+#### Scenario: A worker remains active across polls
+
+- **WHEN** repeated checks find the same running state, result locator or files,
+  or result set and no operator-relevant external-state or decision/action
+  milestone has been crossed
+- **THEN** the coordinator continues waiting without emitting a status update
+
+#### Scenario: A wait reaches an outcome
+
+- **WHEN** the worker completes or fails, or the coordinator abandons the wait
+- **THEN** the coordinator reports that outcome immediately

--- a/openspec/changes/235-coordinator-poll-narration/tasks.md
+++ b/openspec/changes/235-coordinator-poll-narration/tasks.md
@@ -1,7 +1,7 @@
 # Tasks
 
-- [ ] Clarify unchanged wait-state narration in the shared communication contract.
-- [ ] Add the dispatch-specific rule to ticket coordinator mode.
-- [ ] Pin both prose contracts with fail-first normalized assertions.
-- [ ] Run the repository verification command and leave this change active for
+- [x] Clarify unchanged wait-state narration in the shared communication contract.
+- [x] Add the dispatch-specific rule to ticket coordinator mode.
+- [x] Pin both prose contracts with fail-first normalized assertions.
+- [x] Run the repository verification command and leave this change active for
   pull-request review and post-merge finalization.

--- a/openspec/changes/235-coordinator-poll-narration/tasks.md
+++ b/openspec/changes/235-coordinator-poll-narration/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [ ] Clarify unchanged wait-state narration in the shared communication contract.
+- [ ] Add the dispatch-specific rule to ticket coordinator mode.
+- [ ] Pin both prose contracts with fail-first normalized assertions.
+- [ ] Run the repository verification command and leave this change active for
+  pull-request review and post-merge finalization.

--- a/profile/base.md
+++ b/profile/base.md
@@ -18,6 +18,13 @@ check your own first line: if it starts with "I'll", "Let me", "Now", "Next", or
 always retrospective and never counts as speaking before a batch. On the last batch,
 it opens the final answer.
 
+In a wait loop, re-polled unchanged external state, files, result sets, and result
+locators are no news, including after three batches. Elapsed time alone is no news
+and never a milestone. Emit nothing until the worker completes or fails, the wait is
+abandoned, or a predeclared operator-relevant external-state or coordinator
+decision/action milestone occurs. The state-change rule below still reports any
+external state change the coordinator caused.
+
 > Bad: "I searched the config. Now I'll run the tests."
 >
 > Good: "No timeout override in the config, so the 30s default is what's firing."

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -57,6 +57,13 @@ graph-identity rule.
    `skills/drivers/orchestrate/scripts/claude-worker.py`. Never use the built-in
    Agent tool, Workflow tool, background-agent machinery, or native agent dispatch.
 
+   While a dispatched worker is still running, re-polled unchanged worker state,
+   files, result sets, and result locators produce no update, including after three
+   batches. Elapsed time alone is no news and never a milestone. Report completion,
+   failure, an abandoned wait, and a predeclared operator-relevant external-state or
+   coordinator decision/action milestone immediately. The shared state-change rule
+   still reports any external state change the coordinator caused.
+
    For chunk `<n>` and dispatch attempt `<attempt>`, the coordinator writes the
    complete prompt bytes to
    `<session-scratch>/ticket-<ticket-id-lowercase>-chunk-<n>-attempt-<attempt>.prompt`

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2224,6 +2224,36 @@ class OrchestrateCodexPolicyTests(unittest.TestCase):
 
 
 class ReviewerRoutingCanonicalContractTests(unittest.TestCase):
+    def test_shared_profile_keeps_unchanged_waits_silent_until_news(self):
+        text = " ".join((ROOT / "profile" / "base.md").read_text(encoding="utf-8").split())
+
+        self.assertIn(
+            "In a wait loop, re-polled unchanged external state, files, result sets, and "
+            "result locators are no news, including after three batches. Elapsed time alone "
+            "is no news and never a milestone. Emit nothing until the worker completes or "
+            "fails, the wait is abandoned, or a predeclared operator-relevant external-state "
+            "or coordinator decision/action milestone occurs. The state-change rule below "
+            "still reports any external state change the coordinator caused.",
+            text,
+        )
+
+    def test_ticket_coordinator_keeps_unchanged_worker_waits_silent(self):
+        text = " ".join(
+            (ROOT / "skills/drivers/ticket/references/coordinator-mode.md")
+            .read_text(encoding="utf-8")
+            .split()
+        )
+
+        self.assertIn(
+            "While a dispatched worker is still running, re-polled unchanged worker state, "
+            "files, result sets, and result locators produce no update, including after three "
+            "batches. Elapsed time alone is no news and never a milestone. Report completion, "
+            "failure, an abandoned wait, and a predeclared operator-relevant external-state "
+            "or coordinator decision/action milestone immediately. The shared state-change "
+            "rule still reports any external state change the coordinator caused.",
+            text,
+        )
+
     def test_orchestrate_pack_wide_reach_boundaries_are_preserved(self):
         skill = (ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md").read_bytes()
 


### PR DESCRIPTION
## Motivation and Context

Coordinator waits now stay silent while external state and worker results remain unchanged, including after three no-news batches. Previously each poll could become a status update merely because time had advanced.

* Completion, failure, abandoned waits, predeclared operator-relevant milestones, and coordinator-authored state changes are still reported immediately. Elapsed time alone is never a milestone.
* The shared communication contract reaches every wait loop, and ticket coordinator mode repeats the worker-dispatch rule for standalone execution.
* The active OpenSpec change records the decision and stays active for post-merge finalization.

Fixes #235

## How Has This Been Tested?

```text
openspec validate --all --strict
Totals: 4 passed, 0 failed (4 items)

scripts/validate.py
validated 27 skills and 366 files

unittest
Ran 446 tests in 127.988s
OK (skipped=23)

py_compile
(no output)
```

The normalized contract tests fail when either prose obligation is removed. They do not enforce agent output at runtime; that remains the admitted failure in the active change.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
