### PR TITLE
Wait before diagnosing quiet Codex workers

### DIFF
--- a/docs/scope/238-codex-worker-liveness.md
+++ b/docs/scope/238-codex-worker-liveness.md
@@ -1,0 +1,75 @@
+# 238 Codex worker liveness
+
+## Decisions
+
+- Persist the Codex `thread.started` identifier from the exact worker's stdout while
+  that process is still running; do not infer identity from the newest rollout file.
+  Why: the event is authoritative, worker-bound, and already part of the adapter's
+  successful output contract. Disposition: → ADR.
+- Keep `session_id: ""` valid while `lifecycle: "running"`, but define that pair as
+  indeterminate rather than evidence of pre-session failure. Why: the event may not
+  have arrived yet, and current buffering proves silence is not absence. Disposition:
+  inline.
+- Require a session-ID-matched rollout to be absent or unchanged across the liveness
+  observation window before the recorded process group may be stopped. If the state
+  has no session ID, the probe cannot satisfy that precondition and must not classify
+  the worker as hung. Why: termination destroys valid model work and cannot be based
+  on PID presence, parent CPU, empty terminal output, or newest-file guesses.
+  Disposition: → ADR.
+- Preserve the shared lifecycle seam from ADR 150. The shared module owns concurrent
+  stdout/stderr draining and atomic state mutation; the Codex adapter owns recognition
+  of its `thread.started` event; Claude's transport and terminal parsing remain
+  unchanged. Why: two adapters already make lifecycle ownership a real seam, while
+  their output formats remain adapter-specific. Disposition: → ADR.
+
+### Risk contract
+
+- **Must prevent:** terminating a live worker whose matching rollout is progressing;
+  secret exposure; irreversible loss of authoritative data; silent incorrect success.
+- **Must recover:** a stopped or failed worker remains recoverable only through the
+  adapter's existing state-bound `stop` then `verify` path before a successor uses its
+  worktree.
+- **Accepted failure:** a worker that never exposes a session ID remains indeterminate
+  and requires manual investigation rather than automatic termination; the consequence
+  is delayed recovery, not destroyed in-flight work.
+- **Unsupported:** discovering workers not launched through the adapter, matching a
+  rollout by newest-file order, or promising live session capture on the portable
+  process-family path where scoped stop/verify is already unsupported.
+- **Evidence owed:** a CLI-level buffered-worker regression that observes a non-empty
+  session ID before completion and survives the shortened test liveness window; schema
+  tests for both empty/indeterminate and populated/running state; exact-rollout progress
+  guidance pinned by behavior tests; the full repository gate.
+
+Why: worker termination is destructive to in-flight work, so false-positive safety is
+the admission boundary. Disposition: inline.
+
+## Open questions
+
+None.
+
+## Spawned tasks
+
+None.
+
+## Reproduction
+
+`docs/scope/238-probes/buffered-session-id.py --expect empty` launches the public Codex adapter
+against a fixture that flushes `thread.started` and then remains active. On the
+pre-change implementation it observes `lifecycle: "running"` with an empty
+`session_id`, despite the authoritative event already having been emitted.
+
+## Review rounds
+
+- Preflight: fixed two authoring defects before dispatch — the work order now carries
+  the risk contract unchanged, and the operational liveness rule has one normative
+  home.
+- Persona fallback, round 1: three authoring blockers were reproduced. The draft's
+  optional observer created a one-caller seam despite the existing shared `parse`
+  interface; its fail-first step named no home for a demanded record; and the committed
+  probe would fail deliberately after the implementation. The clean revision reuses
+  `parse`, asks only that the failure be observed, and makes the probe's pre/post
+  expectation explicit.
+- Independent cold pass: blocked twice before session start. Each Terra adapter state
+  remained `running` with an empty `session_id`; exact worktree/start-window scans found
+  no rollout after more than the incident's 76-second boundary; both recorded process
+  groups were stopped and verified through the adapter. No order has been posted.

