### PR TITLE
Give research workers explicit source access

### DIFF
--- a/openspec/changes/217-research-worker-network-access/design.md
+++ b/openspec/changes/217-research-worker-network-access/design.md
@@ -11,10 +11,10 @@ Add one opt-in adapter flag whose contract is access to provider-hosted web
 search and fetch while preserving the selected filesystem sandbox. Do not map
 the flag to arbitrary shell-command networking.
 
-For Claude, allowlist `WebSearch` and `WebFetch` while retaining `dontAsk` and
-the existing read-only write denials. For Codex, enable the hosted web-search
-tool in live mode while retaining `--sandbox read-only`. Persist the boolean in
-worker lifecycle state and replay it on resume.
+For Claude, add `--allowedTools WebSearch,WebFetch` while retaining `dontAsk`
+and the existing read-only write denials. For Codex, add `-c web_search=live`
+and `-c tools.web_search=true` while retaining `--sandbox read-only`. Persist
+the boolean in worker lifecycle state and replay it on resume.
 
 ### Consequences
 
@@ -23,5 +23,10 @@ without claiming identical tools or weakening repository confinement. Package
 managers, `curl`, private endpoints, and other shell networking remain outside
 the flag's promise. Provider policy can still refuse hosted tools, so the
 research skill owns a deterministic coordinator-material fallback rather than
-reporting false success.
-
+reporting false success. That fallback is the sole exception to the research
+worker's original-prompt-only input rule: after a successfully completed worker
+returns `SOURCE_ACCESS_UNAVAILABLE:`, the coordinator creates a unique
+`.research-sources.*` directory under the worker cwd, stores only fetched public
+source files plus `manifest.md` mapping each file to its URL, and resumes the
+same session with the absolute manifest path. Ordinary adapter failures and
+non-resumable sessions stop without a findings artifact.

--- a/openspec/changes/217-research-worker-network-access/design.md
+++ b/openspec/changes/217-research-worker-network-access/design.md
@@ -11,10 +11,11 @@ Add one opt-in adapter flag whose contract is access to provider-hosted web
 search and fetch while preserving the selected filesystem sandbox. Do not map
 the flag to arbitrary shell-command networking.
 
-For Claude, add `--allowedTools WebSearch,WebFetch` while retaining `dontAsk`
-and the existing read-only write denials. For Codex, add `-c web_search=live`
-and `-c tools.web_search=true` while retaining `--sandbox read-only`. Persist
-the boolean in worker lifecycle state and replay it on resume.
+Each provider adapter translates the capability to its hosted source tools as
+defined by that adapter's dispatch reference while retaining the selected
+filesystem sandbox. Persist the boolean in worker lifecycle state and replay it
+on resume; the dispatch references remain the sole normative home for concrete
+provider argv.
 
 ### Consequences
 

--- a/openspec/changes/217-research-worker-network-access/design.md
+++ b/openspec/changes/217-research-worker-network-access/design.md
@@ -1,0 +1,27 @@
+# Design
+
+The adapters expose one task-level capability while translating it to each
+provider's hosted research surface. Claude receives explicit permission for
+`WebSearch` and `WebFetch`; Codex receives an enabled live web-search tool. The
+shared lifecycle persists the capability so resume cannot silently lose it.
+
+## ADR 217 — Network opt-in means hosted research tools
+
+Add one opt-in adapter flag whose contract is access to provider-hosted web
+search and fetch while preserving the selected filesystem sandbox. Do not map
+the flag to arbitrary shell-command networking.
+
+For Claude, allowlist `WebSearch` and `WebFetch` while retaining `dontAsk` and
+the existing read-only write denials. For Codex, enable the hosted web-search
+tool in live mode while retaining `--sandbox read-only`. Persist the boolean in
+worker lifecycle state and replay it on resume.
+
+### Consequences
+
+Research gains equivalent source-retrieval capability across model families
+without claiming identical tools or weakening repository confinement. Package
+managers, `curl`, private endpoints, and other shell networking remain outside
+the flag's promise. Provider policy can still refuse hosted tools, so the
+research skill owns a deterministic coordinator-material fallback rather than
+reporting false success.
+

--- a/openspec/changes/217-research-worker-network-access/proposal.md
+++ b/openspec/changes/217-research-worker-network-access/proposal.md
@@ -1,0 +1,36 @@
+# Research worker source access
+
+## Why
+
+Research workers are dispatched read-only, but neither adapter currently opts
+them into the hosted web tools they need to reach primary sources. A denied
+tool leaves the coordinator to improvise a recovery path that the research
+contract does not define.
+
+## What changes
+
+- Add an explicit, persisted network capability to both worker adapters without
+  widening filesystem access or enabling arbitrary shell egress.
+- Require research dispatches to request that capability and fail visibly when
+  source access is unavailable.
+- Define coordinator-fetched local source material as the bounded fallback,
+  resumed through the same worker.
+
+## Risk contract
+
+- **Must prevent:** network access becoming implicit; widening repository write
+  access; secret exposure; and silently presenting uncited output as completed
+  research.
+- **Must recover:** when a provider refuses hosted search or fetch, the
+  coordinator fetches the required sources into session scratch and resumes the
+  same worker against those local files.
+- **Accepted failure:** when neither hosted tools nor coordinator fetching can
+  obtain the required primary sources, research stops clearly and produces no
+  successful findings artifact; recovery is manual.
+- **Unsupported:** arbitrary shell-command egress, private or authenticated
+  sources requiring worker credentials, local-network access, and identical
+  tool names across model families.
+- **Evidence owed:** default dispatch remains offline; the opt-in is present on
+  start and survives resume for both adapters; read-only filesystem boundaries
+  remain unchanged; and the research contract exercises the refusal fallback.
+

