### PR TITLE
Run site-build tests in primary CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,6 +38,7 @@ jobs:
           tests.test_codebase_memory_install
           tests.test_check_dco
           tests.test_ci_changed_paths
+          tests.test_site_build
       - name: Check DCO
         if: github.event_name == 'pull_request'
         run: >-

--- a/docs/scope/224-site-build-ci.md
+++ b/docs/scope/224-site-build-ci.md
@@ -1,0 +1,58 @@
+# Scope ledger: 224-site-build-ci
+
+## Decisions
+
+- Classified as `code`: the deliverable changes a required CI workflow and lands
+  as a pull request. `inline`
+- `/scope` found nothing genuinely uncertain. Add the missing module and enforce
+  equality between the two selections from the observed regression; keep explicit
+  selection rather than introducing discovery or a shared runner. `inline`
+- Surface lifecycle is `none`: no rendered surface changes. `inline`
+- The work order is flat. No slicing trait fires; the workflow edit, regression
+  assertion, and active change record are one coherent CI contract, closest to
+  anchor A's one configuration change in one target. `inline`
+- Review depth is `targeted`: the required CI behavior and its regression contract
+  need end-to-end review, but the change is neither sensitive nor organization-wide
+  inherited workflow machinery. `inline`
+- Profile is `none`: `AGENTS.md` / `CLAUDE.md` declares no `Harden:` command.
+  `inline`
+
+### Risk contract
+
+- **Must prevent:** silent divergence between the unittest modules promised by the
+  repository's documented test command and those run by the primary validation
+  workflow; weakening unrelated CI checks; secret exposure; irreversible loss of
+  authoritative data; silent incorrect success.
+- **Must recover:** nothing. This is a pre-merge repository gate with no runtime
+  state to recover.
+- **Accepted failure:** a parity failure stops verification and requires a
+  contributor to align the two selections manually before merge.
+- **Unsupported:** discovering every test module from the filesystem or enforcing
+  parity with the separate documentation-publication workflow. Named selections
+  remain explicit by repository policy.
+- **Evidence owed:** a public-interface regression test that fails on the observed
+  mismatch and passes after `tests.test_site_build` joins the primary workflow,
+  plus the repository's documented full verification command.
+- **Why:** the observed failure is a two-list drift in a pre-merge gate; a focused
+  parity assertion closes that failure without introducing a new runner or parser
+  dependency.
+- **Disposition:** admitted; automatic test discovery and CI centralization are out
+  of scope.
+
+### Review rounds
+
+- Panel 1: GPT-5.6-Terra returned `SHIP` with 0 blocking objections and 0
+  notes after reproducing both generated evidence blocks. Authoring blockers: 0.
+  Injected blockers: 0.
+
+## Open questions
+
+(none)
+
+## Spawned tasks
+
+- Mandatory cold plan review before the work order is shown or posted.
+
+## Remaining dispositions
+
+(none)

--- a/docs/scope/224-site-build-ci.md
+++ b/docs/scope/224-site-build-ci.md
@@ -44,6 +44,10 @@
 - Panel 1: GPT-5.6-Terra returned `SHIP` with 0 blocking objections and 0
   notes after reproducing both generated evidence blocks. Authoring blockers: 0.
   Injected blockers: 0.
+- Approval-copy re-check: shortening the reviewed draft injected 2 blockers: the
+  host interpreter substitution was missing and the OpenSpec paths were no longer
+  a closed allowlist. Both corrections were reproduced by the same reviewer, which
+  returned `SHIP` with no new blocker. Authoring blockers: 0. Injected blockers: 2.
 
 ## Open questions
 

--- a/openspec/changes/224-site-build-ci/proposal.md
+++ b/openspec/changes/224-site-build-ci/proposal.md
@@ -1,0 +1,38 @@
+# Keep the documented and CI test selections aligned
+
+## Why
+
+The repository's documented verification command names
+`tests.test_site_build`, but the primary validation workflow omits it. A
+contributor can therefore follow the repository's own gate while the required CI
+job silently exercises a narrower unittest selection.
+
+## What changes
+
+- Run `tests.test_site_build` in the primary validation workflow.
+- Add a regression check that keeps the documented unittest module selection and
+  the primary validation workflow's selection equal.
+- Keep explicit test selection; do not replace the repository's named lists with
+  automatic discovery.
+
+## Risk contract
+
+- **Must prevent:** silent divergence between the unittest modules promised by the
+  repository's documented test command and those run by the primary validation
+  workflow; weakening unrelated CI checks; secret exposure; irreversible loss of
+  authoritative data; silent incorrect success.
+- **Must recover:** nothing. This is a pre-merge repository gate with no runtime
+  state to recover.
+- **Accepted failure:** a parity failure stops verification and requires a
+  contributor to align the two selections manually before merge.
+- **Unsupported:** discovering every test module from the filesystem or enforcing
+  parity with the separate documentation-publication workflow. Named selections
+  remain explicit by repository policy.
+- **Evidence owed:** a public-interface regression test that fails on the observed
+  mismatch and passes after `tests.test_site_build` joins the primary workflow,
+  plus the repository's documented full verification command.
+- **Why:** the observed failure is a two-list drift in a pre-merge gate; a focused
+  parity assertion closes that failure without introducing a new runner or parser
+  dependency.
+- **Disposition:** admitted; automatic test discovery and CI centralization are out
+  of scope.