--- a/docs/scope/238-codex-worker-liveness.md
+++ b/docs/scope/238-codex-worker-liveness.md
@@ -1,75 +1,32 @@
 # 238 Codex worker liveness
 
-## Decisions
+## Decision
 
-- Persist the Codex `thread.started` identifier from the exact worker's stdout while
-  that process is still running; do not infer identity from the newest rollout file.
-  Why: the event is authoritative, worker-bound, and already part of the adapter's
-  successful output contract. Disposition: → ADR.
-- Keep `session_id: ""` valid while `lifecycle: "running"`, but define that pair as
-  indeterminate rather than evidence of pre-session failure. Why: the event may not
-  have arrived yet, and current buffering proves silence is not absence. Disposition:
-  inline.
-- Require a session-ID-matched rollout to be absent or unchanged across the liveness
-  observation window before the recorded process group may be stopped. If the state
-  has no session ID, the probe cannot satisfy that precondition and must not classify
-  the worker as hung. Why: termination destroys valid model work and cannot be based
-  on PID presence, parent CPU, empty terminal output, or newest-file guesses.
-  Disposition: → ADR.
-- Preserve the shared lifecycle seam from ADR 150. The shared module owns concurrent
-  stdout/stderr draining and atomic state mutation; the Codex adapter owns recognition
-  of its `thread.started` event; Claude's transport and terminal parsing remain
-  unchanged. Why: two adapters already make lifecycle ownership a real seam, while
-  their output formats remain adapter-specific. Disposition: → ADR.
+This is a coordinator-guidance fix, not a worker-lifecycle project.
 
-### Risk contract
+Codex worker output is buffered. When the adapter is still running but has produced no
+terminal output or session ID, wait another minute and check again. Silence alone is
+not evidence that the worker is hung, and it does not authorize stopping the process.
 
-- **Must prevent:** terminating a live worker whose matching rollout is progressing;
-  secret exposure; irreversible loss of authoritative data; silent incorrect success.
-- **Must recover:** a stopped or failed worker remains recoverable only through the
-  adapter's existing state-bound `stop` then `verify` path before a successor uses its
-  worktree.
-- **Accepted failure:** a worker that never exposes a session ID remains indeterminate
-  and requires manual investigation rather than automatic termination; the consequence
-  is delayed recovery, not destroyed in-flight work.
-- **Unsupported:** discovering workers not launched through the adapter, matching a
-  rollout by newest-file order, or promising live session capture on the portable
-  process-family path where scoped stop/verify is already unsupported.
-- **Evidence owed:** a CLI-level buffered-worker regression that observes a non-empty
-  session ID before completion and survives the shortened test liveness window; schema
-  tests for both empty/indeterminate and populated/running state; exact-rollout progress
-  guidance pinned by behavior tests; the full repository gate.
+No production adapter code, state schema, session discovery, or rollout matching changes
+belong in this ticket.
 
-Why: worker termination is destructive to in-flight work, so false-positive safety is
-the admission boundary. Disposition: inline.
+## Evidence
 
-## Open questions
+`docs/scope/238-probes/buffered-session-id.py --expect empty` demonstrates the condition:
+the fixture has emitted its start event and remains active while the adapter's durable
+state still has an empty session ID.
 
-None.
+## Acceptance
 
-## Spawned tasks
+- The Codex dispatch guidance explicitly tells coordinators to wait another minute when
+  a running adapter is quiet.
+- A behavior test pins that instruction so an agent cannot silently regress to the old
+  hang inference.
+- The repository gate passes.
 
-None.
+## Review outcome
 