--- a/openspec/changes/217-research-worker-network-access/proposal.md
+++ b/openspec/changes/217-research-worker-network-access/proposal.md
@@ -13,24 +13,26 @@ contract does not define.
   widening filesystem access or enabling arbitrary shell egress.
 - Require research dispatches to request that capability and fail visibly when
   source access is unavailable.
-- Define coordinator-fetched local source material as the bounded fallback,
-  resumed through the same worker.
+- Define coordinator-fetched public source material as the bounded fallback for
+  a successfully completed, resumable worker that reports hosted-tool refusal.
 
 ## Risk contract
 
 - **Must prevent:** network access becoming implicit; widening repository write
   access; secret exposure; and silently presenting uncited output as completed
   research.
-- **Must recover:** when a provider refuses hosted search or fetch, the
-  coordinator fetches the required sources into session scratch and resumes the
-  same worker against those local files.
+- **Must recover:** when a successfully completed, resumable worker reports a
+  provider refusal of hosted search or fetch, the coordinator fetches the
+  required public sources into a unique scratch directory under the worker cwd
+  and resumes the same worker against a manifest of those local files.
 - **Accepted failure:** when neither hosted tools nor coordinator fetching can
   obtain the required primary sources, research stops clearly and produces no
-  successful findings artifact; recovery is manual.
+  successful findings artifact; recovery is manual. An adapter failure that
+  leaves no resumable session also stops on this path.
 - **Unsupported:** arbitrary shell-command egress, private or authenticated
   sources requiring worker credentials, local-network access, and identical
   tool names across model families.
 - **Evidence owed:** default dispatch remains offline; the opt-in is present on
   start and survives resume for both adapters; read-only filesystem boundaries
-  remain unchanged; and the research contract exercises the refusal fallback.
-
+  remain unchanged; both providers can read the cwd-local fallback material;
+  and the research contract exercises the refusal fallback.

--- a/openspec/changes/217-research-worker-network-access/specs/planning-and-review/spec.md
+++ b/openspec/changes/217-research-worker-network-access/specs/planning-and-review/spec.md
@@ -1,0 +1,36 @@
+# Planning and review routing — deltas
+
+## ADDED Requirements
+
+### Requirement: Research worker source access
+
+A research-worker dispatch MUST explicitly enable provider-hosted web search
+and fetch while preserving the selected filesystem sandbox, and the selected
+adapter MUST persist that capability across resume. The capability MUST remain
+off for dispatches that do not request it and MUST NOT promise arbitrary shell
+network access.
+
+When the provider refuses or cannot supply hosted source access, the
+coordinator MUST fetch the required primary sources into session scratch and
+resume the same worker against the local material. If neither path can obtain
+the required sources, the research workflow MUST stop clearly and MUST NOT
+report completed research or write a successful findings artifact.
+
+#### Scenario: Research starts with hosted source access
+
+- **WHEN** the research skill dispatches a read-only worker
+- **THEN** the selected adapter enables its hosted web tools without granting
+  repository writes or arbitrary command-network access
+
+#### Scenario: Research resumes after provider refusal
+
+- **WHEN** a hosted web tool is denied or unavailable
+- **THEN** the coordinator places fetched primary-source material in session
+  scratch and resumes the same worker against that material
+
+#### Scenario: A non-research worker starts normally
+
+- **WHEN** an adapter start omits the hosted-web opt-in
+- **THEN** hosted live source access remains disabled and the existing sandbox
+  behavior is unchanged
+

--- a/openspec/changes/217-research-worker-network-access/specs/planning-and-review/spec.md
+++ b/openspec/changes/217-research-worker-network-access/specs/planning-and-review/spec.md
@@ -10,11 +10,14 @@ adapter MUST persist that capability across resume. The capability MUST remain
 off for dispatches that do not request it and MUST NOT promise arbitrary shell
 network access.
 
-When the provider refuses or cannot supply hosted source access, the
-coordinator MUST fetch the required primary sources into session scratch and
-resume the same worker against the local material. If neither path can obtain
-the required sources, the research workflow MUST stop clearly and MUST NOT
-report completed research or write a successful findings artifact.
+When a successfully completed, resumable worker reports hosted source refusal
+with the defined worker result, the coordinator MUST fetch the required public
+primary sources into a unique scratch directory under the worker cwd and resume
+the same worker against a manifest of that local material. This handoff is the
+sole exception to the original-prompt-only worker-input rule. If the adapter
+fails without a resumable session, or neither source path can obtain the
+required sources, the research workflow MUST stop clearly and MUST NOT report
+completed research or write a successful findings artifact.
 
 #### Scenario: Research starts with hosted source access
 
@@ -24,13 +27,19 @@ report completed research or write a successful findings artifact.
 
 #### Scenario: Research resumes after provider refusal
 
-- **WHEN** a hosted web tool is denied or unavailable
-- **THEN** the coordinator places fetched primary-source material in session
-  scratch and resumes the same worker against that material
+- **WHEN** a successfully completed worker reports hosted web refusal as
+  `SOURCE_ACCESS_UNAVAILABLE:` and its state is resumable
+- **THEN** the coordinator places only public fetched sources and their URL
+  manifest in a unique cwd-local scratch directory and resumes that same worker
+  with the manifest path
+
+#### Scenario: The failed worker cannot resume
+
+- **WHEN** an adapter failure leaves no terminal state with a session ID
+- **THEN** research stops visibly and writes no successful findings artifact
 
 #### Scenario: A non-research worker starts normally
 
 - **WHEN** an adapter start omits the hosted-web opt-in
 - **THEN** hosted live source access remains disabled and the existing sandbox
   behavior is unchanged
-

--- a/openspec/changes/217-research-worker-network-access/tasks.md
+++ b/openspec/changes/217-research-worker-network-access/tasks.md
@@ -1,11 +1,11 @@
 # Tasks
 