--- a/openspec/changes/224-site-build-ci/specs/pack-integrity/spec.md
+++ b/openspec/changes/224-site-build-ci/specs/pack-integrity/spec.md
@@ -1,0 +1,38 @@
+# Pack integrity — deltas
+
+## MODIFIED Requirements
+
+### Requirement: Repository checks
+
+Pull-request and main-branch CI MUST run the repository validator, its named
+public-interface unittest modules, syntax checks, and the DCO check where
+applicable, and MUST install exactly the pinned OpenSpec CLI version through
+the documented global npm path and run `openspec validate --all --strict` so an
+invalid baseline spec or active change fails CI deterministically. CI MUST run
+the configured install, installed-copy, and browser-driver checks when
+changed-path classification selects the expensive path. The repository MUST
+treat named unittest and syntax-check lists as explicit selections rather than
+a claim that every eligible file is discovered automatically. The unittest
+module selection in the documented test command MUST equal the selection in
+the primary validation workflow, and a repository test MUST reject drift
+between them. The OpenSpec CLI MUST remain repository CI and development
+tooling rather than a pack runtime dependency.
+
+#### Scenario: CI evaluates a proposed pack change
+
+- **WHEN** the validation workflow runs for a pull request
+- **THEN** it installs the pinned OpenSpec CLI, strictly validates every
+  baseline spec and active change, executes the always-required checks, and
+  conditionally executes the changed-path-gated checks
+
+#### Scenario: The documented and primary CI unittest selections drift
+
+- **WHEN** a unittest module is named by exactly one of the documented test
+  command and the primary validation workflow
+- **THEN** the repository's regression suite exits unsuccessfully and identifies
+  the unequal selections
+
+#### Scenario: An OpenSpec artifact is malformed
+
+- **WHEN** a baseline spec or an active change's delta fails strict validation
+- **THEN** the validation workflow exits unsuccessfully before merge

--- a/openspec/changes/224-site-build-ci/tasks.md
+++ b/openspec/changes/224-site-build-ci/tasks.md
@@ -1,9 +1,9 @@
 # Tasks
 
-- [ ] Add a failing regression check for parity between the documented unittest
+- [x] Add a failing regression check for parity between the documented unittest
   selection and the primary validation workflow's selection.
-- [ ] Add `tests.test_site_build` to the primary validation workflow and make the
+- [x] Add `tests.test_site_build` to the primary validation workflow and make the
   parity check pass.
-- [ ] Run the repository's documented full verification command.
+- [x] Run the repository's documented full verification command.
 - [ ] Open the pull request with the active OpenSpec change still reviewable; do
   not archive it before merge.

--- a/openspec/changes/224-site-build-ci/tasks.md
+++ b/openspec/changes/224-site-build-ci/tasks.md
@@ -5,5 +5,5 @@
 - [x] Add `tests.test_site_build` to the primary validation workflow and make the
   parity check pass.
 - [x] Run the repository's documented full verification command.
-- [ ] Open the pull request with the active OpenSpec change still reviewable; do
+- [x] Open the pull request with the active OpenSpec change still reviewable; do
   not archive it before merge.

--- a/openspec/changes/224-site-build-ci/tasks.md
+++ b/openspec/changes/224-site-build-ci/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [ ] Add a failing regression check for parity between the documented unittest
+  selection and the primary validation workflow's selection.
+- [ ] Add `tests.test_site_build` to the primary validation workflow and make the
+  parity check pass.
+- [ ] Run the repository's documented full verification command.
+- [ ] Open the pull request with the active OpenSpec change still reviewable; do
+  not archive it before merge.

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -4037,7 +4037,26 @@ class ValidatorRegressionTests(unittest.TestCase):
 
 
 class OpenSpecCiContractTests(unittest.TestCase):
+    AGENTS = ROOT / "AGENTS.md"
     WORKFLOW = ROOT / ".github" / "workflows" / "validate.yml"
+
+    def test_documented_and_primary_ci_unittest_selections_match(self):
+        agents = self.AGENTS.read_text(encoding="utf-8")
+        workflow = self.WORKFLOW.read_text(encoding="utf-8")
+
+        documented_command = re.search(r"^- Test: `([^`]+)`", agents, re.MULTILINE).group(1)
+        primary_ci_step = re.search(
+            r"^      - name: Run public-interface behavior tests\n"
+            r"(?P<body>.*?)(?=^      - name: )",
+            workflow,
+            re.MULTILINE | re.DOTALL,
+        ).group("body")
+
+        named_test_module = r"tests\.test_[A-Za-z0-9_]+"
+        self.assertSetEqual(
+            set(re.findall(named_test_module, documented_command)),
+            set(re.findall(named_test_module, primary_ci_step)),
+        )
 
     def test_ci_installs_the_pinned_openspec_cli(self):
         workflow = self.WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Motivation and Context

The primary validation gate now runs the same nine public-interface test modules that the repository's documented verification command promises. Previously the documentation-site module ran in the publication workflow but not the primary pull-request and main-branch gate.

* A repository regression compares the two named module sets and fails when either selection changes alone.
* Test selection remains explicit. Triggers, permissions, action pins, other checks, and the separate publication workflow are unchanged.
* The decision and admitted-risk record remains active under `openspec/changes/224-site-build-ci/` for post-merge finalization.

Fixes #224

## How Has This Been Tested?

```text
Fail-first parity regression:
FAILED (failures=1)
Items in the first set but not the second: tests.test_site_build

Final parity regression:
Ran 1 test in 0.000s
OK

Full repository verification:
validated 27 skills and 365 files
Ran 445 tests in 114.367s
OK (skipped=23)
py_compile: no output, exit 0
```

The local evidence proves the selection contract and repository behavior. The GitHub-hosted workflow execution remains the pull request's check of record.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