-## Reproduction
-
-`docs/scope/238-probes/buffered-session-id.py --expect empty` launches the public Codex adapter
-against a fixture that flushes `thread.started` and then remains active. On the
-pre-change implementation it observes `lifecycle: "running"` with an empty
-`session_id`, despite the authoritative event already having been emitted.
-
-## Review rounds
-
-- Preflight: fixed two authoring defects before dispatch — the work order now carries
-  the risk contract unchanged, and the operational liveness rule has one normative
-  home.
-- Persona fallback, round 1: three authoring blockers were reproduced. The draft's
-  optional observer created a one-caller seam despite the existing shared `parse`
-  interface; its fail-first step named no home for a demanded record; and the committed
-  probe would fail deliberately after the implementation. The clean revision reuses
-  `parse`, asks only that the failure be observed, and makes the probe's pre/post
-  expectation explicit.
-- Independent cold pass: blocked twice before session start. Each Terra adapter state
-  remained `running` with an empty `session_id`; exact worktree/start-window scans found
-  no rollout after more than the incident's 76-second boundary; both recorded process
-  groups were stopped and verified through the adapter. No order has been posted.
+The initial triage over-scoped the ticket into live session capture and concurrency
+machinery. The operator clarified that this is a single-user tool and the required fix
+is the tested patience reminder above. That ruling replaces the earlier draft.

--- a/docs/scope/238-probes/buffered-session-id.py
+++ b/docs/scope/238-probes/buffered-session-id.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Reproduce issue 238 against the Codex adapter's public CLI."""
+
+from __future__ import annotations
+
+import json
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parents[3]
+ADAPTER = ROOT / "skills/drivers/orchestrate/scripts/codex-worker.py"
+
+
+def wait_for_running(state_path: Path) -> dict[str, object]:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            time.sleep(0.02)
+            continue
+        if state.get("lifecycle") == "running":
+            return state
+        time.sleep(0.02)
+    raise RuntimeError("adapter never reached running state")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expect", choices=("empty", "live", "none"), default="none")
+    args = parser.parse_args()
+    if sys.platform != "darwin":
+        print("SKIP: durable process-family lifecycle is macOS-only")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="ticket-238-") as raw:
+        scratch = Path(raw)
+        fake = scratch / "fake-codex"
+        fake.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, time\n"
+            "print(json.dumps({'type': 'thread.started', "
+            "'thread_id': 'buffered-worker'}), flush=True)\n"
+            "time.sleep(30)\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        state_path = scratch / "state.json"
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(ADAPTER),
+                "start",
+                "--codex",
+                str(fake),
+                "--state",
+                str(state_path),
+                "--model",
+                "Terra",
+                "--sandbox",
+                "read-only",
+                "--cwd",
+                str(scratch),
+                "hold after session start",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            state = wait_for_running(state_path)
+            time.sleep(0.25)
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            observed = {
+                "lifecycle": state.get("lifecycle"),
+                "session_id": state.get("session_id"),
+                "fixture_event": "buffered-worker",
+                "adapter_still_running": process.poll() is None,
+            }
+            print(json.dumps(observed, sort_keys=True))
+            expected_id = "" if args.expect == "empty" else "buffered-worker"
+            if args.expect != "none" and observed != {
+                "adapter_still_running": True,
+                "fixture_event": "buffered-worker",
+                "lifecycle": "running",
+                "session_id": expected_id,
+            }:
+                raise RuntimeError(f"{args.expect} expectation failed: {observed!r}")
+        finally:
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(ADAPTER),
+                    "stop",
+                    "--state",
+                    str(state_path),
+                    "--cwd",
+                    str(scratch),
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            try:
+                process.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openspec/changes/238-codex-worker-liveness/design.md
+++ b/openspec/changes/238-codex-worker-liveness/design.md
@@ -1,0 +1,26 @@
+# Design
+
+## ADR 238 — Stream authoritative Codex session identity into shared worker state
+
+Codex session identity comes from the exact launched worker's `thread.started` JSONL
+event, observed while stdout and stderr are drained without waiting for process exit.
+The shared lifecycle module owns safe concurrent draining and atomic mutation of the
+existing state file. It reuses the existing adapter-supplied `parse` interface against
+complete accumulated stdout records: Codex's parser already returns its recognized ID
+alongside the expected partial-output error, while Claude's parser returns no ID until
+its one terminal object is complete. No new callback seam, state field, or state-version
+bump is needed: `session_id` changes from empty to the captured ID while lifecycle
+remains `running`, and terminal parsing/emission continues to validate the complete
+buffered output at exit.
+
+This preserves ADR 150's seam. Claude continues to use the same shared lifecycle with
+no live-event recognizer, and adapter-specific output parsing remains outside the shared
+module. The portable path remains terminal-only because it deliberately has no
+recoverable process-family claim.
+
+Coordinator liveness is fail-safe: `running` plus an empty `session_id` is
+indeterminate. A non-empty ID selects a rollout only by matching
+`session_meta.payload.session_id`; newest-file ordering, terminal silence, PID
+presence, and low parent CPU are not identity or hang evidence. The recorded process
+group may be stopped only after the matching rollout is absent or fails to progress
+across the documented observation window. An empty ID cannot satisfy that precondition.

