### PR TITLE
Make Epic coordination human-operated

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Browse the pack at <https://connorgriffin.github.io/skills/>.
 
 | Skill | Purpose | Extra requirement |
 | --- | --- | --- |
-| [`epic`](skills/drivers/epic/SKILL.md) | Chart a large, foggy effort as a GitHub map of decision tickets, then hand clear subtrees to implementation | GitHub CLI; composes with `research`, `scope`'s interview mode, `ui-craft` |
+| [`epic`](skills/drivers/epic/SKILL.md) | Maintain an OpenSpec epic, file at most three children by default, and stop at an operator-invoked ticket triage handoff | GitHub CLI; composes with `scope`'s interview mode and `ui-craft` |
 | [`implement`](skills/drivers/implement/SKILL.md) | Implement a PRD or issue set via `tdd`, then `code-review`, then commit | `tdd` and `code-review` from this pack |
 | [`openspec-adopt`](skills/drivers/openspec-adopt/SKILL.md) | Initialize the OpenSpec v1 layout and baseline specs describing the system today, delivered as a documentation-only PR | GitHub CLI; global `@fission-ai/openspec@1.11.0` |
 | [`ui-craft`](skills/drivers/ui-craft/SKILL.md) | Full surface lifecycle: revise shipped UI in the running app, lock greenfield specs, build, critique, audit, polish, re-settle | `drive-local-webapp` for rendered review; `spin-worktree` for live base comparison; parallel-agent support is recommended |