-- [ ] Add a backward-compatible persisted hosted-web capability to the shared
+- [x] Add a backward-compatible persisted hosted-web capability to the shared
   worker lifecycle and both adapter command surfaces.
-- [ ] Cover default-off, start, resume, output, provider argv, and malformed
+- [x] Cover default-off, start, resume, output, provider argv, and malformed
   state behavior through the public adapter CLIs.
-- [ ] Update the two adapter references and the research dispatch contract,
+- [x] Update the two adapter references and the research dispatch contract,
   including the bounded cwd-local, same-worker coordinator-material fallback
   and its explicit worker result.
-- [ ] Run the repository's full validation command and strict OpenSpec
+- [x] Run the repository's full validation command and strict OpenSpec
   validation.

--- a/openspec/changes/217-research-worker-network-access/tasks.md
+++ b/openspec/changes/217-research-worker-network-access/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [ ] Add a backward-compatible persisted hosted-web capability to the shared
+  worker lifecycle and both adapter command surfaces.
+- [ ] Cover default-off, start, resume, output, provider argv, and malformed
+  state behavior through the public adapter CLIs.
+- [ ] Update the two adapter references and the research dispatch contract,
+  including the same-worker coordinator-material fallback.
+- [ ] Run the repository's full validation command and strict OpenSpec
+  validation.
+

--- a/openspec/changes/217-research-worker-network-access/tasks.md
+++ b/openspec/changes/217-research-worker-network-access/tasks.md
@@ -5,7 +5,7 @@
 - [ ] Cover default-off, start, resume, output, provider argv, and malformed
   state behavior through the public adapter CLIs.
 - [ ] Update the two adapter references and the research dispatch contract,
-  including the same-worker coordinator-material fallback.
+  including the bounded cwd-local, same-worker coordinator-material fallback
+  and its explicit worker result.
 - [ ] Run the repository's full validation command and strict OpenSpec
   validation.
-

--- a/skills/drivers/orchestrate/references/dispatch-claude.md
+++ b/skills/drivers/orchestrate/references/dispatch-claude.md
@@ -39,12 +39,14 @@ as codex-worker's resume.
 ## Hosted source access
 
 `start --network` opts the worker into provider-hosted source retrieval. The
-adapter maps that capability to `--allowedTools WebSearch,WebFetch`, persists
-the boolean in lifecycle state, replays it on `resume` without a replacement
-flag, and reports it in successful output. Omitting the option leaves hosted
-source tools disabled and reports `network: false`; existing state without the
-field remains valid and resumes offline. This capability promises hosted web
-search and fetch only; shell-command networking, command egress,
+adapter maps that capability to `--allowedTools WebSearch,WebFetch`; the default
+path enforces offline behavior with `--disallowedTools WebSearch,WebFetch`. The
+adapter persists the boolean in lifecycle state, replays it on `resume` without
+a replacement flag, and reports it in successful output. Omitting the option
+leaves hosted source tools explicitly denied and reports `network: false`;
+existing state without the field remains valid and resumes offline. This
+capability promises hosted web search and fetch only; shell-command networking,
+command egress,
 private-network access, credentials, and a wider filesystem sandbox are outside
 the contract.
 

--- a/skills/drivers/orchestrate/references/dispatch-claude.md
+++ b/skills/drivers/orchestrate/references/dispatch-claude.md
@@ -36,6 +36,18 @@ findings and ordinary follow-ups; it restores the captured model, sandbox,
 effort, and canonical cwd rather than taking replacements — the same contract
 as codex-worker's resume.
 
+## Hosted source access
+
+`start --network` opts the worker into provider-hosted source retrieval. The
+adapter maps that capability to `--allowedTools WebSearch,WebFetch`, persists
+the boolean in lifecycle state, replays it on `resume` without a replacement
+flag, and reports it in successful output. Omitting the option leaves hosted
+source tools disabled and reports `network: false`; existing state without the
+field remains valid and resumes offline. This capability promises hosted web
+search and fetch only; shell-command networking, command egress,
+private-network access, credentials, and a wider filesystem sandbox are outside
+the contract.
+
 ## Prompt on stdin, not as an argument
 
 `claude-worker.py` writes the prompt to the worker's stdin and closes it,
@@ -109,7 +121,7 @@ is in scope.
 ## Output
 
 On success the adapter emits one public JSON object: `session_id`, `model`,
-`sandbox`, `cwd`, `effort`, `final_message` (the CLI's `result` field), and
+`sandbox`, `cwd`, `effort`, `network`, `final_message` (the CLI's `result` field), and
 `permission_denials` (whatever the CLI's JSON payload reported as denied, so
 the coordinator can see what the sandbox refused — an empty list when
 nothing was denied). `is_error: true` in the CLI's own JSON is treated as a

--- a/skills/drivers/orchestrate/references/dispatch-codex.md
+++ b/skills/drivers/orchestrate/references/dispatch-codex.md
@@ -13,6 +13,18 @@ control checkout. Persist one state file per worker. Use `resume` with that
 state file for retry findings and ordinary follow-ups; it restores the captured
 model, sandbox, and canonical cwd rather than taking replacements.
 
+## Hosted source access
+
+`start --network` opts the worker into provider-hosted source retrieval. The
+adapter maps that capability to `-c web_search=live -c tools.web_search=true`,
+persists the boolean in lifecycle state, replays it on `resume` without a
+replacement flag, and reports it in successful output. Omitting the option
+keeps the provider argv offline and reports `network: false`; existing state
+without the field remains valid and resumes offline. This capability promises
+hosted web search and fetch only; shell-command networking, command egress,
+private-network access, credentials, and a wider filesystem sandbox are outside
+the contract.
+
 When the worker must judge rendered evidence, pass every evidence image as a
 repeated `--image /absolute/path/to/file` argument on `start`. A path mentioned
 only in the prompt is not an attachment. `resume` accepts the same repeated

--- a/skills/drivers/orchestrate/scripts/claude-worker.py
+++ b/skills/drivers/orchestrate/scripts/claude-worker.py
@@ -56,6 +56,10 @@ def effort_of(state: dict[str, Any]) -> str:
     return state.get("effort", DEFAULT_EFFORT)
 
 
+def network_arguments(enabled: bool) -> list[str]:
+    return ["--allowedTools", "WebSearch,WebFetch"] if enabled else []
+
+
 def parse(output: str) -> tuple[str | None, str | None, Any, str | None]:
     payload, error = parse_result(output)
     if error:
@@ -75,6 +79,7 @@ def emit(state: dict[str, Any], final_message: str, permission_denials: Any) -> 
         "sandbox": state["sandbox"],
         "cwd": state["cwd"],
         "effort": effort_of(state),
+        "network": state.get("network", False),
         "final_message": final_message,
         "permission_denials": permission_denials if permission_denials is not None else [],
     }))