--- a/openspec/changes/238-codex-worker-liveness/design.md
+++ b/openspec/changes/238-codex-worker-liveness/design.md
@@ -1,26 +1,7 @@
 # Design
 
-## ADR 238 — Stream authoritative Codex session identity into shared worker state
+This change is intentionally documentation-only. The adapter's buffered-output behavior
+is acceptable for this single-user workflow; the coordinator needs a tested patience
+guardrail, not a new live-observation mechanism.
 
-Codex session identity comes from the exact launched worker's `thread.started` JSONL
-event, observed while stdout and stderr are drained without waiting for process exit.
-The shared lifecycle module owns safe concurrent draining and atomic mutation of the
-existing state file. It reuses the existing adapter-supplied `parse` interface against
-complete accumulated stdout records: Codex's parser already returns its recognized ID
-alongside the expected partial-output error, while Claude's parser returns no ID until
-its one terminal object is complete. No new callback seam, state field, or state-version
-bump is needed: `session_id` changes from empty to the captured ID while lifecycle
-remains `running`, and terminal parsing/emission continues to validate the complete
-buffered output at exit.
-
-This preserves ADR 150's seam. Claude continues to use the same shared lifecycle with
-no live-event recognizer, and adapter-specific output parsing remains outside the shared
-module. The portable path remains terminal-only because it deliberately has no
-recoverable process-family claim.
-
-Coordinator liveness is fail-safe: `running` plus an empty `session_id` is
-indeterminate. A non-empty ID selects a rollout only by matching
-`session_meta.payload.session_id`; newest-file ordering, terminal silence, PID
-presence, and low parent CPU are not identity or hang evidence. The recorded process
-group may be stopped only after the matching rollout is absent or fails to progress
-across the documented observation window. An empty ID cannot satisfy that precondition.
+The Codex dispatch reference remains the single normative home for the rule.

--- a/openspec/changes/238-codex-worker-liveness/proposal.md
+++ b/openspec/changes/238-codex-worker-liveness/proposal.md
@@ -1,35 +1,16 @@
-# Live Codex worker identity before completion
+# Wait before diagnosing a quiet Codex worker
 
 ## Why
 
-The Codex adapter buffers worker output until exit, so its durable state can report a
-running process with no session identifier even after Codex has created a session and
-is actively writing a rollout. Current coordinator guidance can therefore mistake live
-model work for a pre-session hang and terminate it.
+The Codex adapter buffers output while its child is active. A coordinator can therefore
+mistake an ordinary quiet interval for a hang.
 
 ## What changes
 
-- Persist the exact Codex session identifier from the worker's streamed
-  `thread.started` event while the worker remains active.
-- Define an empty session identifier during `running` as indeterminate and require
-  exact-session rollout non-progress evidence before stopping a silent worker.
-- Cover the live state transition through the adapter CLI and keep Claude adapter
-  behavior unchanged through the shared lifecycle seam.
+- Tell coordinators to wait another minute when a Codex adapter is still running but
+  quiet.
+- State that silence or an empty session ID alone is not evidence of a hang.
+- Pin the instruction in a behavior test because agent-facing prose is executable
+  workflow policy.
 