--- a/docs/epic-flow.md
+++ b/docs/epic-flow.md
@@ -11,18 +11,21 @@ The primary contracts are [`epic`](../skills/drivers/epic/SKILL.md), [`ticket`](
 
 - **Before merge:** an ordinary ticket keeps its active change and deltas in the pull request for review; it does not fold or archive them.
 - **After merge:** `/ticket finalize` verifies the human merge and CI, follows `operations.archive.guidance`, verifies archive JSON and strict validation, commits and pushes the archive on `main`, then verifies post-push CI before it comments completion or moves the ticket to done.
-- **Epic children:** they create no child change and leave their parent epic's active change and archive ownership untouched.
+- **Epic children:** they create no child change. A required parent-plan amendment is
+  committed in the child worktree and travels with implementation; the parent epic's
+  active change remains the authority and the parent retains archive ownership.
 
 ## The map from idea to merge
 
 1. Start or resume an epic when the effort needs multiple sessions, decisions, spikes, or independently shippable builds.
 2. Record the epic in `openspec/changes/<epic-slug>/`. Its `proposal.md`, `design.md`, and `tasks.md` are authoritative: tasks link child issues in checked implementation sequence, while the tracker keeps their live type, status, dependencies, and deferral.
-3. Keep imprecise concerns as named open questions in `design.md`; record a decision there or promote the question to a spike. File a build only when no open spike or named open question can invalidate its outcome, constraints, or acceptance criteria.
-4. Run `/ticket triage <id>` on each build ticket. Triage grounds the ticket, runs `/scope`, chooses flat or chunked execution, stamps review depth and session fit, and posts one locked work order comment.
-5. Run `/ticket start <id>` in a fresh session. It executes the work order, verifies the result, reviews the change, and opens the pull request.
-6. Run `/ticket revise <id>` once per review round when the open pull request needs changes. It reloads the order, fixes and verifies the round, rebases once, and pushes the same branch.
-7. A human reviews and merges the pull request after green CI and passed review. Agents do not merge, self-approve, or answer reviews outside `revise`.
-8. Run `/ticket finalize <id>` after the human merge. It verifies the post-merge workflow, completes the repository's post-merge archive guidance for an ordinary OpenSpec change, comments the outcome, moves the ticket to done, records measured cost, and tears down the ticket worktree.
+3. Keep imprecise concerns as named open questions in `design.md`; record a decision there or promote the question to a spike. File a build only when no open spike or named open question can invalidate its outcome, constraints, or acceptance criteria. Default to three or fewer child tickets; a fourth or later child requires a `design.md` justification naming the independently shippable boundary or real dependency that prevents consolidation.
+4. Maintain the active plan on one pushed epic planning branch without opening a pull request. Permit only one in-flight child. Put `Parent plan base: <branch name without the origin/ prefix>@<full commit>` in the child issue-body draft, then stop for the operator to run `/ticket triage <id>`.
+5. Ticket triage verifies that the remote parent-plan branch still resolves to the pinned full commit, starts the child worktree from that branch, grounds and reviews the draft, and posts the only locked work order comment. A stale pin posts no lock and returns to the attended epic session.
+6. Run `/ticket start <id>` in a fresh session. It executes the work order, verifies the result, reviews the change, and opens the pull request.
+7. Run `/ticket revise <id>` once per review round when the open pull request needs changes. It reloads the order, fixes and verifies the round, rebases once, and pushes the same branch.
+8. A human reviews and merges the pull request after green CI and passed review. Agents do not merge, self-approve, or answer reviews outside `revise`.
+9. Run `/ticket finalize <id>` after the human merge. It verifies the post-merge workflow, completes the repository's post-merge archive guidance for an ordinary OpenSpec change, comments the outcome, moves the ticket to done, records measured cost, and tears down the ticket worktree. An epic child leaves its parent change active for parent-owned archive.
 
 An epic closes only after its live GitHub state proves that no spike child is open, every build child has a merged closing pull request or is closed `NOT_PLANNED`, and no deferred child remains open; then close the epic issue.
 
@@ -30,13 +33,13 @@ An epic closes only after its live GitHub state proves that no spike child is op
 
 ### File
 
-File a GitHub Issue under the epic when the work is a native child. Use a `spike` child for research, interview, mockup, or a human prerequisite. Use a `build` child for bounded implementation. Actual dependencies use native `blocked-by` edges. A follow-up needed for the epic destination is an in-scope child; work outside the destination can be a deferred native child.
+File a GitHub Issue under the epic when the work is a native child. Use a `spike` child for research, interview, mockup, or a human prerequisite. Use a `build` child for bounded implementation. Default to no more than three children. Before filing a fourth or later child, record the consolidation justification in the active `design.md`. Actual dependencies use native `blocked-by` edges. A follow-up needed for the epic destination is an in-scope child; work outside the destination can be a deferred native child.
 
-The epic home session keeps the active change coherent and stays at planning altitude. `proposal.md`, `design.md`, and `tasks.md` hold durable planning state; live GitHub is authoritative for child work state. Pointer-only notes are deliberately omitted: owning skills and repository rules remain discoverable at their authoritative homes.
+The epic home session keeps the active change coherent and stays at planning altitude. `proposal.md`, `design.md`, and `tasks.md` hold durable planning state; live GitHub is authoritative for child work state. The coordinator writes a draft order and pinned parent-plan base into the issue body, then stops for operator-invoked ticket triage. It never posts the fenced lock, invokes a ticket verb, or opens a pull request. Pointer-only notes are deliberately omitted: owning skills and repository rules remain discoverable at their authoritative homes.
 
 ### Triage
 
-Run `/ticket triage <id>`. The procedure first reads the issue, parent, links, and comments, then cuts or reuses the ticket worktree before grounding in the repository. It reads standing decisions when configured, repository decisions and change records, documentation, recent history, related pull requests, and the judging CI workflows.
+Run `/ticket triage <id>`. For an epic child, triage first fetches the remote and requires the issue draft's unprefixed parent-plan branch to resolve as `origin/<branch>` at the pinned full commit. It passes that branch to `spin-worktree --base`; a mismatch posts nothing and returns to Epic. The procedure then cuts or reuses the ticket worktree before grounding in the repository. It reads standing decisions when configured, repository decisions and change records, documentation, recent history, related pull requests, and the judging CI workflows.
 
 Triage then:
 
@@ -94,46 +97,24 @@ Run `/ticket revise <id>` for one round on an open pull request. It reloads the 
 
 After a human merge, run `/ticket finalize <id>`. It performs the applicable OpenSpec lifecycle above, then records actual session cost and tears down the worktree and branch. The cost verdict can identify a good slice, under-slicing, over-slicing, degraded chunks, degraded coordination, missing data, or unreadable transcripts. Under- or over-slicing produces an amendment proposal for the rubric; the skill does not silently edit the rubric.
 
-## Delegated execution and waves
+## Human handoff and ticket-owned execution
 
-Delegation is explicit and revocable. The home session may take a locked epic subtree when every order is stamped or every needed ruling is settled. A newly opened decision returns that subtree to attended mode. The home session keeps the parent change coherent.
+The epic permits one in-flight child. Every later handoff waits for the prior
+implementation pull request to be human-merged. The attended epic session then
+advances its planning branch from the updated remote default branch, applies the
+next planning update, pushes a new full-commit pin, writes the next issue-body
+draft, and stops for the operator to invoke ticket triage.
 
-Delegated triage uses the existing `/ticket triage` interface. Delegated builds use `/ticket start`. The home session collects worker comments, pull requests, and worktree results; it does not invent a parallel lifecycle.
+Ticket owns all execution after that point. Flat implementation, mandatory review,
+verification, pull-request creation, and any chunk coordination stay inside the
+explicitly invoked ticket workflow. A chunked ticket still ends with one ticket
+branch and one pull request; see
+[`coordinator-mode.md`](../skills/drivers/ticket/references/coordinator-mode.md).
 
-Before each wave, the coordinator:
-
-- Draws a conflict map from queued expected diffs.
-- Verifies the shared checkout equals the current origin default-branch tip.
-- Verifies each target worktree is at or descends from that tip before a build or review dispatch.
-- Writes complete prompts to coordinator-owned session scratch, uses one state file per dispatch, and records a durable result locator.
-
-Read-only drafts and reviews fan out in parallel. Builds use per-issue worktrees. Write-bearing triage and builds serialize only when expected diffs overlap. Chunks that touch a shared surface merge one at a time, rebasing when needed. A chunked ticket still ends with one ticket branch and one pull request.
-
-For a chunked ticket, the ticket branch is the trunk. Each chunk branch starts from that trunk, implements only its independently executable sub-order, is reviewed at its stamped depth, and merges back with `--no-ff`. Parallel chunk worktrees are created together. Serial chunks are created only after the predecessor merges, so they include the dependency. The coordinator verifies each chunk, merges it, removes its chunk worktree, records the change itself after all chunks merge, runs the whole-ticket verification, and reviews the merged diff before opening the one pull request. See [`coordinator-mode.md`](../skills/drivers/ticket/references/coordinator-mode.md).
-
-All delegated results are verified by the coordinator. A failed result gets one same-session retry. Under a Claude parent, a second failure escalates one tier along the selected ladder; at the top, the failure is surfaced. A Codex UI parent's v0 route stops with `NO_VALIDATED_ROUTE` after the same-session retry. There are no unbounded retries, tier skips, or silent route changes.
-
-## Roles and model routing
-
-Roles describe the work, and the routing table selects a model for that area. The table is benchmarked as of 2026-08-03 and says to re-benchmark when a new model ships. It gives these initial routes and ladders:
-
-| Work area | Initial route | Escalation ladder |
-| --- | --- | --- |
-| Exploration or codebase mapping | Luna for bounded lookups, Sonnet for full-system maps | Luna, Sonnet, Opus |
-| Hermetic implementation | Terra | Terra, Sonnet, Opus |
-| Plan or spec writing | Terra | Terra, Sol, Opus |
-| Prototyping, including UI mockups | Sol | Sol, Opus, none |
-| Novel-solution brainstorming | Terra, or Opus when novelty is the deliverable | Terra, Opus, none |
-| Documentation writing | Haiku, with Luna as an equal-scored alternate | Haiku, Opus, Sol |
-| Code review | Luna for routine PRs, Opus for load-bearing or safety review | Luna, Sonnet, Opus, or Opus directly for load-bearing |
-
-The table's bans and qualifications also apply. Never delegate to Fable. Luna is banned for UI mockups. Haiku is not used for exploration whose citations will not be independently verified, and Haiku never reviews. GPT-5.5, GPT-5.4, and GPT-5.4-Mini are light-pass plan or review probes only where the table explicitly permits them; GPT-5.4 is a viable plan alternate, while GPT-5.4-Mini is not a review choice.
-
-Review routing has its own precedence. With a work order, Focused and Targeted are routine and Full is load-bearing. Without one, the sensitivity floor judges the stakes. `code-review` uses Luna with usable Codex for routine review, then Claude-only Sonnet when Codex is absent, unknown, at 5% or less headroom, or rate-limited. Load-bearing `code-review` uses Opus directly. `plan-review` uses Terra with usable Codex for routine review, then Claude-only Opus on absent, unknown, low-headroom, or rate-limited Codex. Load-bearing `plan-review` uses Opus directly. Reviewer selection never comes from the builder tier and never borrows a fallback from another row. See [`review-routing.md`](../skills/drivers/orchestrate/references/review-routing.md).
-
-The Codex headroom gate runs when `/orchestrate` is invoked. A Claude parent checks for both CLIs, probes Codex with a Luna read-only run, and enters Claude-only mode when headroom is unknown, at most 5%, or the probe is rate-limited. A Codex UI parent stops dispatching in that condition and does not switch to Claude workers. If neither CLI exists, the coordinator cannot dispatch. Claude-only routing uses the Claude rungs in each applicable row.
-
-Every delegation names the selected adapter, model, and effort. Dispatch goes through the pack's `claude-worker.py` or `codex-worker.py`, never the built-in Agent tool, Workflow tool, or background-agent machinery. Both adapters default effort to `medium`, and the coordinator may set the effort explicitly. The routing table's Codex benchmark used medium effort; no per-model default is treated as a benchmark result. These rules are the accepted decision in [`adr-149-pack-owned-model-dispatch.md`](adr/adr-149-pack-owned-model-dispatch.md).
+The epic coordinator never opens a pull request, and planning-only pull requests
+are unsupported. If triage must amend the parent plan, it commits that amendment in
+the child worktree so the planning artifacts travel with the implementation pull
+request. Finalize leaves the parent change active for the epic's archive guidance.
 
 ## Load-bearing rules
 
@@ -158,16 +139,21 @@ The operator types `/epic` to open or resume an epic, files or answers tracked i
 - `/ticket revise <id>` handles one review round.
 - `/ticket finalize <id>` closes the loop after human merge.
 
-The operator may explicitly say to delegate a settled epic subtree. The operator also supplies decisions that `/scope` identifies as human-only and reviews and merges pull requests.
-
-The procedures automatically claim sessions, cut or reuse worktrees, bind graph identity, read and post through the tracker contract, move ticket labels, run mandatory plan and code review dispatches, verify worker results, create chunk waves, write and collect adapter state, run verification commands, open pull requests, and record finalize actuals. Those actions remain subject to visible failure reporting. A failed status move is non-fatal and is not retried. A tracker, authentication, or Git failure stops the operation that needs it.
+The operator invokes every ticket verb, supplies decisions that `/scope` identifies
+as human-only, and reviews and merges pull requests. Epic writes each issue-body
+draft and stops. Ticket sessions claim themselves, cut or reuse worktrees, bind graph
+identity, enforce the fenced lock, run mandatory plan and code review, verify the
+change, and open the implementation pull request. A failed status move is non-fatal
+and is not retried. A tracker, authentication, or Git failure stops the operation
+that needs it.
 
 ## Where to look when something is off
 
 - Read the active change's proposal, design, and tasks for planning context, then check live GitHub for child work state.
 - The ticket's issue comments contain the newest work order, amendments, and session fit. If no order is found, return to `/ticket triage <id>`.
 - The pull request contains the implementation evidence, verification output, review conversation, and known residue. Use `/ticket revise <id>` for an open pull request, not manual patching in the control checkout.
-- A silent or unfinished delegated worker is diagnosed from its named adapter state, launcher stdout, worktree or branch, or posted comment. Use the adapter's scoped `verify`; do not search for or stop unknown processes.
+- If an attended child session fails, leave the child open, inspect its ticket or
+  pull-request result, and let the operator explicitly resume the applicable verb.
 - A stale or overlapping target is a preflight failure. Refresh from the origin default-branch tip and re-triage when the order no longer matches the tree.
 - A model or effort mismatch is a launch failure. Compare the session's actual model and confirmed effort to the stamped `Session fit` or `Open as` line.
 - A review dispute is resolved against the order's `Done when` clause, the stamped depth, and the cited repository rule. Reopen scope only when evidence changes a settled risk assumption.

--- a/openspec/changes/241-epic-human-dispatch-slicing/design.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/design.md
@@ -39,12 +39,11 @@ existing `--base` input. A mismatch means the child draft is stale: triage posts
 nothing and returns to the attended epic session for a refreshed draft. No new
 parser or worktree helper interface is required.
 
-When child triage commits a parent-plan amendment, the epic refuses to hand off any
-later child until the amendment-bearing implementation pull request is human-merged.
-It then advances the epic planning branch from the updated remote default-branch tip,
-records any next planning update, and pins a new commit. Parent-plan amendments
-therefore serialize at the merge boundary; children whose locked work requires no
-parent-plan amendment may otherwise overlap when their expected diffs do not conflict.
+The epic permits only one in-flight child. It refuses every later child handoff until
+the prior child's implementation pull request is human-merged, then advances the
+epic planning branch from the updated remote default-branch tip, records any next
+planning update, and pins a new commit. This uniform serial rule avoids a second
+tracker marker whose only purpose would be distinguishing amendment-bearing children.
 
 ## ADR 241 — Prefer three or fewer independently shippable children
 

--- a/openspec/changes/241-epic-human-dispatch-slicing/design.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/design.md
@@ -1,0 +1,41 @@
+# Design
+
+## ADR 241 — Epic coordination ends before execution
+
+An epic coordinator owns the durable plan and the bounded child work orders. The
+operator owns dispatch: each child proceeds only when the operator explicitly runs
+the applicable ticket verb. The epic skill therefore has no worker-adapter,
+delegated-subtree, fan-out, liveness, retry, or result-collection path, including
+for research spikes.
+
+This keeps the authority split shallow: OpenSpec owns the epic plan, ticket comments
+own executable child orders, GitHub owns live child state, and attended ticket
+sessions own implementation and review. Ticket's mandatory independent review is
+unchanged because it is part of a child invocation, not an epic-owned dispatch.
+
+### Consequences
+
+- The coordinator may prepare and post a child work order, but it does not invoke
+  `/ticket triage`, `/ticket start`, `/ticket revise`, or a worker adapter.
+- Research, prototype, interview, and build children are resumed in attended
+  sessions by the operator; the epic records their returned decisions and status.
+- Existing dispatch ADRs remain frozen history. The active epic contract no longer
+  names `epic` as a dispatching consumer.
+
+## ADR 241 — Prefer three or fewer independently shippable children
+
+An epic defaults to at most three child tickets. Creating a fourth or later child
+requires a written `design.md` justification that names the capability boundary or
+dependency preventing consolidation into fewer, larger independently shippable
+builds. The count is a planning admission check, not an execution-time guard.
+
+## ADR 241 — Planning artifacts ship with implementation
+
+An epic coordinator never opens a pull request. Proposal, design, tasks, and delta
+spec changes remain in the active change until an implementation ticket includes
+the applicable planning updates in its pull request. A pull request containing only
+epic planning artifacts is unsupported.
+
+The separate one-time `openspec-adopt` workflow is outside this decision: its
+documentation-only pull request establishes OpenSpec before an epic exists and is
+not an epic planning-only pull request.

--- a/openspec/changes/241-epic-human-dispatch-slicing/design.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/design.md
@@ -24,6 +24,25 @@ unchanged because it is part of a child invocation, not an epic-owned dispatch.
 - Existing dispatch ADRs remain frozen history. The active epic contract no longer
   names `epic` as a dispatching consumer.
 
+## ADR 241 — Child work is based on an immutable parent-plan commit
+
+The attended epic session maintains its active change on one remote epic planning
+branch but opens no pull request for that branch. Before handing off a child, it
+commits and pushes the current plan, then records `Parent plan base: <remote
+branch>@<full commit>` in the child issue's draft order.
+
+Ticket triage fetches the remote, requires the named remote branch still to resolve
+to the pinned full commit, and passes the branch name through spin-worktree's
+existing `--base` input. A mismatch means the child draft is stale: triage posts
+nothing and returns to the attended epic session for a refreshed draft. No new
+parser or worktree helper interface is required.
+
+The first merged implementation makes the parent active change visible on the
+default branch. Before a later child starts, the epic planning branch incorporates
+the latest default-branch tip, records any next planning update, and pins a new
+commit. Parent-plan edits therefore serialize at the handoff boundary even when
+child implementations whose pinned plans do not conflict can otherwise overlap.
+
 ## ADR 241 — Prefer three or fewer independently shippable children
 
 An epic defaults to at most three child tickets. Creating a fourth or later child

--- a/openspec/changes/241-epic-human-dispatch-slicing/design.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/design.md
@@ -39,11 +39,12 @@ existing `--base` input. A mismatch means the child draft is stale: triage posts
 nothing and returns to the attended epic session for a refreshed draft. No new
 parser or worktree helper interface is required.
 
-The first merged implementation makes the parent active change visible on the
-default branch. Before a later child starts, the epic planning branch incorporates
-the latest default-branch tip, records any next planning update, and pins a new
-commit. Parent-plan edits therefore serialize at the handoff boundary even when
-child implementations whose pinned plans do not conflict can otherwise overlap.
+When child triage commits a parent-plan amendment, the epic refuses to hand off any
+later child until the amendment-bearing implementation pull request is human-merged.
+It then advances the epic planning branch from the updated remote default-branch tip,
+records any next planning update, and pins a new commit. Parent-plan amendments
+therefore serialize at the merge boundary; children whose locked work requires no
+parent-plan amendment may otherwise overlap when their expected diffs do not conflict.
 
 ## ADR 241 — Prefer three or fewer independently shippable children
 

--- a/openspec/changes/241-epic-human-dispatch-slicing/design.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/design.md
@@ -29,10 +29,12 @@ unchanged because it is part of a child invocation, not an epic-owned dispatch.
 The attended epic session maintains its active change on one remote epic planning
 branch but opens no pull request for that branch. Before handing off a child, it
 commits and pushes the current plan, then records `Parent plan base: <remote
-branch>@<full commit>` in the child issue's draft order.
+branch name without the origin/ prefix>@<full commit>` in the child issue's draft
+order, for example `epic/218-vanilla-openspec@0123456789abcdef0123456789abcdef01234567`.
 
-Ticket triage fetches the remote, requires the named remote branch still to resolve
-to the pinned full commit, and passes the branch name through spin-worktree's
+Ticket triage fetches the remote, resolves the field's branch name exclusively as
+`origin/<branch name>`, requires it still to resolve to the pinned full commit, and passes
+that same unprefixed branch name through spin-worktree's
 existing `--base` input. A mismatch means the child draft is stale: triage posts
 nothing and returns to the attended epic session for a refreshed draft. No new
 parser or worktree helper interface is required.

--- a/openspec/changes/241-epic-human-dispatch-slicing/design.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/design.md
@@ -2,11 +2,12 @@
 
 ## ADR 241 — Epic coordination ends before execution
 
-An epic coordinator owns the durable plan and the bounded child work orders. The
-operator owns dispatch: each child proceeds only when the operator explicitly runs
-the applicable ticket verb. The epic skill therefore has no worker-adapter,
-delegated-subtree, fan-out, liveness, retry, or result-collection path, including
-for research spikes.
+An epic coordinator owns the durable plan and writes a draft order into each bounded
+child issue. The operator owns the lock and dispatch: `/ticket triage <id>` grounds
+and independently reviews that draft before posting the only executable fenced work
+order, and each later phase proceeds only when the operator explicitly invokes its
+ticket verb. The epic skill therefore has no worker-adapter, delegated-subtree,
+fan-out, liveness, retry, or result-collection path, including for research spikes.
 
 This keeps the authority split shallow: OpenSpec owns the epic plan, ticket comments
 own executable child orders, GitHub owns live child state, and attended ticket
@@ -15,8 +16,9 @@ unchanged because it is part of a child invocation, not an epic-owned dispatch.
 
 ### Consequences
 
-- The coordinator may prepare and post a child work order, but it does not invoke
-  `/ticket triage`, `/ticket start`, `/ticket revise`, or a worker adapter.
+- The coordinator writes the draft order in the child issue body, but does not post
+  the fenced executable lock or invoke `/ticket triage`, `/ticket start`, `/ticket
+  revise`, or a worker adapter.
 - Research, prototype, interview, and build children are resumed in attended
   sessions by the operator; the epic records their returned decisions and status.
 - Existing dispatch ADRs remain frozen history. The active epic contract no longer
@@ -31,10 +33,16 @@ builds. The count is a planning admission check, not an execution-time guard.
 
 ## ADR 241 — Planning artifacts ship with implementation
 
-An epic coordinator never opens a pull request. Proposal, design, tasks, and delta
-spec changes remain in the active change until an implementation ticket includes
-the applicable planning updates in its pull request. A pull request containing only
+An epic coordinator never opens a pull request. When ticket triage discovers that
+the parent plan must change before a child can execute, it amends the parent active
+change in that child's existing worktree, commits the amendment there, and continues
+triage. The child implementation pull request therefore carries both the required
+planning update and the implementation it governs. A pull request containing only
 epic planning artifacts is unsupported.
+
+This is not a per-child change record: the parent proposal/design/tasks/spec delta
+remains the one authority and archive unit. Ticket finalization still leaves archive
+ownership with the parent epic.
 
 The separate one-time `openspec-adopt` workflow is outside this decision: its
 documentation-only pull request establishes OpenSpec before an epic exists and is

--- a/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
@@ -16,6 +16,9 @@ children and two planning pull requests.
 - The operator invokes ticket triage to ground, independently review, and post that
   draft as the only executable work-order lock. A required parent-plan amendment
   stays on the child branch and ships with its implementation.
+- The epic records and pushes an immutable parent-plan branch/commit in every child
+  draft. Fresh child work starts from that remote branch only after it still resolves
+  to the pinned commit; a stale pin returns to the attended epic session.
 - Require the operator to invoke each child ticket's execution explicitly.
 - Default to no more than three child tickets. Four or more children require a
   written justification in the epic change's `design.md` explaining why fewer,
@@ -37,7 +40,7 @@ children and two planning pull requests.
   pull requests. Mandatory independent review inside an explicitly invoked ticket
   remains governed by the ticket workflow and is not epic dispatch.
 - **Evidence owed:** contract tests prove the epic and ticket skills contain the
-  human-dispatch, draft-to-lock handoff, parent-plan carrier, slicing-cap, and
+  human-dispatch, draft-to-lock handoff, pinned parent-plan base, parent-plan carrier, slicing-cap, and
   planning-PR rules and contain no epic-owned adapter, delegated execution, wave,
   or worker-lifecycle path; public docs and agent metadata are covered too; the
   repository's structural and unit gates pass.

--- a/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
@@ -1,0 +1,39 @@
+# Human-operated epics
+
+## Why
+
+The epic coordinator can currently dispatch ticket workers, run research workers,
+and coordinate execution waves. In practice that nested an epic coordinator over
+ticket coordination, opened an unrequested planning-only pull request during
+triage, and split a small set of overlapping documentation changes into eight
+children and two planning pull requests.
+
+## What changes
+
+- Keep the epic coordinator at planning altitude: it maintains the OpenSpec change,
+  records decisions, files bounded child issues, and writes their work orders, but
+  never dispatches workers, runs a ticket, or opens a pull request.
+- Require the operator to invoke each child ticket's execution explicitly.
+- Default to no more than three child tickets. Four or more children require a
+  written justification in the epic change's `design.md` explaining why fewer,
+  larger independently shippable builds do not fit.
+- Ban pull requests that contain only epic planning artifacts. Planning records
+  travel with the implementation pull request that realizes them.
+
+## Risk contract
+
+- **Must prevent:** an epic coordinator dispatching or terminating worker sessions,
+  executing child tickets, opening pull requests, silently creating four or more
+  child tickets without a recorded justification, or routing planning artifacts
+  into a planning-only pull request.
+- **Must recover:** none; the workflow stops for the operator before execution or
+  pull-request creation.
+- **Accepted failure:** an attended epic may pause while it waits for the operator
+  to run a child ticket or merge an implementation pull request.
+- **Unsupported:** automatic epic execution, background waves, and planning-only
+  pull requests. Mandatory independent review inside an explicitly invoked ticket
+  remains governed by the ticket workflow and is not epic dispatch.
+- **Evidence owed:** contract tests prove the epic skill contains the human-dispatch,
+  slicing-cap, and planning-PR rules and contains no epic-owned adapter, delegated
+  execution, wave, or worker-lifecycle path; the repository's structural and unit
+  gates pass.

--- a/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
@@ -19,6 +19,9 @@ children and two planning pull requests.
 - The epic records and pushes an immutable parent-plan branch/commit in every child
   draft. Fresh child work starts from that remote branch only after it still resolves
   to the pinned commit; a stale pin returns to the attended epic session.
+- Only one epic child may be in flight. The next child is handed off only after the
+  prior child's implementation pull request is human-merged and the epic planning
+  branch advances from the updated remote default branch.
 - Require the operator to invoke each child ticket's execution explicitly.
 - Default to no more than three child tickets. Four or more children require a
   written justification in the epic change's `design.md` explaining why fewer,
@@ -36,9 +39,10 @@ children and two planning pull requests.
   pull-request creation.
 - **Accepted failure:** an attended epic may pause while it waits for the operator
   to run a child ticket or merge an implementation pull request.
-- **Unsupported:** automatic epic execution, background waves, and planning-only
-  pull requests. Mandatory independent review inside an explicitly invoked ticket
-  remains governed by the ticket workflow and is not epic dispatch.
+- **Unsupported:** automatic epic execution, background waves, concurrent in-flight
+  epic children, and planning-only pull requests. Mandatory independent review
+  inside an explicitly invoked ticket remains governed by the ticket workflow and
+  is not epic dispatch.
 - **Evidence owed:** contract tests prove the epic and ticket skills contain the
   human-dispatch, draft-to-lock handoff, pinned parent-plan base, parent-plan carrier, slicing-cap, and
   planning-PR rules and contain no epic-owned adapter, delegated execution, wave,

--- a/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/proposal.md
@@ -11,8 +11,11 @@ children and two planning pull requests.
 ## What changes
 
 - Keep the epic coordinator at planning altitude: it maintains the OpenSpec change,
-  records decisions, files bounded child issues, and writes their work orders, but
-  never dispatches workers, runs a ticket, or opens a pull request.
+  records decisions, files bounded child issues, and writes a draft order into each
+  child issue, but never dispatches workers, runs a ticket, or opens a pull request.
+- The operator invokes ticket triage to ground, independently review, and post that
+  draft as the only executable work-order lock. A required parent-plan amendment
+  stays on the child branch and ships with its implementation.
 - Require the operator to invoke each child ticket's execution explicitly.
 - Default to no more than three child tickets. Four or more children require a
   written justification in the epic change's `design.md` explaining why fewer,
@@ -23,9 +26,9 @@ children and two planning pull requests.
 ## Risk contract
 
 - **Must prevent:** an epic coordinator dispatching or terminating worker sessions,
-  executing child tickets, opening pull requests, silently creating four or more
-  child tickets without a recorded justification, or routing planning artifacts
-  into a planning-only pull request.
+  executing child tickets, posting an executable work-order lock, opening pull
+  requests, silently creating four or more child tickets without a recorded
+  justification, or routing planning artifacts into a planning-only pull request.
 - **Must recover:** none; the workflow stops for the operator before execution or
   pull-request creation.
 - **Accepted failure:** an attended epic may pause while it waits for the operator
@@ -33,7 +36,8 @@ children and two planning pull requests.
 - **Unsupported:** automatic epic execution, background waves, and planning-only
   pull requests. Mandatory independent review inside an explicitly invoked ticket
   remains governed by the ticket workflow and is not epic dispatch.
-- **Evidence owed:** contract tests prove the epic skill contains the human-dispatch,
-  slicing-cap, and planning-PR rules and contains no epic-owned adapter, delegated
-  execution, wave, or worker-lifecycle path; the repository's structural and unit
-  gates pass.
+- **Evidence owed:** contract tests prove the epic and ticket skills contain the
+  human-dispatch, draft-to-lock handoff, parent-plan carrier, slicing-cap, and
+  planning-PR rules and contain no epic-owned adapter, delegated execution, wave,
+  or worker-lifecycle path; public docs and agent metadata are covered too; the
+  repository's structural and unit gates pass.

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
@@ -14,6 +14,18 @@ invoke each later child ticket phase that proceeds to attended work.
 - **WHEN** the epic has settled a child's decisions and written its draft order in the issue
 - **THEN** the coordinator stops for the operator to invoke ticket triage instead of posting the lock or invoking a worker adapter
 
+### Requirement: Epic child drafts pin their parent-plan base
+
+Before handing a child to the operator, an epic coordinator MUST commit and push
+the current active plan on the epic planning branch and record the remote branch
+plus full commit in the child issue draft. The epic coordinator MUST NOT open a
+pull request for the planning branch.
+
+#### Scenario: A child draft is handed to the operator
+
+- **WHEN** the epic has finished the child's draft order
+- **THEN** the draft identifies the pushed remote parent-plan branch and the full commit it must still resolve to
+
 ### Requirement: Epic slicing defaults to three or fewer children
 
 An epic MUST default to no more than three child tickets. Before creating a fourth

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
@@ -3,14 +3,16 @@
 ### Requirement: Epic dispatch remains human-operated
 
 An epic coordinator MUST maintain the active OpenSpec plan, record decisions,
-file bounded children, and write child work orders without dispatching workers,
-running ticket verbs, or opening pull requests. The operator MUST explicitly invoke
-each child ticket that proceeds to attended work.
+file bounded children, and write a draft order into each child issue without
+dispatching workers, running ticket verbs, posting the executable work-order lock,
+or opening pull requests. The operator MUST invoke ticket triage to ground and
+independently review the draft before it becomes the fenced lock, and MUST explicitly
+invoke each later child ticket phase that proceeds to attended work.
 
 #### Scenario: A child work order is ready
 
-- **WHEN** the epic has settled a child's decisions and written its bounded work order
-- **THEN** the coordinator stops for the operator instead of invoking the ticket or a worker adapter
+- **WHEN** the epic has settled a child's decisions and written its draft order in the issue
+- **THEN** the coordinator stops for the operator to invoke ticket triage instead of posting the lock or invoking a worker adapter
 
 ### Requirement: Epic slicing defaults to three or fewer children
 
@@ -26,8 +28,9 @@ or later child, the coordinator MUST record a justification in the active change
 ### Requirement: Epic planning artifacts ship with implementation
 
 An epic coordinator MUST NOT open a pull request containing only epic planning
-artifacts. Applicable proposal, design, tasks, and delta-spec updates MUST travel
-with an implementation pull request that realizes them.
+artifacts. When ticket triage requires a parent-plan amendment, it MUST commit that
+amendment in the child's ticket worktree and the resulting planning updates MUST
+travel with the implementation pull request that realizes them.
 
 #### Scenario: Planning changes are ready but implementation has not run
 

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
@@ -26,10 +26,15 @@ pull request for the planning branch.
 - **WHEN** the epic has finished the child's draft order
 - **THEN** the draft identifies the pushed parent-plan branch name without an `origin/` prefix and the full commit it must still resolve to
 
-#### Scenario: A child carries a parent-plan amendment
+#### Scenario: A child is already in flight
 
-- **WHEN** child triage commits a required parent-plan amendment in that child's worktree
-- **THEN** the epic refuses every later child handoff until the amendment-bearing implementation pull request is human-merged and the planning branch advances from the updated remote default branch
+- **WHEN** a child implementation pull request has not yet been human-merged
+- **THEN** the epic refuses every later child handoff
+
+#### Scenario: The next child becomes eligible for handoff
+
+- **WHEN** the prior child implementation pull request is human-merged
+- **THEN** the epic advances its planning branch from the updated remote default branch, records any next planning update, and pins a new commit before handing off the next child
 
 ### Requirement: Epic slicing defaults to three or fewer children
 

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Epic dispatch remains human-operated
+
+An epic coordinator MUST maintain the active OpenSpec plan, record decisions,
+file bounded children, and write child work orders without dispatching workers,
+running ticket verbs, or opening pull requests. The operator MUST explicitly invoke
+each child ticket that proceeds to attended work.
+
+#### Scenario: A child work order is ready
+
+- **WHEN** the epic has settled a child's decisions and written its bounded work order
+- **THEN** the coordinator stops for the operator instead of invoking the ticket or a worker adapter
+
+### Requirement: Epic slicing defaults to three or fewer children
+
+An epic MUST default to no more than three child tickets. Before creating a fourth
+or later child, the coordinator MUST record a justification in the active change's
+`design.md` that explains why fewer, larger independently shippable builds do not fit.
+
+#### Scenario: A proposed epic has four child tickets
+
+- **WHEN** the coordinator cannot consolidate the proposed work into three independently shippable children
+- **THEN** it records the capability boundary or dependency that requires the additional child before filing it
+
+### Requirement: Epic planning artifacts ship with implementation
+
+An epic coordinator MUST NOT open a pull request containing only epic planning
+artifacts. Applicable proposal, design, tasks, and delta-spec updates MUST travel
+with an implementation pull request that realizes them.
+
+#### Scenario: Planning changes are ready but implementation has not run
+
+- **WHEN** the epic's planning artifacts have changed and no child implementation is ready
+- **THEN** the coordinator keeps the change active and waits rather than opening a planning-only pull request

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
@@ -26,6 +26,11 @@ pull request for the planning branch.
 - **WHEN** the epic has finished the child's draft order
 - **THEN** the draft identifies the pushed parent-plan branch name without an `origin/` prefix and the full commit it must still resolve to
 
+#### Scenario: A child carries a parent-plan amendment
+
+- **WHEN** child triage commits a required parent-plan amendment in that child's worktree
+- **THEN** the epic refuses every later child handoff until the amendment-bearing implementation pull request is human-merged and the planning branch advances from the updated remote default branch
+
 ### Requirement: Epic slicing defaults to three or fewer children
 
 An epic MUST default to no more than three child tickets. Before creating a fourth

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/planning-and-review/spec.md
@@ -18,13 +18,13 @@ invoke each later child ticket phase that proceeds to attended work.
 
 Before handing a child to the operator, an epic coordinator MUST commit and push
 the current active plan on the epic planning branch and record the remote branch
-plus full commit in the child issue draft. The epic coordinator MUST NOT open a
+name without an `origin/` prefix plus full commit in the child issue draft. The epic coordinator MUST NOT open a
 pull request for the planning branch.
 
 #### Scenario: A child draft is handed to the operator
 
 - **WHEN** the epic has finished the child's draft order
-- **THEN** the draft identifies the pushed remote parent-plan branch and the full commit it must still resolve to
+- **THEN** the draft identifies the pushed parent-plan branch name without an `origin/` prefix and the full commit it must still resolve to
 
 ### Requirement: Epic slicing defaults to three or fewer children
 

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
@@ -4,7 +4,9 @@
 
 An epic child's ticket triage MUST treat the issue body's epic-authored order as a
 draft, ground and independently review it through the ordinary triage procedure,
-and post the resulting fenced work order as the only execution lock. When the draft
+fetch the named remote parent-plan branch, and require that branch to resolve to the
+full commit pinned in the draft before cutting the child worktree from that branch.
+It MUST post the resulting fenced work order as the only execution lock. When the draft
 requires an amendment to the parent epic's active OpenSpec change, triage MUST commit
 that amendment in the child's ticket worktree and continue; it MUST NOT open or
 require a separate planning-only pull request.
@@ -16,8 +18,13 @@ require a separate planning-only pull request.
 
 #### Scenario: An epic-authored child draft is ready for locking
 
-- **WHEN** the operator invokes ticket triage on an epic child whose issue contains a draft order
-- **THEN** triage grounds and reviews the draft before posting the only fenced executable work order
+- **WHEN** the operator invokes ticket triage on an epic child whose issue contains a draft order and a parent-plan branch/commit pin
+- **THEN** triage verifies the fetched branch resolves to the pinned commit, cuts the child worktree from that branch, and grounds and reviews the draft before posting the only fenced executable work order
+
+#### Scenario: The pinned parent-plan branch advanced
+
+- **WHEN** the fetched remote parent-plan branch no longer resolves to the commit pinned in the child draft
+- **THEN** triage posts nothing and returns the stale draft to the attended epic session for refresh
 
 ### Requirement: Epic child implementation preserves the parent archive owner
 

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
@@ -38,7 +38,7 @@ authority and archive owner.
 - **WHEN** the child's implementation is ready after triage amended the parent plan
 - **THEN** the pull request includes that parent-plan amendment with the implementation and leaves the active change unarchived
 
-#### Scenario: Another child is ready while a parent-plan amendment is unmerged
+#### Scenario: Another child is ready while the prior child is unmerged
 
-- **WHEN** a prior child pull request carries a parent-plan amendment and is not yet human-merged
-- **THEN** the epic refuses the later child handoff rather than pinning a plan that omits the amendment
+- **WHEN** a prior child implementation pull request is not yet human-merged
+- **THEN** the epic refuses the later child handoff regardless of whether the prior child amended the parent plan

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Epic child triage carries required parent-plan amendments
+
+An epic child's ticket triage MUST treat the issue body's epic-authored order as a
+draft, ground and independently review it through the ordinary triage procedure,
+and post the resulting fenced work order as the only execution lock. When the draft
+requires an amendment to the parent epic's active OpenSpec change, triage MUST commit
+that amendment in the child's ticket worktree and continue; it MUST NOT open or
+require a separate planning-only pull request.
+
+#### Scenario: A child draft requires a parent design clarification
+
+- **WHEN** ticket triage verifies that the child cannot execute until the parent design is amended
+- **THEN** it commits the amendment in the child worktree, includes it in the independently reviewed lock, and leaves it for the child's implementation pull request
+
+#### Scenario: An epic-authored child draft is ready for locking
+
+- **WHEN** the operator invokes ticket triage on an epic child whose issue contains a draft order
+- **THEN** triage grounds and reviews the draft before posting the only fenced executable work order
+
+### Requirement: Epic child implementation preserves the parent archive owner
+
+An epic child MAY carry updates to its parent's active OpenSpec change when those
+updates are required by that child's implementation. It MUST NOT create a per-child
+change record or archive the parent change; the parent epic remains the single change
+authority and archive owner.
+
+#### Scenario: A child pull request carries its parent-plan amendment
+
+- **WHEN** the child's implementation is ready after triage amended the parent plan
+- **THEN** the pull request includes that parent-plan amendment with the implementation and leaves the active change unarchived

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
@@ -37,3 +37,8 @@ authority and archive owner.
 
 - **WHEN** the child's implementation is ready after triage amended the parent plan
 - **THEN** the pull request includes that parent-plan amendment with the implementation and leaves the active change unarchived
+
+#### Scenario: Another child is ready while a parent-plan amendment is unmerged
+
+- **WHEN** a prior child pull request carries a parent-plan amendment and is not yet human-merged
+- **THEN** the epic refuses the later child handoff rather than pinning a plan that omits the amendment

--- a/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/specs/ticket-workflow/spec.md
@@ -4,7 +4,7 @@
 
 An epic child's ticket triage MUST treat the issue body's epic-authored order as a
 draft, ground and independently review it through the ordinary triage procedure,
-fetch the named remote parent-plan branch, and require that branch to resolve to the
+fetch the named parent-plan branch as `origin/<branch name>`, and require that branch to resolve to the
 full commit pinned in the draft before cutting the child worktree from that branch.
 It MUST post the resulting fenced work order as the only execution lock. When the draft
 requires an amendment to the parent epic's active OpenSpec change, triage MUST commit
@@ -19,7 +19,7 @@ require a separate planning-only pull request.
 #### Scenario: An epic-authored child draft is ready for locking
 
 - **WHEN** the operator invokes ticket triage on an epic child whose issue contains a draft order and a parent-plan branch/commit pin
-- **THEN** triage verifies the fetched branch resolves to the pinned commit, cuts the child worktree from that branch, and grounds and reviews the draft before posting the only fenced executable work order
+- **THEN** triage resolves the unprefixed branch name as `origin/<branch name>`, verifies it resolves to the pinned commit, passes the same unprefixed name to `--base`, and grounds and reviews the draft before posting the only fenced executable work order
 
 #### Scenario: The pinned parent-plan branch advanced
 

--- a/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
@@ -2,12 +2,16 @@
 
 - [ ] Replace epic-owned delegated execution, research-worker dispatch, wave, and
   adapter lifecycle prose with a human-dispatch boundary and attended child flow.
+- [ ] Define the child issue's draft order → operator-invoked ticket triage → fenced
+  executable lock handoff without adding a second execution entry.
 - [ ] Add the three-child default and require a `design.md` justification before
   filing a fourth or later child.
 - [ ] State that epic planning artifacts ship with implementation and that the
   coordinator never opens a planning-only pull request.
+- [ ] Replace ticket's docs-only epic-amendment prerequisite with a parent-change
+  amendment committed in the child worktree and carried by implementation.
 - [ ] Align the operator guide, README summary, and Epic agent metadata with the
   new boundary.
 - [ ] Replace dispatch-presence tests with regression tests for the new rules and
-  removal of epic-owned dispatch paths.
+  removal of epic-owned dispatch paths across skill, guide, README, and metadata.
 - [ ] Run `python3 scripts/validate.py && python3 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco tests.test_ci_changed_paths tests.test_site_build && python3 -m py_compile skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py skills/drivers/orchestrate/scripts/worker_lifecycle.py skills/drivers/orchestrate/scripts/codex-worker.py skills/drivers/orchestrate/scripts/claude-worker.py`.

--- a/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
@@ -1,21 +1,21 @@
 # Tasks
 
-- [ ] Replace epic-owned delegated execution, research-worker dispatch, wave, and
+- [x] Replace epic-owned delegated execution, research-worker dispatch, wave, and
   adapter lifecycle prose with a human-dispatch boundary and attended child flow.
-- [ ] Define the child issue's draft order → operator-invoked ticket triage → fenced
+- [x] Define the child issue's draft order → operator-invoked ticket triage → fenced
   executable lock handoff without adding a second execution entry.
-- [ ] Pin each child draft to a pushed remote epic-plan branch/commit and make
+- [x] Pin each child draft to a pushed remote epic-plan branch/commit and make
   ticket triage fail closed when that branch no longer resolves to the pinned commit.
-- [ ] Permit only one in-flight epic child; require human merge and planning-branch
+- [x] Permit only one in-flight epic child; require human merge and planning-branch
   advancement from the updated default branch before handing off the next child.
-- [ ] Add the three-child default and require a `design.md` justification before
+- [x] Add the three-child default and require a `design.md` justification before
   filing a fourth or later child.
-- [ ] State that epic planning artifacts ship with implementation and that the
+- [x] State that epic planning artifacts ship with implementation and that the
   coordinator never opens a planning-only pull request.
-- [ ] Replace ticket's docs-only epic-amendment prerequisite with a parent-change
+- [x] Replace ticket's docs-only epic-amendment prerequisite with a parent-change
   amendment committed in the child worktree and carried by implementation.
-- [ ] Align the operator guide, README summary, and Epic agent metadata with the
+- [x] Align the operator guide, README summary, and Epic agent metadata with the
   new boundary.
-- [ ] Replace dispatch-presence tests with regression tests for the new rules and
+- [x] Replace dispatch-presence tests with regression tests for the new rules and
   removal of epic-owned dispatch paths across skill, guide, README, and metadata.
-- [ ] Run `python3 scripts/validate.py && python3 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco tests.test_ci_changed_paths tests.test_site_build && python3 -m py_compile skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py skills/drivers/orchestrate/scripts/worker_lifecycle.py skills/drivers/orchestrate/scripts/codex-worker.py skills/drivers/orchestrate/scripts/claude-worker.py`.
+- [x] Run `python3 scripts/validate.py && python3 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco tests.test_ci_changed_paths tests.test_site_build && python3 -m py_compile skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py skills/drivers/orchestrate/scripts/worker_lifecycle.py skills/drivers/orchestrate/scripts/codex-worker.py skills/drivers/orchestrate/scripts/claude-worker.py`.

--- a/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [ ] Replace epic-owned delegated execution, research-worker dispatch, wave, and
+  adapter lifecycle prose with a human-dispatch boundary and attended child flow.
+- [ ] Add the three-child default and require a `design.md` justification before
+  filing a fourth or later child.
+- [ ] State that epic planning artifacts ship with implementation and that the
+  coordinator never opens a planning-only pull request.
+- [ ] Align the operator guide, README summary, and Epic agent metadata with the
+  new boundary.
+- [ ] Replace dispatch-presence tests with regression tests for the new rules and
+  removal of epic-owned dispatch paths.
+- [ ] Run `python3 scripts/validate.py && python3 -m unittest tests.test_behavior tests.test_pr_body tests.test_pr_body_gate tests.test_pr_body_bench tests.test_ticket tests.test_codebase_memory_install tests.test_check_dco tests.test_ci_changed_paths tests.test_site_build && python3 -m py_compile skills/tools/codebase-memory/scripts/install.py scripts/ci_changed_paths.py skills/drivers/orchestrate/scripts/worker_lifecycle.py skills/drivers/orchestrate/scripts/codex-worker.py skills/drivers/orchestrate/scripts/claude-worker.py`.

--- a/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
@@ -6,6 +6,8 @@
   executable lock handoff without adding a second execution entry.
 - [ ] Pin each child draft to a pushed remote epic-plan branch/commit and make
   ticket triage fail closed when that branch no longer resolves to the pinned commit.
+- [ ] Permit only one in-flight epic child; require human merge and planning-branch
+  advancement from the updated default branch before handing off the next child.
 - [ ] Add the three-child default and require a `design.md` justification before
   filing a fourth or later child.
 - [ ] State that epic planning artifacts ship with implementation and that the

--- a/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
+++ b/openspec/changes/241-epic-human-dispatch-slicing/tasks.md
@@ -4,6 +4,8 @@
   adapter lifecycle prose with a human-dispatch boundary and attended child flow.
 - [ ] Define the child issue's draft order → operator-invoked ticket triage → fenced
   executable lock handoff without adding a second execution entry.
+- [ ] Pin each child draft to a pushed remote epic-plan branch/commit and make
+  ticket triage fail closed when that branch no longer resolves to the pinned commit.
 - [ ] Add the three-child default and require a `design.md` justification before
   filing a fourth or later child.
 - [ ] State that epic planning artifacts ship with implementation and that the

--- a/skills/drivers/epic/SKILL.md
+++ b/skills/drivers/epic/SKILL.md
@@ -13,90 +13,86 @@ An epic lives at `openspec/changes/<epic-slug>/`. Its `proposal.md`, `design.md`
 
 Route every tracker operation through the installed binding. [bindings/github-issues.md](bindings/github-issues.md) is the shipped default. Read [the tracker contract](references/tracker-contract.md) before the first tracker action. A tracker, authentication, or Git failure stops the current operation visibly; do not guess or repair authoritative state locally.
 
-The home session owns the epic. It stays at planning altitude, files and reads issues, and keeps the active change coherent. Build and triage sessions report in ticket comments and pull requests. Coordinators do not nest.
+The home session owns the epic. It stays at planning altitude, files and reads issues,
+and keeps the active change coherent. It performs no child execution. Research,
+prototype, interview, triage, and build work resumes only in fresh attended sessions
+that the operator invokes. Those sessions report through tracker comments and pull
+requests; the epic records their tracker result and any resulting decision.
 
 ## Start and maintain an epic
 
 1. Confirm the target repository already has OpenSpec. Otherwise run `$openspec-adopt` as a separate documentation-only pull request.
-2. Create one active change with its proposal, design, and tasks. Create the epic issue with the `epic` label and its native child issues. Add each child issue link to `tasks.md` in the implementation sequence; do not duplicate live tracker fields there.
+2. Create one active change with its proposal, design, and tasks. Create the epic issue
+   with the `epic` label. Maintain the change on one pushed epic planning branch and
+   identify each handoff by that branch's full commit, but never open a pull request
+   from that branch. Add each filed
+   child issue link to `tasks.md` in implementation sequence; do not duplicate live
+   tracker fields there.
 3. Re-read relevant live tracker state before each mutation. Update the change when destination, design, or checked sequence changes; preserve child type, status, dependencies, deferral, and closing-pull-request facts on the tracker.
 4. Keep every imprecise concern as a named open question in `design.md`. Clear an open question only by recording its decision in `design.md` or promoting it to a tracker spike; never silently delete it. Do not add pointer-only Notes: owning skills and repository rules remain discoverable at their authoritative homes.
 
 ## Admit work deliberately
 
-File a spike when an open question is precise but not yet resolved. A spike can be research, interview, mockup, or a human prerequisite. File a build only as a bounded refusal: refuse to file a build while an open spike or named open question can invalidate its outcome, constraints, or acceptance criteria.
+File a spike when an open question is precise but not yet resolved. A spike can be
+research, interview, mockup, or a human prerequisite. File a build only as a bounded
+refusal: refuse to file a build while an open spike or named open question can
+invalidate its outcome, constraints, or acceptance criteria.
 
 Before filing a build, require every relevant load-bearing ruling in the repository's ADR home. User-facing work also requires a locked `/ui-craft` spec. The build issue must stand alone and receive the normal `$ticket` triage flow; the epic does not manufacture a work order.
 
-Use native `blocked-by` edges for actual dependencies. A follow-up required to reach the epic destination is an in-scope native child. A follow-up outside that destination is also filed as a native child, receives its `spike` or `build` type plus `deferred`, and is reported on the originating ticket. Ordinary builds still receive `build` from ticket triage.
+Use native `blocked-by` edges for actual dependencies. A follow-up required to reach
+the epic destination is an in-scope native child. A follow-up outside that
+destination is also filed as a native child, receives its `spike` or `build` type
+plus `deferred`, and is reported on the originating ticket. Ordinary builds still
+receive `build` from ticket triage.
 
-## Delegated execution
+Default to three or fewer child tickets. Before filing a fourth or later child,
+require a written justification in the active change's `design.md`. The justification
+must name the independently shippable capability boundary or real dependency that
+prevents consolidation into fewer, larger children. Apply this as semantic planning
+judgment through the existing child-filing interface; do not add a parser, counter
+script, or tracker operation.
 
-The operator may explicitly and revocably delegate a locked epic subtree to
-the home session when every order is stamped or every needed ruling is settled.
-Attended sessions remain the default; any newly opened decision returns that
-subtree to attended mode.
+## Hand a child to the operator
 
-For delegated triage the home session dispatches a worker through the existing `$ticket triage` interface; for a
-delegated build it dispatches a worker through the existing `$ticket start`
-interface. Those workers use their existing ticket contracts and post stamped
-work orders, session-fit, and completed work products through tracker comments.
+Permit only one in-flight epic child. Refuse every later handoff until the prior
+child's implementation pull request is human-merged. After that merge, fetch the
+updated remote default branch, advance the pushed epic planning branch from that
+updated remote default-branch tip, apply any next planning update, commit, and push a
+new full-commit pin before preparing another child.
 
-The home session dispatches only through the pack adapters, with prompt text
-passed positionally from coordinator-owned session-scratch prompt files and one
-coordinator-owned state file per dispatch. Do not add adapter flags or alter
-adapter mechanics.
+Before each handoff, commit and push the current active change on the epic planning
+branch. Record its unprefixed branch name and full commit in the child issue body's
+draft order as:
 
-Work delegated to the home session proceeds in waves. Before each fan-out, draw
-a conflict map from the queued expected diffs and verify that the shared checkout
-equals the current origin default-branch tip. Fan out every read-only draft and
-review in parallel. Serialize only write-bearing triage and build steps whose
-expected diffs overlap; builds use per-issue worktrees, tickets editing the same
-files run in order, and pull requests merge one at a time with a rebase when a
-shared surface is touched. Before dispatching a build or review worker, verify
-that its target worktree is at, or descends from, the current origin
-default-branch tip; refuse a stale target.
+```text
+Parent plan base: <branch name without the origin/ prefix>@<full commit>
+```
 
-Collect child results under `orchestrate`'s `## Collect child results` section.
-Permit a human merge only after green CI and passed review. Surface a failure
-after the applicable routing ladder is exhausted; do not retry past that ladder.
+The issue body is a draft, not the executable lock. The epic does not post a fenced
+`WORK ORDER` comment, does not invoke `/ticket triage`, `/ticket start`, `/ticket
+revise`, or `/ticket finalize`, and does not open a pull request. Stop and tell the
+operator to invoke `/ticket triage <id>`. Ticket triage independently grounds,
+scopes, reviews, and posts the only fenced executable work order.
 
 ## Resolve spikes
 
-For a research spike, run `$research` in a temporary per-spike worktree. The worker returns the required Markdown findings to the home session. The home session writes the Markdown file required by its public interface, posts that returned content under the exact heading `## Findings`, verifies the `## Findings` comment, removes the temporary worktree and its unshipped file, and only then closes the spike.
+Research spikes resume in fresh attended sessions that the operator invokes;
+interview and mockup spikes follow the same rule. Close a spike only after its tracker result is present and verified,
+then record the tracker result and resulting decision in `design.md` when it settles
+a named open question. A failed attended session leaves the spike open; do not infer
+a result.
 
-Close the spike issue only after that verification. Record the resulting decision in `design.md` when it settles a named open question. A failed worker leaves the spike `dispatched`; it is not resolved by inference. Interview and mockup spikes run as fresh attended sessions.
+## Pull-request boundary
 
-## Worker dispatch
-
-The coordinator supplies the selected adapter, explicit worker model, and explicit
-worker effort. Dispatch only through
-`skills/drivers/orchestrate/scripts/codex-worker.py` or
-`skills/drivers/orchestrate/scripts/claude-worker.py`. Never use the built-in Agent
-tool, Workflow tool, or background-agent machinery.
-
-For each research spike, the coordinator owns
-`<session-scratch>/epic-research-<spike-id>.state` and
-`<session-scratch>/epic-research-<spike-id>.prompt`. The prompt identifies its
-recipient as the already-dispatched research worker, directs that worker to research
-directly without dispatching another worker, and states the research question, required
-Markdown output, temporary-worktree boundary, and return-and-verification contract.
-Write that complete brief to the prompt file, then pass its exact contents as the
-selected adapter's positional prompt.
-
-Start the worker through the adapter's `workspace-write` surface with the temporary
-per-spike worktree as its cwd and the coordinator checkout as its control checkout.
-Use the adapter's start, resume, stop, and verify surface. Preserve adapter-owned
-state, same-worker resume, and coordinator-owned recovery; do not restate adapter argv
-or lifecycle mechanics here.
-
-Reject a nonzero adapter invocation. For a successful invocation, read its
-`final_message` as the Markdown findings returned to the home session. The home
-session writes the Markdown file required by its public interface, then follows the
-existing `## Findings` posting and verification rule. Do not close the spike as
-successful without that verified result. Remove the prompt file after the home session
-verifies the `## Findings` comment, or after it reports a failed worker. Never commit
-the prompt file or state file.
+The coordinator never opens a pull request. A planning-only pull request is
+unsupported. The epic's OpenSpec planning artifacts stay active until they travel
+with the implementation pull request that realizes them. When ticket triage finds a
+required parent-plan amendment, that attended ticket workflow commits the amendment
+in the child's worktree and carries it through review and implementation; the epic
+does not open a separate prerequisite pull request. The one-time `$openspec-adopt`
+documentation-only pull request remains outside this lifecycle because it happens
+before an epic exists.
 
 ## Deferred child close-out
 

--- a/skills/drivers/epic/agents/openai.yaml
+++ b/skills/drivers/epic/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Epic"
-  short_description: "Coordinate an OpenSpec epic and clear child tickets"
-  default_prompt: "Use $epic to maintain this effort's OpenSpec authority, resolve its open spikes, and file clear child tickets."
+  short_description: "Plan an OpenSpec epic for operator-run ticket triage"
+  default_prompt: "Use $epic to maintain this effort's OpenSpec authority, file bounded child tickets, and stop for the operator to invoke ticket triage."

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -38,8 +38,9 @@ model dispatch.
   ticket comment. Work too big for one agent's context is sliced into sub-orders
   in that same comment ([references/slicing.md](references/slicing.md)). It
   writes nothing to the repo except scope and spec documents committed in the
-  ticket's worktree. An epic child writes only its work order; a required epic
-  spec amendment is a separate docs-only pull request merged before stamping.
+  ticket's worktree. An epic child treats its issue-body order as a draft and may
+  commit a required parent-plan amendment in the child worktree before posting the
+  reviewed lock; that amendment travels with the implementation pull request.
 * `start` runs in a fresh session, fetches the work order, refuses if there is
   none, implements it on a branch in an isolated worktree (or, on a sliced order,
   coordinates one agent per chunk), iterates the verification step until the
@@ -145,7 +146,9 @@ worker is unsupported.
    cuts the branch and worktree through `spin-worktree`; `start` and `revise`
    reuse them; `finalize` tears them down. The first repository action after the
    summary-and-claim opening, before grounding or any repo read, is to cut or
-   reuse the ticket's worktree. Outside an epic child, grounding, scope ledgers, and
+   reuse the ticket's worktree. The one pre-worktree exception is fresh epic-child
+   triage: it fetches and verifies the issue body's pinned remote parent-plan base,
+   then passes that branch to the helper. Outside an epic child, grounding, scope ledgers, and
    the active change record are written and committed there; post-merge archiving
    follows `operations.archive.guidance` on `main`. An epic child keeps its
    instrumentation in session scratch and relies on its parent record. The control checkout may be dirty, stale, or
@@ -160,10 +163,11 @@ worker is unsupported.
    chunk merges back into it, so the ticket still ends with one branch and one
    pull request ([references/coordinator-mode.md](references/coordinator-mode.md)).
 
-6. **Working state lives on the ticket.** No plan files and no scratch
-   directories on the branch. Outside an epic, the branch carries shipping code plus
-   the repo's own change record; an epic child carries shipping code only and its
-   parent epic owns the record.
+6. **Working state lives on the ticket.** No scratch directories live on the branch.
+   Outside an epic, the branch carries shipping code plus the repo's own change
+   record. An epic child creates no per-child change record; its branch carries
+   implementation plus any required parent-plan amendment that triage committed,
+   while the parent epic's active change remains the authority.
 
 7. **Ground in what the repo already says.** Read the repo's own decision and
    change records, `docs/`, and recent `git log` before forming opinions. Read the
@@ -263,9 +267,11 @@ want of it.
 
 The skill records the change where the target repo already records changes.
 
-An **epic child** creates, revises, and records no per-child change record. Its
-parent epic owns the active change and its post-merge archive; the child leaves
-that change active and records no child change.
+An **epic child** creates no per-child change record. Its parent epic owns the active
+change and its post-merge archive. Triage may commit a required parent-plan
+amendment in the child worktree; start, revise, and coordinator mode preserve the
+parent-plan bytes through the implementation pull request, and finalize leaves the
+parent active and unarchived.
 
 Outside an epic, follow this per-ticket rule:
 

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -10,11 +10,12 @@ report. Anything larger than mechanical goes back to a delegate.
 What follows is what this skill adds on top. It replaces `start` steps 8 through
 11, and rejoins that verb at step 12 when the last chunk has merged.
 
-An epic child creates, revises, and records no per-child change record. Coordinator
-work leaves its parent epic's active change untouched through child pull-request
-review and post-merge finalization; the parent owns the archive. Outside an epic,
-coordinator work keeps the ticket's active change and deltas reviewable until the
-human merge, then finalization follows the repository's archive guidance.
+An epic child creates no per-child change record. Coordinator work preserves the
+parent-plan bytes that triage committed, carries them through the child pull request,
+and leaves the parent active and unarchived at finalization; the parent owns the
+archive. Outside an epic, coordinator work keeps the ticket's active change and
+deltas reviewable until the human merge, then finalization follows the repository's
+archive guidance.
 
 1. **One branch, one pull request, still.** The ticket branch from `start` step 4 is
    the trunk. Each chunk gets its own branch cut from it and merges back. Nothing

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -26,8 +26,9 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    Git-unaware: this verb trusts the verified GitHub merge state and adds no
    enforcement layer. An archive, validation, commit, push, or post-push workflow
    failure stops finalization before the completion comment and done transition.
-   An epic child leaves archive ownership with the parent epic and creates no child
-   change record; it skips this ordinary-change archive procedure.
+   An epic child creates no child change record, skips this ordinary-change archive
+   procedure, and leaves the parent active and unarchived for the parent epic's
+   archive guidance.
 
    d. Comment on the ticket (attribution first): the merged pull request link, a
    one-line outcome, the post-merge evidence, and, for an ordinary change, the

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -78,9 +78,10 @@ chunked: the chunks merged long ago and the pull request is one diff.
    the pull request, resolving or answering it. Outside an epic, update the active
    change record if its checklist moved, and update its decision record if a
    decision changed during review; its active change and deltas remain reviewable
-   until the human merge, so do not fold or archive them. An epic child revises neither
-   a per-child change record nor the parent epic record; its parent epic's active
-   change remains authoritative.
+   until the human merge, so do not fold or archive them. An epic child creates no
+   per-child change record. Preserve the parent-plan bytes already carried by the
+   branch, including grounded review fixes to that amendment; the parent epic's
+   active change remains authoritative.
 
 9. **Status.** Comment on the ticket (attribution first) only if the round
    materially changed the plan. Routine fix-and-push rounds need no ticket comment.

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -74,8 +74,9 @@ Before declaring the change ready, run each check below.
    repo has none, work to the user's global standards. Follow the order's Do section.
    Match the repo's existing idioms, reading neighboring code first. Record the
    change where the repo already records changes, on the same branch, per the skill
-   page's change-record rule. An epic child creates no change record: the parent
-   epic's existing change record is authoritative.
+   page's change-record rule. An epic child creates no per-child change record: the
+   parent epic's existing change record is authoritative, and implementation
+   preserves the parent-plan bytes already committed by triage.
 
    **Route by shape of the change.** `Surface lifecycle: build` runs `/ui-craft
    build` against the named locked manifest. `Surface lifecycle: revise` runs
@@ -127,9 +128,9 @@ Before declaring the change ready, run each check below.
 
 11. **Preserve the change record for merge.** Outside an epic, the active change
     and its deltas remain reviewable in the pull request. Do not fold or archive
-    them before merge. An epic child creates no per-child change record and leaves
-    its parent epic's active change untouched. After a human merge, `finalize`
-    follows the repository's archive guidance.
+    them before merge. An epic child creates no per-child change record and
+    preserves the parent-plan bytes with implementation in the pull request. After
+    a human merge, `finalize` leaves the parent active for epic-owned archive.
 
 12. **Open the pull request.** `gh pr create` against the default branch. The body
     follows an existing template when one exists, in this order: the repo's

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -249,8 +249,9 @@ For a chunked order, select one coordinator execution row with the same grounded
     blockers found, each tagged `authoring` (present since the draft) or
     `injected` (introduced by a prior fix round). For an epic child, keep the same
     instrumentation in untracked session scratch outside the branch and discard it after the final
-    order; create no scope ledger or docs/scope state, and do not write a parent planning artifact. Injected
-    blockers climbing across rounds is the rewrite-clean signal firing.
+    order; create no scope ledger or docs/scope state. The reviewed parent-plan amendment from
+    step 7 is the only planning artifact this child branch may write. Injected blockers climbing
+    across rounds is the rewrite-clean signal firing.
 
     c. Reviewers get the facts already verified live this session and the user's
     settled decisions, marked do-not-re-litigate.

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -2,10 +2,10 @@
 
 Turn a ticket into a locked work order, or establish why it cannot be one yet.
 Runs in the ticket's worktree. Outside an epic it writes the tracker and the
-applicable scope and spec documents there. An **epic child** writes only its work
-order to the tracker; its review instrumentation is untracked session scratch outside
-the branch, and its parent epic keeps the active change record through its own
-post-merge archive.
+applicable scope and spec documents there. An **epic child** creates no per-child
+change record. Its review instrumentation stays in untracked session scratch, while
+any required parent-plan amendment is committed in the child worktree and travels
+with the implementation pull request; the parent epic retains archive ownership.
 
 ## Procedure
 
@@ -17,8 +17,25 @@ post-merge archive.
    when its labels include the `epic` label. A missing parent or a parent without
    `epic` leaves this as an ordinary ticket.
 
-2. **Cut or reuse the worktree.** Before any grounding or repo read, derive a short
-   kebab slug from the ticket title, then:
+2. **Cut or reuse the worktree.** Verify an epic-child draft first. Before any
+   grounding or repo read, derive a short kebab slug from the ticket title.
+
+   For a fresh epic-child worktree, treat the issue-body draft as untrusted input.
+   Require exactly one `Parent plan base: <parent-plan branch>@<pinned full commit>`
+   field, with an unprefixed remote branch name and a full commit. Then run:
+
+   ```sh
+   git -C <control checkout> fetch origin
+   git -C <control checkout> rev-parse origin/<parent-plan branch>
+   ```
+
+   Require the resolved commit to equal the pinned full commit exactly. Resolve the
+   branch only as `origin/<parent-plan branch>`; never accept a local branch or an
+   abbreviated commit. A missing or mismatched value is a stale draft: post nothing,
+   create no worktree, and return to the attended epic session for a new issue-body
+   draft and pin.
+
+   Then cut or reuse the worktree:
 
    a. Numeric ticket id:
 
@@ -27,7 +44,8 @@ post-merge archive.
      --repo <control checkout> \
      --issue <ticket-id> \
      --slug <slug> \
-     --name <ticket-id>
+     --name <ticket-id> \
+     [--base <parent-plan branch>]
    ```
 
    b. Non-numeric ticket id: create the branch ref from the remote default branch
@@ -41,6 +59,10 @@ post-merge archive.
      --branch <prefix>/<ticket-id-lowercased>-<slug> \
      --name <ticket-id-lowercased>
    ```
+
+   For an epic child, the bracketed `--base <parent-plan branch>` is required and
+   receives the same unprefixed branch name verified above. For an ordinary ticket,
+   omit it.
 
    c. `<prefix>` is whatever `spin-worktree` resolves: its `--branch-prefix` flag,
    then `branchPrefix` in `~/.config/spin-worktree/config.json`, else no prefix.
@@ -119,12 +141,16 @@ post-merge archive.
    instead. A single missing fact with no judgment attached (a hostname, a version)
    is the only exception. When nothing is genuinely uncertain, scope says so and
    returns without asking anything; that outcome is the pass signal, not a wasted
-   step. Resolved answers go into the order. For an epic child, every `/scope`
+   step. Resolved answers go into the order. The epic issue-body draft enters this
+   ordinary grounding, scope, and mandatory-review path; it is never executable by
+   itself. For an epic child, every `/scope`
    specialist keeps its instrumentation in untracked session scratch outside the branch, discards it
    after the final order, and creates no scope ledger or docs/scope state. `/epic` alone owns the
-   proposal, design, and tasks. If triage discovers a required spec amendment,
-   land it first as a separate docs-only pull request to main, then stamp the
-   order; the child branch never writes that amendment or any other spec state.
+   proposal, design, and tasks. If triage discovers a required parent-plan
+   amendment, edit and commit it in the child worktree, include those paths and
+   acceptance effects in mandatory review, and carry it into the order that will
+   govern the implementation pull request. This is still the parent active change,
+   not a per-child change record.
 
    **Resolve the surface lifecycle.** Every order and sub-order gets one closed
    `Surface lifecycle:` value:
@@ -250,9 +276,11 @@ For a chunked order, select one coordinator execution row with the same grounded
     because the executing agent grounds in the same repo and resolves polish itself.
 
 13. **Confirm, then post.** Show the user the draft. On approval, post it as one
-    ticket comment through the contract's post operation: attribution quote block
-    first, then the human summary, then the fenced order or sub-orders. One comment
-    carries the whole order, chunked or not.
+   ticket comment through the contract's post operation: attribution quote block
+   first, then the human summary, then the fenced order or sub-orders. One comment
+   carries the whole order, chunked or not. For an epic child, this is the only
+   fenced `WORK ORDER` and the only execution lock; the issue-body draft never
+   substitutes for it.
 
 14. **Move the status** to triaged, passing the classification from step 6. Report
     a failed move; do not retry. A failed code classification `build` creation or

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -4488,15 +4488,13 @@ class EpicProtocolContractTests(unittest.TestCase):
         self.require(self.EPIC, r"load-bearing.*ADR")
         self.require(self.EPIC, r"user-facing.*locked.*ui-craft")
 
-    def test_research_handoff_uses_exact_findings_heading_and_temporary_worktree(self):
-        self.assertIn("## Findings", self.EPIC)
-        self.require(self.EPIC, r"temporary per-spike worktree")
-        self.require(self.EPIC, r"verif.*Findings.*close")
-        self.require(self.EPIC, r"removes.*temporary.*unshipped.*only then closes")
+    def test_research_handoff_returns_to_an_attended_operator_session(self):
+        self.require(self.EPIC, r"research.*attended.*operator")
+        self.require(self.EPIC, r"record.*tracker result.*design\.md")
 
     def test_research_close_uses_verified_tracker_evidence(self):
-        self.require(self.EPIC, r"close.*spike.*only after.*verification")
-        self.require(self.EPIC, r"failed worker.*spike.*dispatched")
+        self.require(self.EPIC, r"close.*spike.*only after.*tracker.*result")
+        self.require(self.EPIC, r"failed.*attended session.*spike.*open")
 
     def test_deferred_children_have_explicit_close_out_dispositions(self):
         self.require(self.EPIC, r"promote.*remove.*deferred")
@@ -4541,57 +4539,46 @@ class EpicProtocolContractTests(unittest.TestCase):
         self.assertNotIn("planning pull request", self.EPIC.lower())
 
 
-class EpicAdapterDispatchTests(unittest.TestCase):
-    EPIC = ROOT / "skills" / "drivers" / "epic" / "SKILL.md"
+class EpicHumanDispatchContractTests(unittest.TestCase):
+    SURFACES = {
+        "skill": ROOT / "skills" / "drivers" / "epic" / "SKILL.md",
+        "guide": ROOT / "docs" / "epic-flow.md",
+        "readme": ROOT / "README.md",
+        "metadata": ROOT / "skills" / "drivers" / "epic" / "agents" / "openai.yaml",
+    }
 
     def setUp(self):
-        self.text = self.EPIC.read_text(encoding="utf-8")
+        self.text = {
+            name: " ".join(path.read_text(encoding="utf-8").split())
+            for name, path in self.SURFACES.items()
+        }
 
-    def test_research_spike_worker_findings_handoff_is_explicit(self):
-        self.assertIn(
-            "For a research spike, run `$research` in a temporary per-spike worktree. The worker "
-            "returns the required Markdown findings to the home session. The home session writes the "
-            "Markdown file required by its public interface, posts that returned content under the exact heading "
-            "`## Findings`, verifies the `## Findings` comment, removes the temporary worktree and "
-            "its unshipped file, and only then closes the spike.",
-            self.text,
-        )
+    def test_public_surfaces_describe_operator_triage_instead_of_epic_execution(self):
+        for name, text in self.text.items():
+            with self.subTest(surface=name):
+                self.assertRegex(text, r"(?i)operator.{0,180}ticket triage")
+                self.assertNotRegex(text, r"(?i)delegate a (?:locked|settled) epic subtree")
+                self.assertNotRegex(text, r"(?i)epic.{0,120}(?:worker adapter|adapter state|execution wave)")
 
-    def test_spike_close_order_and_failed_worker_disposition_are_explicit(self):
-        self.assertIn("Close the spike issue only after that verification.", self.text)
-        self.assertIn("Record the resulting decision in `design.md`", self.text)
-        self.assertIn("A failed worker leaves the spike `dispatched`", self.text)
+    def test_epic_skill_pins_the_parent_plan_and_stops_before_the_lock(self):
+        epic = self.text["skill"]
+        self.assertIn("Parent plan base:", epic)
+        self.assertRegex(epic, r"(?i)pushed epic planning branch.{0,180}full commit")
+        self.assertRegex(epic, r"(?i)does not post.{0,120}fenced.{0,80}work order")
+        self.assertRegex(epic, r"(?i)does not invoke.{0,120}/ticket triage")
 
-    def test_research_worker_dispatch_stays_on_the_worker_adapters_only(self):
-        normalized = " ".join(self.text.split())
-        self.assertIn(
-            "The coordinator supplies the selected adapter, explicit worker model, and explicit "
-            "worker effort. Dispatch only through "
-            "`skills/drivers/orchestrate/scripts/codex-worker.py` or "
-            "`skills/drivers/orchestrate/scripts/claude-worker.py`. Never use the built-in Agent "
-            "tool, Workflow tool, or background-agent machinery.",
-            normalized,
-        )
+    def test_epic_skill_limits_children_and_serializes_handoffs(self):
+        epic = self.text["skill"]
+        self.assertRegex(epic, r"(?i)(?:three or fewer|at most three).{0,180}child")
+        self.assertRegex(epic, r"(?i)fourth or later.{0,180}design\.md.{0,220}(?:capability boundary|dependency)")
+        self.assertRegex(epic, r"(?i)one.{0,80}in-flight.{0,80}child")
+        self.assertRegex(epic, r"(?i)human-merged.{0,220}updated remote default")
 
-
-class EpicDelegatedExecutionContractTests(unittest.TestCase):
-    EPIC = ROOT / "skills" / "drivers" / "epic" / "SKILL.md"
-
-    def test_epic_delegated_execution_keeps_dispatch_and_wave_rules(self):
-        epic = " ".join(self.EPIC.read_text(encoding="utf-8").split())
-        self.assertIn("It stays at planning altitude", epic)
-        self.assertIn("Coordinators do not nest.", epic)
-        self.assertIn(
-            "The home session dispatches only through the pack adapters, with prompt text "
-            "passed positionally from coordinator-owned session-scratch prompt files and one "
-            "coordinator-owned state file per dispatch. Do not add adapter flags or alter "
-            "adapter mechanics.",
-            epic,
-        )
-        self.assertIn(
-            "Collect child results under `orchestrate`'s `## Collect child results` section.",
-            epic,
-        )
+    def test_epic_skill_bans_planning_only_pull_requests(self):
+        epic = self.text["skill"]
+        self.assertRegex(epic, r"(?i)never opens a pull request")
+        self.assertRegex(epic, r"(?i)planning-only pull request.{0,120}unsupported")
+        self.assertRegex(epic, r"(?i)planning artifacts.{0,180}implementation pull request")
 
 
 class ReviewRouteResolverTests(unittest.TestCase):

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -4560,6 +4560,29 @@ class EpicHumanDispatchContractTests(unittest.TestCase):
                 self.assertNotRegex(text, r"(?i)delegate a (?:locked|settled) epic subtree")
                 self.assertNotRegex(text, r"(?i)epic.{0,120}(?:worker adapter|adapter state|execution wave)")
 
+    def test_epic_surfaces_remove_every_epic_owned_execution_mechanism(self):
+        removed_promises = (
+            "## Delegated execution",
+            "## Worker dispatch",
+            "temporary per-spike worktree",
+            "home session dispatches",
+            "pack adapters",
+            "fan-out",
+            "Collect child results",
+            "applicable routing ladder is exhausted",
+            "coordinator-owned state file",
+            "same-session retry",
+            "unfinished delegated worker",
+            "create chunk waves",
+            "write and collect adapter state",
+            "verify worker results",
+        )
+
+        for surface in ("skill", "guide"):
+            with self.subTest(surface=surface):
+                for promise in removed_promises:
+                    self.assertNotIn(promise.lower(), self.text[surface].lower())
+
     def test_epic_skill_pins_the_parent_plan_and_stops_before_the_lock(self):
         epic = self.text["skill"]
         self.assertIn("Parent plan base:", epic)

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -598,10 +598,10 @@ class TicketSkillContractTests(unittest.TestCase):
 
     def test_epic_child_change_record_consumers_state_their_phase_boundary(self):
         expected = {
-            "start.md": "creates no change record",
-            "revise.md": "revises neither a per-child change record",
-            "finalize.md": "leaves archive ownership with the parent epic",
-            "coordinator-mode.md": "creates, revises, and records no per-child",
+            "start.md": "preserves the parent-plan bytes",
+            "revise.md": "preserve the parent-plan bytes",
+            "finalize.md": "leaves the parent active and unarchived",
+            "coordinator-mode.md": "preserves the parent-plan bytes",
         }
 
         for filename, boundary in expected.items():
@@ -645,7 +645,7 @@ class TicketSkillContractTests(unittest.TestCase):
         self.assertLess(finalize_contract.index("post-push workflow"), finalize_contract.index("Move the ticket to done"))
         self.assertLess(finalize_contract.index("Move the ticket to done"), finalize_contract.index("**Record the actuals.**"))
         self.assertLess(finalize_contract.index("**Record the actuals.**"), finalize_contract.index("**Tear the worktree and branch down.**"))
-        self.assertIn("leaves archive ownership with the parent epic", finalize_contract)
+        self.assertIn("leaves the parent active and unarchived", finalize_contract)
         self.assertIn("no child change", finalize_contract)
         self.assertIn("active change", coordinator_contract)
         self.assertNotIn("standing planning-pull-request", coordinator_contract)
@@ -668,16 +668,70 @@ class TicketSkillContractTests(unittest.TestCase):
         for classification in ("investigation", "manual"):
             self.assertIn(f"`{classification}` does not create or attach `build`", binding)
 
-    def test_epic_child_triage_keeps_parent_planning_authority_off_the_child_branch(self):
+    def test_epic_child_triage_verifies_the_pinned_remote_parent_plan_before_worktree(self):
         triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
-        contract = " ".join(triage.lower().split())
+        contract = " ".join(triage.split())
 
-        self.assertIn("writes only its work order", contract)
-        self.assertIn("separate docs-only pull request to main", contract)
-        self.assertIn("untracked session scratch", contract)
-        self.assertIn("outside the branch", contract)
-        self.assertIn("discard it after the final order", contract)
-        self.assertIn("do not write a parent planning artifact", contract)
+        self.assertIn("Parent plan base:", contract)
+        self.assertIn("git -C <control checkout> fetch origin", contract)
+        self.assertIn("origin/<parent-plan branch>", contract)
+        self.assertIn("pinned full commit", contract)
+        self.assertIn("--base <parent-plan branch>", contract)
+        self.assertRegex(contract.lower(), r"stale draft.{0,180}post nothing.{0,180}attended epic")
+        self.assertLess(
+            contract.index("git -C <control checkout> fetch origin"),
+            contract.index("spin-worktree.py"),
+        )
+
+    def test_epic_issue_draft_routes_through_operator_triage_to_the_only_lock(self):
+        epic = " ".join(
+            (ROOT / "skills" / "drivers" / "epic" / "SKILL.md")
+            .read_text(encoding="utf-8")
+            .split()
+        )
+        triage = " ".join(
+            (TICKET_DIRECTORY / "verbs" / "triage.md")
+            .read_text(encoding="utf-8")
+            .split()
+        )
+
+        self.assertRegex(epic, r"issue body.{0,120}draft")
+        self.assertRegex(epic, r"operator.{0,100}/ticket triage")
+        self.assertRegex(epic, r"does not post.{0,120}fenced")
+        self.assertRegex(triage, r"issue-body draft.{0,200}ordinary grounding")
+        self.assertRegex(triage, r"only fenced.{0,100}WORK ORDER")
+
+    def test_epic_child_parent_plan_amendment_rides_the_implementation_pull_request(self):
+        consumers = [
+            TICKET_DIRECTORY / "SKILL.md",
+            TICKET_DIRECTORY / "verbs" / "triage.md",
+            TICKET_DIRECTORY / "verbs" / "start.md",
+            TICKET_DIRECTORY / "verbs" / "revise.md",
+            TICKET_DIRECTORY / "verbs" / "finalize.md",
+            TICKET_DIRECTORY / "references" / "coordinator-mode.md",
+        ]
+        live = "\n".join(path.read_text(encoding="utf-8") for path in consumers)
+        normalized = " ".join(live.split())
+
+        self.assertRegex(
+            normalized,
+            r"parent-plan amendment.{0,220}child worktree.{0,220}implementation pull request",
+        )
+        self.assertIn("preserves the parent-plan bytes", normalized)
+        self.assertIn("leaves the parent active and unarchived", normalized)
+        self.assertNotIn("separate docs-only pull request", live.lower())
+        self.assertNotIn("epic child carries shipping code only", live.lower())
+
+    def test_epic_serial_child_handoff_advances_the_plan_after_human_merge(self):
+        epic = " ".join(
+            (ROOT / "skills" / "drivers" / "epic" / "SKILL.md")
+            .read_text(encoding="utf-8")
+            .split()
+        )
+
+        self.assertRegex(epic, r"only one in-flight epic child")
+        self.assertRegex(epic, r"Refuse every later handoff.{0,180}human-merged")
+        self.assertRegex(epic, r"updated remote default branch.{0,220}new full-commit pin")
 
     def test_revise_requires_a_base_currency_and_mergeability_refresh(self):
         revise = (TICKET_DIRECTORY / "verbs" / "revise.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Motivation and Context

Epics now maintain one pushed plan, hand one pinned child at a time to operator-invoked ticket triage, and default to no more than three children. Previously the Epic workflow could launch its own execution subtree, coordinate waves, and route planning changes through separate planning-only pull requests.

* Each child issue carries an unprefixed parent-plan branch and full commit. Ticket triage fetches that remote branch, refuses a stale pin before creating a worktree, and posts the only executable lock after its ordinary review.
* A required parent-plan amendment travels with the child implementation pull request. The parent change remains active and owns post-merge archive; no per-child change record is created.
* The public guide, README summary, and Epic metadata describe the attended handoff. Ticket's mandatory review, verification, and human-merge boundaries remain in place.
* Decisions and admitted risks remain active under `openspec/changes/241-epic-human-dispatch-slicing/` for post-merge finalization.

Fixes #241

## How Has This Been Tested?

```text
OpenSpec strict validation:
Change '241-epic-human-dispatch-slicing' is valid

Structural validation:
validated 27 skills and 390 files

Full repository verification after the CI repair and rebase:
Ran 471 tests in 91.218s
OK (skipped=23)
py_compile: no output, exit 0

Full two-axis review, round two:
Standards: 15 rules checked, 0 findings, Converged
Spec: 11 criteria and 5 risk entries checked, 0 findings, Converged
```

The Full-depth review used the explicitly permitted Codex route and is labeled unvalidated because no benchmark-validated Codex route exists for load-bearing review. The contract tests falsify prose drift; they do not add a runtime parser or enforce agent behavior, matching the active risk contract. After verification, the archived-spec fixture repair landed independently on `main`; this branch is rebased on that upstream fix.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