@@ -120,6 +125,7 @@ def start(args: argparse.Namespace) -> int:
     command = [
         args.claude, "-p", "--model", args.model, "--effort", args.effort,
         "--permission-mode", "dontAsk", "--settings", str(settings),
+        *network_arguments(state.get("network", False)),
         "--session-id", session_id, "--output-format", "json",
     ]
     return lifecycle.run_lifecycle(
@@ -141,6 +147,7 @@ def resume(args: argparse.Namespace) -> int:
     command = [
         args.claude, "-p", "--resume", fresh["session_id"], "--model", fresh["model"],
         "--effort", effort, "--permission-mode", "dontAsk", "--settings", str(settings),
+        *network_arguments(fresh.get("network", False)),
         "--output-format", "json",
     ]
     return lifecycle.run_lifecycle(
@@ -166,7 +173,7 @@ def parser() -> argparse.ArgumentParser:
     common.add_argument("--claude", default="claude")
     common.add_argument("--state", type=Path, required=True)
     common.add_argument("prompt", nargs="?")
-    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=lifecycle.resolved_directory); start_parser.set_defaults(handler=start)
+    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--network", action="store_true"); start_parser.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=lifecycle.resolved_directory); start_parser.set_defaults(handler=start)
     resume_parser = commands.add_parser("resume", parents=[common]); resume_parser.set_defaults(handler=resume)
     for name, handler in (("stop", stop), ("verify", verify)):
         command = commands.add_parser(name, parents=[common]); command.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); command.add_argument("--grace-seconds", type=float, default=1.0); command.set_defaults(handler=handler)

--- a/skills/drivers/orchestrate/scripts/claude-worker.py
+++ b/skills/drivers/orchestrate/scripts/claude-worker.py
@@ -57,7 +57,8 @@ def effort_of(state: dict[str, Any]) -> str:
 
 
 def network_arguments(enabled: bool) -> list[str]:
-    return ["--allowedTools", "WebSearch,WebFetch"] if enabled else []
+    option = "--allowedTools" if enabled else "--disallowedTools"
+    return [option, "WebSearch,WebFetch"]
 
 
 def parse(output: str) -> tuple[str | None, str | None, Any, str | None]:

--- a/skills/drivers/orchestrate/scripts/codex-worker.py
+++ b/skills/drivers/orchestrate/scripts/codex-worker.py
@@ -93,6 +93,10 @@ def image_arguments(paths: list[Path]) -> list[str]:
     return [value for path in paths for value in ("--image", str(path))]
 
 
+def network_arguments(enabled: bool) -> list[str]:
+    return ["-c", "web_search=live", "-c", "tools.web_search=true"] if enabled else []
+
+
 def parse(output: str) -> tuple[str | None, str | None, Any, str | None]:
     items, error = parse_jsonl(output)
     if error:
@@ -108,7 +112,7 @@ def emit(state: dict[str, Any], final_message: str, _metadata: Any = None) -> No
     limits = latest_rate_limits(state["session_id"])
     primary = limits.get("primary") if isinstance(limits, dict) else None
     remaining = 100 - primary["used_percent"] if isinstance(primary, dict) and isinstance(primary.get("used_percent"), (int, float)) else None
-    print(json.dumps({"session_id": state["session_id"], "model": state["model"], "sandbox": state["sandbox"], "cwd": state["cwd"], "effort": effort_of(state), "final_message": final_message, "headroom": remaining, "headroom_status": "known" if remaining is not None else "unknown"}))
+    print(json.dumps({"session_id": state["session_id"], "model": state["model"], "sandbox": state["sandbox"], "cwd": state["cwd"], "effort": effort_of(state), "network": state.get("network", False), "final_message": final_message, "headroom": remaining, "headroom_status": "known" if remaining is not None else "unknown"}))
 
 
 def start(args: argparse.Namespace) -> int:
@@ -119,7 +123,7 @@ def start(args: argparse.Namespace) -> int:
         return fail(error)
     assert state is not None
     effort = effort_of(state)