-## Risk contract
-
-- **Must prevent:** terminating a live worker whose matching rollout is progressing;
-  secret exposure; irreversible loss of authoritative data; silent incorrect success.
-- **Must recover:** a stopped or failed worker remains recoverable only through the
-  adapter's existing state-bound `stop` then `verify` path before a successor uses its
-  worktree.
-- **Accepted failure:** a worker that never exposes a session ID remains indeterminate
-  and requires manual investigation rather than automatic termination; the consequence
-  is delayed recovery, not destroyed in-flight work.
-- **Unsupported:** discovering workers not launched through the adapter, matching a
-  rollout by newest-file order, or promising live session capture on the portable
-  process-family path where scoped stop/verify is already unsupported.
-- **Evidence owed:** a CLI-level buffered-worker regression that observes a non-empty
-  session ID before completion and survives the shortened test liveness window; schema
-  tests for both empty/indeterminate and populated/running state; exact-rollout progress
-  guidance pinned by behavior tests; the full repository gate.
+No worker lifecycle or adapter code changes.

--- a/openspec/changes/238-codex-worker-liveness/proposal.md
+++ b/openspec/changes/238-codex-worker-liveness/proposal.md
@@ -1,0 +1,35 @@
+# Live Codex worker identity before completion
+
+## Why
+
+The Codex adapter buffers worker output until exit, so its durable state can report a
+running process with no session identifier even after Codex has created a session and
+is actively writing a rollout. Current coordinator guidance can therefore mistake live
+model work for a pre-session hang and terminate it.
+
+## What changes
+
+- Persist the exact Codex session identifier from the worker's streamed
+  `thread.started` event while the worker remains active.
+- Define an empty session identifier during `running` as indeterminate and require
+  exact-session rollout non-progress evidence before stopping a silent worker.
+- Cover the live state transition through the adapter CLI and keep Claude adapter
+  behavior unchanged through the shared lifecycle seam.
+
+## Risk contract
+
+- **Must prevent:** terminating a live worker whose matching rollout is progressing;
+  secret exposure; irreversible loss of authoritative data; silent incorrect success.
+- **Must recover:** a stopped or failed worker remains recoverable only through the
+  adapter's existing state-bound `stop` then `verify` path before a successor uses its
+  worktree.
+- **Accepted failure:** a worker that never exposes a session ID remains indeterminate
+  and requires manual investigation rather than automatic termination; the consequence
+  is delayed recovery, not destroyed in-flight work.
+- **Unsupported:** discovering workers not launched through the adapter, matching a
+  rollout by newest-file order, or promising live session capture on the portable
+  process-family path where scoped stop/verify is already unsupported.
+- **Evidence owed:** a CLI-level buffered-worker regression that observes a non-empty
+  session ID before completion and survives the shortened test liveness window; schema
+  tests for both empty/indeterminate and populated/running state; exact-rollout progress
+  guidance pinned by behavior tests; the full repository gate.

--- a/openspec/changes/238-codex-worker-liveness/specs/planning-and-review/spec.md
+++ b/openspec/changes/238-codex-worker-liveness/specs/planning-and-review/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Durable Codex worker liveness identity
+
+The Codex worker adapter MUST persist the exact launched session's authoritative
+identifier while that session is running, and orchestration MUST treat a running state
+with an empty identifier as indeterminate. A coordinator MUST NOT stop the recorded
+worker process group unless an identifier-matched rollout is absent or has failed to
+progress across the documented observation window; PID presence, terminal silence,
+parent-process CPU, and newest-rollout ordering MUST NOT independently or collectively
+substitute for that exact match.
+
+#### Scenario: Buffered worker remains active beyond the liveness window
+
+- **WHEN** Codex emits its session-start event and continues working while terminal
+  output remains buffered
+- **THEN** the adapter state exposes that exact session identifier before completion
+  and the coordinator uses its matching rollout progress as the liveness evidence
+
+#### Scenario: Running state has no session identifier
+
+- **WHEN** a worker state reports `running` with an empty session identifier
+- **THEN** orchestration treats the state as indeterminate and does not terminate the
+  recorded process group on silence, PID presence, CPU observations, or a guessed
+  rollout

