### PR TITLE
docs(ticket): cover fidelity screenshots in worker-egress consent grant

### DIFF
--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ticket
-description: "Drive one tracked ticket from arrival to resolution through four verbs: triage, start, revise, finalize. Use when the user says triage/start/revise/finalize with a ticket id, asks to turn a ticket into a locked brief, to execute a work order, to action a review round on a ticket's pull request, or to close out a merged ticket. Literal triage, start, or revise invocation requests the work order or task prompt plus only needed repository code and documentation for every mandatory worker dispatch, including nested review and nested Orchestrate work: to OpenAI's Codex model service for a Codex UI parent, or OpenAI's Codex model service or Anthropic's Claude model service for a Claude Code parent. For delegated workflow work, the coordinator dispatches every mandatory reviewer and resumes the same worker. Credentials, secrets, patient data, `.env`, and real database contents are excluded. Automatic activation outside an invoked parent workflow asks once before dispatch; finalize grants no worker-egress consent."
+description: "Drive one tracked ticket from arrival to resolution through four verbs: triage, start, revise, finalize. Use when the user says triage/start/revise/finalize with a ticket id, asks to turn a ticket into a locked brief, to execute a work order, to action a review round on a ticket's pull request, or to close out a merged ticket. Literal triage, start, or revise invocation requests the work order or task prompt plus only needed repository code, documentation, and manufactured-data UI fidelity evidence (screenshots) for every mandatory worker dispatch, including nested review and nested Orchestrate work: to OpenAI's Codex model service for a Codex UI parent, or OpenAI's Codex model service or Anthropic's Claude model service for a Claude Code parent. For delegated workflow work, the coordinator dispatches every mandatory reviewer and resumes the same worker. Credentials, secrets, patient data, `.env`, and real database contents are excluded. Automatic activation outside an invoked parent workflow asks once before dispatch; finalize grants no worker-egress consent."
 ---
 
 # Ticket
@@ -18,8 +18,9 @@ four.
 Literal user invocation of `/ticket triage`, `/ticket start`, or `/ticket revise`
 requests the bounded transfer needed for every mandatory worker dispatch the
 selected workflow routes, including nested review and nested Orchestrate work. The
-payload is the work order or task prompt plus only the repository code and
-documentation needed for that delegated task. For a Codex UI parent, the destination
+payload is the work order or task prompt plus only the repository code,
+documentation, and manufactured-data UI fidelity evidence (screenshots rendered
+from manufactured data, never real user data) needed for that delegated task. For a Codex UI parent, the destination
 is an isolated worker on OpenAI's Codex model service. For a Claude Code parent,
 existing routing selects an isolated worker on OpenAI's Codex model service or
 Anthropic's Claude model service. Credentials, secrets, patient data, `.env`, and

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -107,7 +107,11 @@ non-blocking rule.
    entry from
    [review-routing.md](../../orchestrate/references/review-routing.md) using that
    chunk's stamped depth. Builder tier is not an input. Dispatch the selected
-   reviewer on the chunk's branch against the ticket branch. Findings go back to
+   reviewer on the chunk's branch against the ticket branch. The literal `/ticket`
+   invocation already granted this dispatch's transfer — work order, needed
+   repository code and documentation, and manufactured-data UI fidelity evidence
+   (screenshots) — so do not re-ask; credentials, secrets, patient data, `.env`,
+   and real database contents stay excluded. Findings go back to
    the chunk's own agent to fix. Claim each dispatched reviewer session through the
    shared claim rule with `--verb start` and `--role reviewer`, plus the same `--session <id>`,
    `--agent <agent>` and `--project` it ran in, so review overhead is measured as


### PR DESCRIPTION
## Motivation and Context

The ticket worker-egress consent grant now covers manufactured-data UI fidelity screenshots, and the coordinator's reviewer-dispatch step restates the grant in place. Previously the grant named only the work order, code, and documentation, so a compliant Codex worker mid `/ticket start` stopped to re-ask before sending fidelity screenshots to its mandatory reviewers.

* The frontmatter description and the body grant both name the screenshot payload, with the same exclusions (credentials, secrets, patient data, `.env`, real database contents).
* The restatement sits at the reviewer-dispatch step because the worker sees that reference at dispatch time, long after the invocation-time grant has scrolled out of attention.
* Guidance text only; no script, hook, or workflow mechanics change.

## How Has This Been Tested?

```text
validated 27 skills and 396 files
tests.test_ticket: Ran 87 tests, OK
```

The tests pin existing ticket policy text; no test exercises the new consent wording itself.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