-    command = [args.codex, "exec", "-m", args.model, "-c", f"model_reasoning_effort={effort}", "--sandbox", args.sandbox, "--skip-git-repo-check", "-C", str(args.cwd), "--json", *image_arguments(getattr(args, "image", [])), args.prompt]
+    command = [args.codex, "exec", "-m", args.model, "-c", f"model_reasoning_effort={effort}", *network_arguments(state.get("network", False)), "--sandbox", args.sandbox, "--skip-git-repo-check", "-C", str(args.cwd), "--json", *image_arguments(getattr(args, "image", [])), args.prompt]
     return lifecycle.run_lifecycle(
         args, command, state, parse=parse, emit=emit, fail=fail,
         stdin_text=None, effort_levels=EFFORT_LEVELS,
@@ -134,7 +138,7 @@ def resume(args: argparse.Namespace) -> int:
         return fail(error)
     assert fresh is not None and expected is not None
     effort = effort_of(fresh)
-    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", "--skip-git-repo-check", "--json", *image_arguments(getattr(args, "image", [])), args.prompt]
+    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", *network_arguments(fresh.get("network", False)), "--skip-git-repo-check", "--json", *image_arguments(getattr(args, "image", [])), args.prompt]
     return lifecycle.run_lifecycle(
         args, command, fresh, expected=expected, parse=parse, emit=emit, fail=fail,
         stdin_text=None, effort_levels=EFFORT_LEVELS,
@@ -159,7 +163,7 @@ def parser() -> argparse.ArgumentParser:
     common.add_argument("--state", type=Path, required=True)
     common.add_argument("--image", action="append", default=[], type=existing_file)
     common.add_argument("prompt", nargs="?")
-    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=lifecycle.resolved_directory); start_parser.set_defaults(handler=start)
+    start_parser = commands.add_parser("start", parents=[common]); start_parser.add_argument("--model", required=True); start_parser.add_argument("--sandbox", choices=("read-only", "workspace-write"), required=True); start_parser.add_argument("--effort", default=DEFAULT_EFFORT); start_parser.add_argument("--network", action="store_true"); start_parser.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); start_parser.add_argument("--control-checkout", type=lifecycle.resolved_directory); start_parser.set_defaults(handler=start)
     resume_parser = commands.add_parser("resume", parents=[common]); resume_parser.set_defaults(handler=resume)
     for name, handler in (("stop", stop), ("verify", verify)):
         command = commands.add_parser(name, parents=[common]); command.add_argument("--cwd", type=lifecycle.resolved_directory, required=True); command.add_argument("--grace-seconds", type=float, default=1.0); command.set_defaults(handler=handler)