--- a/openspec/changes/238-codex-worker-liveness/specs/planning-and-review/spec.md
+++ b/openspec/changes/238-codex-worker-liveness/specs/planning-and-review/spec.md
@@ -1,25 +1,22 @@
 ## ADDED Requirements
 
-### Requirement: Durable Codex worker liveness identity
+### Requirement: Patient Codex worker liveness checks
 
-The Codex worker adapter MUST persist the exact launched session's authoritative
-identifier while that session is running, and orchestration MUST treat a running state
-with an empty identifier as indeterminate. A coordinator MUST NOT stop the recorded
-worker process group unless an identifier-matched rollout is absent or has failed to
-progress across the documented observation window; PID presence, terminal silence,
-parent-process CPU, and newest-rollout ordering MUST NOT independently or collectively
-substitute for that exact match.
+When a Codex adapter remains running without terminal output or a session identifier,
+the coordinator MUST wait another minute and check again. Silence, an empty session
+identifier, PID presence, or low parent-process CPU MUST NOT by itself be treated as a
+hang or authority to stop the worker.
 
-#### Scenario: Buffered worker remains active beyond the liveness window
+The repository MUST contain a behavior test that pins this agent-facing instruction.
 
-- **WHEN** Codex emits its session-start event and continues working while terminal
-  output remains buffered
-- **THEN** the adapter state exposes that exact session identifier before completion
-  and the coordinator uses its matching rollout progress as the liveness evidence
+#### Scenario: Running adapter is quiet
 
-#### Scenario: Running state has no session identifier
+- **WHEN** the Codex adapter is still running and has not emitted terminal output or a
+  session identifier
+- **THEN** the coordinator waits another minute before checking again and does not stop
+  the worker based on silence alone
 
-- **WHEN** a worker state reports `running` with an empty session identifier
-- **THEN** orchestration treats the state as indeterminate and does not terminate the
-  recorded process group on silence, PID presence, CPU observations, or a guessed
-  rollout
+#### Scenario: Guidance regresses
+
+- **WHEN** the patience instruction is removed or weakened
+- **THEN** the behavior test fails

--- a/openspec/changes/238-codex-worker-liveness/tasks.md
+++ b/openspec/changes/238-codex-worker-liveness/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [ ] Add live Codex `thread.started` observation through the shared lifecycle's
+  existing adapter-supplied parser without changing Claude transport or terminal
+  output validation.
+- [ ] Persist the exact session ID atomically while lifecycle remains running, with
+  schema and CLI-level buffered-worker regression coverage.
+- [ ] Replace ambiguous CPU/newest-rollout liveness guidance with exact-session,
+  progress-based stop preconditions and pin the prose contract in tests.
+- [ ] Run `python3 scripts/validate.py`, the complete named unittest command from
+  `AGENTS.md`, and the three named `py_compile` checks for worker scripts.

--- a/openspec/changes/238-codex-worker-liveness/tasks.md
+++ b/openspec/changes/238-codex-worker-liveness/tasks.md
@@ -1,5 +1,5 @@
 # Tasks
 
-- [ ] Add the one-minute patience rule to `dispatch-codex.md`.
-- [ ] Pin the rule in `tests/test_behavior.py`.
-- [ ] Run OpenSpec validation and the repository gate.
+- [x] Add the one-minute patience rule to `dispatch-codex.md`.
+- [x] Pin the rule in `tests/test_behavior.py`.
+- [x] Run OpenSpec validation and the repository gate.

--- a/openspec/changes/238-codex-worker-liveness/tasks.md
+++ b/openspec/changes/238-codex-worker-liveness/tasks.md
@@ -1,11 +1,5 @@
 # Tasks
 