--- a/skills/drivers/orchestrate/scripts/worker_lifecycle.py
+++ b/skills/drivers/orchestrate/scripts/worker_lifecycle.py
@@ -147,6 +147,8 @@ def _valid_common_schema(
         return False
     if "effort" in state and (not isinstance(state["effort"], str) or state["effort"] not in effort_levels):
         return False
+    if "network" in state and type(state["network"]) is not bool:
+        return False
     control = state.get("control_checkout")
     if control is not None and not _canonical_path(control):
         return False
@@ -160,7 +162,7 @@ def valid_family_schema(state: dict[str, Any], *, effort_levels: set[str]) -> bo
     identity = {"pid", "pgid", "sid", "birth"}
     if not identity.issubset(state):
         return False
-    allowed = BASE_STATE_FIELDS | identity | {"control_checkout", "effort"}
+    allowed = BASE_STATE_FIELDS | identity | {"control_checkout", "effort", "network"}
     if not _valid_common_schema(state, allowed, effort_levels=effort_levels):
         return False
     for field in ("pid", "pgid", "sid"):
@@ -177,7 +179,7 @@ def valid_family_schema(state: dict[str, Any], *, effort_levels: set[str]) -> bo
 
 
 def valid_portable_schema(state: dict[str, Any], *, effort_levels: set[str]) -> bool:
-    allowed = BASE_STATE_FIELDS | {"control_checkout", "family_semantics", "generation", "effort"}
+    allowed = BASE_STATE_FIELDS | {"control_checkout", "family_semantics", "generation", "effort", "network"}
     if not _valid_common_schema(state, allowed, effort_levels=effort_levels):
         return False
     if state["lifecycle"] != "exited":
@@ -442,6 +444,7 @@ def prepare_start(
         "sandbox": args.sandbox,
         "cwd": str(args.cwd),
         "session_id": "",
+        "network": bool(getattr(args, "network", False)),
     }
     if effort != default_effort:
         state["effort"] = effort
@@ -462,9 +465,11 @@ def prepare_resume(
             return None, None, "state file is malformed or incomplete"
         if "version" not in state:
             legacy = {"session_id", "model", "sandbox", "cwd"}
-            if not legacy.issubset(state) or not set(state).issubset(legacy | {"control_checkout", "effort"}):
+            if not legacy.issubset(state) or not set(state).issubset(legacy | {"control_checkout", "effort", "network"}):
                 return None, None, "state file is malformed or incomplete"
             if not all(isinstance(state[key], str) and state[key] for key in legacy):
+                return None, None, "state file is malformed or incomplete"
+            if "network" in state and type(state["network"]) is not bool:
                 return None, None, "state file is malformed or incomplete"
         elif not (
             valid_family_schema(state, effort_levels=effort_levels)
@@ -498,6 +503,7 @@ def prepare_resume(
             "model": state["model"],
             "sandbox": sandbox,
             "cwd": str(cwd),
+            "network": state.get("network", False),
         }
         if effort != default_effort:
             fresh["effort"] = effort

--- a/skills/tools/research/SKILL.md
+++ b/skills/tools/research/SKILL.md
@@ -14,9 +14,11 @@ through `skills/drivers/orchestrate/scripts/codex-worker.py` or
 adapter's read-only surface. Never use the built-in Agent tool, Workflow tool,
 or background-agent machinery.
 
-Use the selected adapter's `start` surface with one coordinator-owned state file
-under the coordinator's session-scratch directory. The selected adapter's
-`resume`, `stop`, and `verify` surfaces retain lifecycle ownership.
+Use the provider-neutral hosted-source capability defined by the selected
+adapter's dispatch reference on every read-only research `start`, with one
+coordinator-owned state file under the coordinator's session-scratch directory.
+The selected adapter's `resume`, `stop`, and `verify` surfaces retain lifecycle
+ownership. Do not restate provider argv here.
 
 After selection, this interface does not reclassify research work or choose a
 model or effort. Preserve adapter-owned state and coordinator-owned recovery
@@ -26,7 +28,24 @@ lifecycle mechanics here.
 Before dispatch, the coordinator writes the exact complete research-task prompt
 bytes to an immutable session-scratch file and passes that file's contents as
 the selected adapter's positional prompt. The worker receives no chat transcript
-or other coordinator-session material.
+or other coordinator-session material. The prompt requires the worker to return
+a final message beginning `SOURCE_ACCESS_UNAVAILABLE:` when hosted search or
+fetch is refused, and to write no findings document in that case.
+
+Only when that start completed with a terminal, resumable session and its final
+message begins with the exact `SOURCE_ACCESS_UNAVAILABLE:` prefix may the
+coordinator fetch the required public sources. Create a unique
+`.research-sources.*` directory under the worker cwd, store only fetched public
+unauthenticated source files plus `manifest.md` mapping each file to its source
+URL, and resume the same worker with the manifest's absolute path. This bounded
+handoff is the sole narrow exception to the original-prompt-only rule and takes
+precedence over it. The directory is removed after completion.
+
+If the adapter leaves no resumable session or the coordinator cannot obtain the
+required primary sources, stop explicitly and write no successful findings
+document. Never put transcripts, credentials, secrets, `.env`, patient data,
+authenticated or private source material, or unrelated coordinator-session
+content in the handoff.
 
 The worker performs the research directly and returns source-cited findings to
 the coordinator. Never spawn another background agent or nested worker. If the

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2443,7 +2443,12 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertIn("model_reasoning_effort=medium", argv)
-        self.assertNotIn("effort", json.loads(self.state.read_text(encoding="utf-8")))
+        self.assertNotIn("web_search=live", argv)
+        self.assertNotIn("tools.web_search=true", argv)
+        state = json.loads(self.state.read_text(encoding="utf-8"))
+        self.assertNotIn("effort", state)
+        self.assertIs(state["network"], False)
+        self.assertIs(json.loads(result.stdout)["network"], False)
 
     def test_codex_start_carries_a_custom_effort_and_persists_it(self):
         self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'
@@ -2456,6 +2461,22 @@ class WorkerEffortDialTests(unittest.TestCase):
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertIn("model_reasoning_effort=high", argv)
         self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["effort"], "high")
+
+    def test_codex_start_network_enables_hosted_search_and_persists_capability(self):
+        self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'
+
+        result = self.run_codex(
+            "start", "--codex", str(self.codex_binary), "--state", str(self.state),
+            "--model", "Terra", "--sandbox", "read-only", "--network",
+            "--cwd", str(self.worktree), "research primary sources",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertIn(["-c", "web_search=live"], [argv[index:index + 2] for index in range(len(argv) - 1)])
+        self.assertIn(["-c", "tools.web_search=true"], [argv[index:index + 2] for index in range(len(argv) - 1)])
+        self.assertIs(json.loads(self.state.read_text(encoding="utf-8"))["network"], True)
+        self.assertIs(json.loads(result.stdout)["network"], True)
 
     def test_codex_effort_enum_matches_the_live_api_probe(self):
         self.assertEqual(
@@ -2476,7 +2497,32 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertIn("model_reasoning_effort=high", argv)
-        self.assertEqual(json.loads(result.stdout)["effort"], "high")
+        self.assertNotIn("web_search=live", argv)
+        self.assertNotIn("tools.web_search=true", argv)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["effort"], "high")
+        self.assertIs(payload["network"], False)
+
+    def test_codex_resume_replays_persisted_network_capability(self):
+        persisted = {
+            "version": LIFECYCLE_MODULE.STATE_VERSION, "lifecycle": "exited",
+            "session_id": "worker-1", "model": "Terra", "sandbox": "read-only",
+            "cwd": str(self.worktree.resolve()), "network": True,
+            "family_semantics": "unsupported", "generation": 1,
+        }
+        self.state.write_text(json.dumps(persisted), encoding="utf-8")
+        self.environment["FAKE_OUTPUT"] = '{"type":"thread.started","thread_id":"worker-1"}\n{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n'
+
+        result = self.run_codex(
+            "resume", "--codex", str(self.codex_binary), "--state", str(self.state),
+            "continue the research",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertIn(["-c", "web_search=live"], [argv[index:index + 2] for index in range(len(argv) - 1)])
+        self.assertIn(["-c", "tools.web_search=true"], [argv[index:index + 2] for index in range(len(argv) - 1)])
+        self.assertIs(json.loads(result.stdout)["network"], True)
 
     def test_codex_start_attaches_each_image_through_the_cli_interface(self):
         first = self.scratch / "before.png"
@@ -2542,8 +2588,12 @@ class WorkerEffortDialTests(unittest.TestCase):
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertIn("--effort", argv)
         self.assertEqual(argv[argv.index("--effort") + 1], "medium")
-        self.assertNotIn("effort", json.loads(self.state.read_text(encoding="utf-8")))
+        self.assertNotIn("--allowedTools", argv)
+        state = json.loads(self.state.read_text(encoding="utf-8"))
+        self.assertNotIn("effort", state)
+        self.assertIs(state["network"], False)
         self.assertEqual(json.loads(result.stdout)["effort"], "medium")
+        self.assertIs(json.loads(result.stdout)["network"], False)
 
     def test_claude_start_carries_a_custom_effort_and_persists_it(self):
         self.environment["FAKE_OUTPUT"] = json.dumps({"session_id": "s1", "result": "ok", "is_error": False})
@@ -2557,6 +2607,24 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(argv[argv.index("--effort") + 1], "xhigh")
         self.assertEqual(json.loads(self.state.read_text(encoding="utf-8"))["effort"], "xhigh")
         self.assertEqual(json.loads(result.stdout)["effort"], "xhigh")
+
+    def test_claude_start_network_allows_hosted_tools_and_persists_capability(self):
+        self.environment["FAKE_OUTPUT"] = json.dumps(
+            {"session_id": "s1", "result": "ok", "is_error": False}
+        )
+
+        result = self.run_claude(
+            "start", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "--model", "sonnet", "--sandbox", "read-only", "--network",
+            "--cwd", str(self.worktree), "research primary sources",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertEqual(argv[argv.index("--allowedTools") + 1], "WebSearch,WebFetch")
+        self.assertEqual(self.stdin_capture.read_text(encoding="utf-8"), "research primary sources")
+        self.assertIs(json.loads(self.state.read_text(encoding="utf-8"))["network"], True)
+        self.assertIs(json.loads(result.stdout)["network"], True)
 
     def test_claude_rejects_an_effort_outside_its_own_enum(self):
         # "minimal" is invalid for both adapters, although their enums differ.
@@ -2582,7 +2650,33 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertEqual(argv[argv.index("--effort") + 1], "high")
-        self.assertEqual(json.loads(result.stdout)["effort"], "high")
+        self.assertNotIn("--allowedTools", argv)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["effort"], "high")
+        self.assertIs(payload["network"], False)
+
+    def test_claude_resume_replays_persisted_network_capability(self):
+        persisted = {
+            "version": LIFECYCLE_MODULE.STATE_VERSION, "lifecycle": "exited",
+            "session_id": "worker-1", "model": "sonnet", "sandbox": "read-only",
+            "cwd": str(self.worktree.resolve()), "network": True,
+            "family_semantics": "unsupported", "generation": 1,
+        }
+        self.state.write_text(json.dumps(persisted), encoding="utf-8")
+        self.environment["FAKE_OUTPUT"] = json.dumps(
+            {"session_id": "worker-1", "result": "ok", "is_error": False}
+        )
+
+        result = self.run_claude(
+            "resume", "--claude", str(self.claude_binary), "--state", str(self.state),
+            "continue the research",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        argv = json.loads(self.arguments.read_text(encoding="utf-8"))
+        self.assertEqual(argv[argv.index("--allowedTools") + 1], "WebSearch,WebFetch")
+        self.assertEqual(self.stdin_capture.read_text(encoding="utf-8"), "continue the research")
+        self.assertIs(json.loads(result.stdout)["network"], True)
 
     def test_claude_start_argv_carries_no_cwd_flag_and_settings_matches_sandbox_mode(self):
         # The installed claude CLI has no --cwd flag; the adapter establishes
@@ -3306,6 +3400,8 @@ class PersonaReviewAdapterDispatchTests(unittest.TestCase):
 class ResearchAdapterDispatchTests(unittest.TestCase):
     SKILL = ROOT / "skills" / "tools" / "research" / "SKILL.md"
     AGENT_METADATA = ROOT / "skills" / "tools" / "research" / "agents" / "openai.yaml"
+    CODEX_DISPATCH = ROOT / "skills" / "drivers" / "orchestrate" / "references" / "dispatch-codex.md"
+    CLAUDE_DISPATCH = ROOT / "skills" / "drivers" / "orchestrate" / "references" / "dispatch-claude.md"
 
     def setUp(self):
         self.text = self.SKILL.read_text(encoding="utf-8")
@@ -3333,6 +3429,48 @@ class ResearchAdapterDispatchTests(unittest.TestCase):
         job = self.research_job()
         self.assertIn("The coordinator writes the returned findings to a single Markdown file", job)
         self.assertIn("Save it where the repo already keeps such notes; match the existing convention", job)
+
+    def test_adapter_references_own_the_hosted_source_command_contract(self):
+        codex = " ".join(self.CODEX_DISPATCH.read_text(encoding="utf-8").split())
+        claude = " ".join(self.CLAUDE_DISPATCH.read_text(encoding="utf-8").split())
+        for contract in (codex, claude):
+            self.assertIn("`start --network`", contract)
+            self.assertIn("persists", contract)
+            self.assertIn("replays", contract)
+            self.assertIn("`network: false`", contract)
+            self.assertIn("shell-command networking", contract)
+        self.assertIn("`-c web_search=live -c tools.web_search=true`", codex)
+        self.assertIn("`--allowedTools WebSearch,WebFetch`", claude)
+
+    def test_research_requests_hosted_sources_and_defines_exact_refusal_result(self):
+        dispatch = " ".join(
+            self.text.split("## Research-worker dispatch", 1)[1]
+            .split("## The research worker's job", 1)[0]
+            .split()
+        )
+        self.assertIn("provider-neutral hosted-source capability", dispatch)
+        self.assertIn("every read-only research `start`", dispatch)
+        self.assertIn("`SOURCE_ACCESS_UNAVAILABLE:`", dispatch)
+        self.assertIn("no findings document", dispatch)
+        self.assertNotIn("WebSearch,WebFetch", dispatch)
+        self.assertNotIn("web_search=live", dispatch)
+
+    def test_research_fallback_is_same_worker_cwd_local_and_fail_closed(self):
+        normalized = " ".join(self.text.split())
+        for requirement in (
+            "terminal, resumable session",
+            "unique `.research-sources.*` directory under the worker cwd",
+            "`manifest.md` mapping each file to its source URL",
+            "sole narrow exception to the original-prompt-only rule",
+            "resume the same worker",
+            "removed after completion",
+            "public unauthenticated source files",
+            "transcripts, credentials, secrets, `.env`, patient data",
+            "authenticated or private source material",
+        ):
+            self.assertIn(requirement, normalized)
+        self.assertIn("If the adapter leaves no resumable session", normalized)
+        self.assertIn("write no successful findings document", normalized)
 
 
 class DesignItTwiceAdapterDispatchTests(unittest.TestCase):
@@ -3624,6 +3762,8 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             ("sandbox type", {**base, "sandbox": []}),
             ("sandbox value", {**base, "sandbox": "danger-full-access"}),
             ("session type", {**base, "session_id": 1}),
+            ("network type", {**base, "network": "true"}),
+            ("network null", {**base, "network": None}),
             ("workspace control missing", {**base, "sandbox": "workspace-write"}),
             ("control checkout type", {**base, "control_checkout": 1}),
             ("control checkout empty", {**base, "control_checkout": ""}),
@@ -3669,6 +3809,7 @@ class WorkerLifecycleContractTests(unittest.TestCase):
             ("generation overflow", {**base, "generation": 2**64}),
             ("nonterminal lifecycle", {**base, "lifecycle": "running"}),
             ("fabricated identity", {**base, "pid": 41}),
+            ("network type", {**base, "network": 1}),
         )
         for name, state in mutations:
             operations = (
@@ -3929,6 +4070,20 @@ class WorkerLifecycleContractTests(unittest.TestCase):
         with mock.patch.object(LIFECYCLE_MODULE, "run_lifecycle", return_value=0) as launch:
             self.assertEqual(WORKER_MODULE.resume(argparse.Namespace(state=self.state, codex="codex", prompt="continue")), 0)
             self.assertEqual(launch.call_args.args[2]["lifecycle"], "launching")
+            self.assertIs(launch.call_args.args[2]["network"], False)
+
+        malformed = {**legacy, "network": "true"}
+        self.state.write_text(json.dumps(malformed), encoding="utf-8")
+        with mock.patch.object(LIFECYCLE_MODULE, "run_lifecycle") as launch:
+            self.assertNotEqual(
+                WORKER_MODULE.resume(
+                    argparse.Namespace(
+                        state=self.state, codex="codex", prompt="continue"
+                    )
+                ),
+                0,
+            )
+            launch.assert_not_called()
 
     def test_process_family_constants_and_no_global_cleanup_authority(self):
         self.assertEqual(LIFECYCLE_MODULE.BSD_SIZE, 136)

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2589,6 +2589,9 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertIn("--effort", argv)
         self.assertEqual(argv[argv.index("--effort") + 1], "medium")
         self.assertNotIn("--allowedTools", argv)
+        self.assertEqual(
+            argv[argv.index("--disallowedTools") + 1], "WebSearch,WebFetch"
+        )
         state = json.loads(self.state.read_text(encoding="utf-8"))
         self.assertNotIn("effort", state)
         self.assertIs(state["network"], False)
@@ -2622,6 +2625,7 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertEqual(argv[argv.index("--allowedTools") + 1], "WebSearch,WebFetch")
+        self.assertNotIn("--disallowedTools", argv)
         self.assertEqual(self.stdin_capture.read_text(encoding="utf-8"), "research primary sources")
         self.assertIs(json.loads(self.state.read_text(encoding="utf-8"))["network"], True)
         self.assertIs(json.loads(result.stdout)["network"], True)
@@ -2651,6 +2655,9 @@ class WorkerEffortDialTests(unittest.TestCase):
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertEqual(argv[argv.index("--effort") + 1], "high")
         self.assertNotIn("--allowedTools", argv)
+        self.assertEqual(
+            argv[argv.index("--disallowedTools") + 1], "WebSearch,WebFetch"
+        )
         payload = json.loads(result.stdout)
         self.assertEqual(payload["effort"], "high")
         self.assertIs(payload["network"], False)
@@ -2675,6 +2682,7 @@ class WorkerEffortDialTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         argv = json.loads(self.arguments.read_text(encoding="utf-8"))
         self.assertEqual(argv[argv.index("--allowedTools") + 1], "WebSearch,WebFetch")
+        self.assertNotIn("--disallowedTools", argv)
         self.assertEqual(self.stdin_capture.read_text(encoding="utf-8"), "continue the research")
         self.assertIs(json.loads(result.stdout)["network"], True)
 
@@ -2703,6 +2711,7 @@ class WorkerEffortDialTests(unittest.TestCase):
                     [
                         "-p", "--model", "sonnet", "--effort", "medium",
                         "--permission-mode", "dontAsk", "--settings", argv[argv.index("--settings") + 1],
+                        "--disallowedTools", "WebSearch,WebFetch",
                         "--session-id", argv[argv.index("--session-id") + 1],
                         "--output-format", "json",
                     ],


### PR DESCRIPTION
## Motivation and Context

Research workers can opt into provider-hosted source access while remaining in the selected filesystem sandbox. Ordinary workers explicitly stay offline, and research stops without a findings artifact when neither hosted tools nor the bounded coordinator fallback can supply primary sources.

* Both worker adapters persist the source-access capability through resume and report its state. The provider mappings live in the two dispatch contracts.
* Claude explicitly denies hosted search and fetch by default, then replaces that deny with an allow on opt-in. Codex adds live hosted search only on opt-in. Neither path enables shell-command networking or wider filesystem access.
* A refused research worker returns one defined result. A terminal, resumable session can receive public unauthenticated sources from a temporary manifest under its own working directory; otherwise research stops visibly.
* The decision and admitted-risk record remains active under `openspec/changes/217-research-worker-network-access/` for post-merge finalization.

Fixes #217

## How Has This Been Tested?

```text
Strict OpenSpec validation:
Change '217-research-worker-network-access' is valid

Structural validation:
validated 27 skills and 374 files

Full repository verification:
Ran 454 tests in 99.489s
OK (skipped=23)

py_compile: no output, exit 0
```

The CLI tests prove default denial, opt-in provider arguments, lifecycle persistence, resume replay, malformed-state rejection, and public output. The live provider retrieval and read-only fallback probes are recorded in the issue's locked work order rather than replayed by the hermetic suite.

Known review residue: adapter behavior is pinned, but the documentation-contract test does not separately assert the new Claude default-deny sentence.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