-- [ ] Add live Codex `thread.started` observation through the shared lifecycle's
-  existing adapter-supplied parser without changing Claude transport or terminal
-  output validation.
-- [ ] Persist the exact session ID atomically while lifecycle remains running, with
-  schema and CLI-level buffered-worker regression coverage.
-- [ ] Replace ambiguous CPU/newest-rollout liveness guidance with exact-session,
-  progress-based stop preconditions and pin the prose contract in tests.
-- [ ] Run `python3 scripts/validate.py`, the complete named unittest command from
-  `AGENTS.md`, and the three named `py_compile` checks for worker scripts.
+- [ ] Add the one-minute patience rule to `dispatch-codex.md`.
+- [ ] Pin the rule in `tests/test_behavior.py`.
+- [ ] Run OpenSpec validation and the repository gate.

--- a/skills/drivers/orchestrate/references/dispatch-codex.md
+++ b/skills/drivers/orchestrate/references/dispatch-codex.md
@@ -58,6 +58,11 @@ automatic-activation rule.
 
 ## Worker liveness
 
+When the adapter is still running but has no terminal output or session ID, wait
+another minute and check again. `session_id: ""` while `lifecycle: running` is
+indeterminate, not a pre-session failure. Silence, PID presence, or low parent CPU
+alone does not prove a hang and does not authorize stopping the worker.
+
 A PID appearing in `ps` proves nothing. A healthy worker accrues CPU time
 within a minute and writes `~/.codex/sessions/<date>/rollout-*.jsonl` at session
 start. Before trusting a long-running worker, check that `ps -o time` is growing

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2190,6 +2190,22 @@ class OrchestrateCodexPolicyTests(unittest.TestCase):
         self.assertIn("A PID appearing in `ps` proves nothing.", dispatch)
         self.assertIn("`ps -o time` is growing", dispatch)
         self.assertIn("rollout-*.jsonl", dispatch)
+        normalized_dispatch = " ".join(dispatch.split())
+        self.assertIn(
+            "When the adapter is still running but has no terminal output or session ID, "
+            "wait another minute and check again.",
+            normalized_dispatch,
+        )
+        self.assertIn(
+            "Silence, PID presence, or low parent CPU alone does not prove a hang and "
+            "does not authorize stopping the worker.",
+            normalized_dispatch,
+        )
+        self.assertIn(
+            '`session_id: ""` while `lifecycle: running` is indeterminate, not a '
+            "pre-session failure.",
+            normalized_dispatch,
+        )
 
     def test_claude_parent_codex_dispatch_reference_is_pinned(self):
         skill = (ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md").read_text(


### PR DESCRIPTION
## Motivation and Context

Codex coordinators now wait another minute when a running worker is quiet and treat a blank live session ID as indeterminate. Previously buffered worker output could be mistaken for a pre-session hang and active work could be stopped.

* Silence, PID presence, or low parent CPU alone does not authorize stopping the worker.
* A behavior test pins the patience instruction and the no-silence inference.
* This changes coordinator guidance only. Worker lifecycle, adapter behavior, session discovery, and rollout matching are unchanged.
* The decision and admitted-risk record remains active under `openspec/changes/238-codex-worker-liveness/` for post-merge finalization.

Fixes #238

## How Has This Been Tested?

```text
Fail-first policy regression:
Ran 1 test in 0.001s
FAILED (failures=1)
missing one-minute patience instruction

Strict OpenSpec validation:
Totals: 4 passed, 0 failed (4 items)

Full repository verification on main SHA 75f8f9e:
validated 27 skills and 396 files
Ran 471 tests in 77.594s
OK (skipped=23)
py_compile: no output, exit 0

Focused two-axis review:
Standards: 12 rules checked, 0 findings
Spec: 8 criteria and 4 risk entries checked, 0 findings
```

The behavior test falsifies drift in the agent-facing policy. It does not add a live worker-observation mechanism.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.

