### PR TITLE
Keep worker orders available after context compaction

### DIFF
--- a/docs/scope/255-compaction-proof-worker-orders.md
+++ b/docs/scope/255-compaction-proof-worker-orders.md
@@ -1,0 +1,81 @@
+# 255 — Compaction-proof worker orders
+
+Scope ledger. Routed from `/ticket triage 255` to interview mode: a concrete plan
+exists in the issue body, with open decisions about where the durable order lives
+and how far the rule reaches.
+
+## Decisions
+
+- Settled by grounding (`inline`): the issue's floated follow-on, a ~180k peak as
+  the Codex chunk-size ceiling, is already a shipped requirement in
+  `openspec/specs/ticket-workflow/spec.md` ("target each worker chunk below the
+  180k-token peak band"). Out of scope for this ticket; do not restate it.
+- Settled by grounding (`inline`): mechanical git exclusion of an order file is
+  rejected. Verified live on git 2.50.1 that a linked worktree's own
+  `$GIT_DIR/info/exclude` is never read; only the shared `.git/info/exclude`
+  applies, and it silences the control checkout too. Excluding the file is
+  therefore shared-state mutation across every worktree, not a worktree-local act.
+- Settled by grounding (`inline`): the issue's "worktree `AGENTS.md`" option is
+  rejected as a general rule. A target repo may already track a root `AGENTS.md`
+  (this one does), so writing the order there dirties a tracked file and invites
+  committing it.
+- Settled by grounding (`inline`): today the complete prompt bytes are written to
+  coordinator session scratch (`skills/drivers/orchestrate/SKILL.md` "Collect child
+  results", `skills/drivers/ticket/references/coordinator-mode.md`). That location
+  is coordinator-side, so a worker that compacts cannot reach it. This is the gap.
+- Measured (`inline`): the worker sandboxes restrict writes, not reads. Both
+  adapters configure only `filesystem.allowWrite`/`denyWrite`
+  (`skills/drivers/orchestrate/scripts/claude-worker.py:91-104`), and the #149 probe
+  log (`docs/scope/149-probes/run-log.md`) shows a sandboxed worker listing and
+  reading while writes outside its cwd are refused. So a durable order is readable
+  from either inside or outside the working copy; readability does not decide Q1.
+
+- Q1 settled: A (`inline`). The durable order lives inside the worker's own
+  working copy at the fixed root name `ORDER.md`. A compacted worker can find a
+  fixed name by listing its cwd; it cannot recover an absolute path it was told
+  once. Readability did not decide this (both places are readable).
+- Q2 settled: A (`inline`). The rule binds every pack-owned write-mode dispatch,
+  so its single home is Orchestrate's pack-wide `## Collect child results`
+  contract. The issue body proposed ticket's drafting conventions as the home;
+  that is the wrong layer for a pack-wide rule, so the pointer direction is
+  reversed from the issue body and drafting conventions points at Orchestrate.
+- Q3 settled: A (`inline`). A worker that cannot read its durable order stops and
+  reports; the coordinator writes it again and resumes that same worker.
+- Settled: minimum mechanism (`inline`). Operator called the interview
+  over-engineered for the change. No git exclusion, no new coordinator gate, no
+  new template field: the convention is prose in one home plus a behavior test.
+- Settled (`inline`): the standing re-read line is appended by the coordinator to
+  the prompt bytes, and `ORDER.md` is those same bytes. An instruction that lived
+  only in a prompt preamble would die at the compaction it exists to survive, so
+  it must be inside the durable file. The work-order template needs no new field.
+- Settled (`inline`): the original-prompt-only worker-input rule
+  (`openspec/specs/planning-and-review/spec.md`) is left intact. `ORDER.md` is the
+  same bytes as the original prompt, placed at dispatch, not new material
+  introduced mid-session, so it is not a second exception alongside the research
+  source handoff.
+
+### Risk contract
+
+- **Must prevent:** a worker reporting done while its durable order was never
+  written, or while it silently drifted past the order's closed acceptance list.
+- **Must recover:** nothing automatically.
+- **Accepted failure:** the durable order is missing or unreadable at re-read
+  time. The worker stops and reports; the coordinator writes it again and resumes
+  that same worker.
+- **Unsupported:** any mechanical guarantee that the file is never committed or
+  pushed. The order's own text and the diff the coordinator already reads before
+  merging are the whole enforcement. Git-level exclusion is explicitly rejected
+  above as shared-state mutation.
+- **Evidence owed:** a behavior test pinning the convention text in its single
+  home.
+- **Why:** a prose-contract change to a single-operator public skill pack; the
+  failure mode is visible drift, recoverable by rerunning the work.
+- **Disposition:** inline.
+
+## Open questions
+
+_None. The frontier is empty; every question above is settled in `Decisions`._
+
+## Spawned tasks
+
+_None yet._

--- a/docs/scope/255-compaction-proof-worker-orders.md
+++ b/docs/scope/255-compaction-proof-worker-orders.md
@@ -44,10 +44,29 @@ and how far the rule reaches.
 - Settled: minimum mechanism (`inline`). Operator called the interview
   over-engineered for the change. No git exclusion, no new coordinator gate, no
   new template field: the convention is prose in one home plus a behavior test.
-- Settled (`inline`): the standing re-read line is appended by the coordinator to
-  the prompt bytes, and `ORDER.md` is those same bytes. An instruction that lived
-  only in a prompt preamble would die at the compaction it exists to survive, so
-  it must be inside the durable file. The work-order template needs no new field.
+- REOPENED then re-settled (`inline`), round 1 cold review, on evidence: the
+  standing re-read line cannot be appended by the coordinator. A chunk's prompt is
+  fixed as "the sub-order fence verbatim, followed only by that chunk's worktree
+  path, branch name, `root_path`, and `project` ... and never coordinator
+  commentary" (`skills/drivers/ticket/references/coordinator-mode.md:71-76`), and
+  the fence must stay "executable without coordinator commentary"
+  (`skills/drivers/ticket/templates/work-order.md:29`). The instruction still has
+  to live inside the durable file, because `ORDER.md` is the prompt bytes and an
+  instruction carried only in a preamble dies at the compaction it exists to
+  survive. So it goes in the work-order template's fence boilerplate, and
+  `skills/drivers/ticket/templates/work-order.md` joins the allowlist. This
+  reverses the earlier "the template needs no new field" reading, which rested on
+  a coordinator-appends assumption the evidence refuted.
+- Settled (`inline`), round 1 cold review: ticket chunk dispatch is currently the
+  pack's only write-mode dispatch; every other pack dispatcher runs
+  `--sandbox read-only`. The rule still belongs in the pack-wide contract so a
+  future write-mode dispatcher inherits it, but ticket is its only consumer today.
+- Settled (`inline`), round 1 cold review: a coordinator that cannot write
+  `ORDER.md` into the worker's cwd reports the dispatch unavailable and does not
+  start the worker. Without this, a sandboxed coordinator (the Codex
+  `workspace-write` case already documented at
+  `skills/drivers/ticket/SKILL.md:120-125`) silently produces exactly the
+  must-prevent outcome: a worker running with no durable order.
 - Settled (`inline`): the original-prompt-only worker-input rule
   (`openspec/specs/planning-and-review/spec.md`) is left intact. `ORDER.md` is the
   same bytes as the original prompt, placed at dispatch, not new material

--- a/docs/scope/255-compaction-proof-worker-orders.md
+++ b/docs/scope/255-compaction-proof-worker-orders.md
@@ -91,9 +91,49 @@ and how far the rule reaches.
   failure mode is visible drift, recoverable by rerunning the work.
 - **Disposition:** inline.
 
+## Round 3 — drafting halted, decisions reopened
+
+Three review panels ran (cold, its delta re-check, a fresh cold pass). Blocking
+counts by round: 4 authoring, then 2 injected by the round-1 fixes, then 4 more of
+which 2 were injected by the round-2 fixes. Injected blockers climbing across
+rounds is the rewrite-clean signal, and the findings below are unsettled decisions
+rather than undiscovered typos, so drafting stopped at the cap per
+`skills/drivers/ticket/verbs/triage.md` step 12.
+
+### Newly measured, and it reprices Q1
+
+`ORDER.md` left untracked in a worker's worktree breaks worktree teardown. Verified
+live: with an untracked `ORDER.md` present, `git worktree remove` exits 128 with
+"contains modified or untracked files, use --force to delete it". This repo forbids
+the force: `skills/drivers/ticket/verbs/finalize.md:144` ("A dirty worktree makes
+`worktree remove` fail. Report that and stop; never force it") and
+`skills/drivers/ticket/verbs/revise.md:21-22` (stop when `status --short` is
+non-empty, never force). So every chunked ticket would stop-and-report at chunk
+teardown and again at finalization.
+
+This was not known when Q1 was settled and it materially reprices option A. The
+file now needs an owner for its deletion, or it needs to not be in the worktree.
+
+### Also confirmed, and dependent on the Q1 re-decision
+
+- A delegated `start`, `triage`, or `revise` worker is an adapter-dispatched
+  write-mode worker (`verbs/start.md:98`, `verbs/triage.md:220`,
+  `verbs/revise.md:66`). A delegated `start` worker executes a FLAT order, so the
+  round-2 boundary claiming flat orders are never dispatched is false as written.
+- The inventory's stop-and-report escape clause is scoped to "write-mode
+  dispatchers" while the inventory itself lists "pages stating a prompt-file rule".
+  Different sets; a correct implementer would halt on the mismatch.
+- Appendix item 3's grep misses the phrase "positional prompt", so
+  `skills/tools/code-review/SKILL.md:195-199` and
+  `skills/drivers/orchestrate/references/dispatch-claude.md:56-61` were absent. The
+  order's claim that dispatch-claude.md states no prompt rule was a grep artifact.
+- Done-when bullet 1 ("the only page in the repo that states them") is
+  unsatisfiable against step 4c's spec delta and step 5's behavior test, which must
+  both carry the clause text.
+
 ## Open questions
 
-_None. The frontier is empty; every question above is settled in `Decisions`._
+- Q4. Who deletes the durable order, and when. Blocks redrafting.
 
 ## Spawned tasks
 

--- a/docs/scope/255-compaction-proof-worker-orders.md
+++ b/docs/scope/255-compaction-proof-worker-orders.md
@@ -157,9 +157,38 @@ file now needs an owner for its deletion, or it needs to not be in the worktree.
   ordinary adapter-dispatched write-mode worker and gets an `ORDER.md`. Only a flat
   fence executed directly by the `/ticket start` session does not.
 
+## Round 5 — three-panel cap reached
+
+The final cold panel returned three blockers and two notes, all verified and all
+fixed. None reopened a decision; each was a precision defect in the contract's own
+wording, with a determinate correction:
+
+- `fence-less` and `write-mode`/`read-mode` appear nowhere else in the pack
+  (`grep -rn 'fence-less' skills/` returns nothing; `write-mode` hits only an
+  unrelated ADR filename). Clause 1a now defines both terms against the adapters'
+  real `--sandbox` values at first use.
+- The coverage hole that mattered: a delegated `start` worker's prompt carries a
+  flat work-order fence, so it was neither "a sub-order fence" nor "fence-less",
+  and neither producer of the standing instruction fired on the pack's most common
+  write-mode dispatch. Clause 1b now branches on "a chunk sub-order fence" versus
+  "every other write-mode dispatch".
+- A delegated `triage` or `revise` prompt has no `Done when` heading, so 1b now
+  says "the order's acceptance list"; only the sub-order fence boilerplate names
+  `Done when` literally.
+- Clause 1d bound resumes to `ORDER.md` for read-only reviewers, which 1f gives no
+  such file. Now scoped to write-mode workers.
+- Done-when bullet 1 forbade the very teardown edits bullet 3 mandates. Its
+  carve-out now names all four: the three teardown sites carry clause 1h
+  operationally, the fence boilerplate is the worker-facing instruction, and the
+  spec delta and test are the record and its evidence.
+
+Panel counts: 4 authoring blockers, then 2 injected, then 4 (2 injected), then 3.
+The three-panel cap is now spent. The final fixes carry no fresh cold pass, which
+is stated to the operator at approval rather than papered over.
+
 ## Open questions
 
-_None. Frontier empty; the order is redrafted clean and goes to a final panel._
+_None. The order awaits operator approval before posting._
 
 ## Spawned tasks
 

--- a/docs/scope/255-compaction-proof-worker-orders.md
+++ b/docs/scope/255-compaction-proof-worker-orders.md
@@ -131,9 +131,35 @@ file now needs an owner for its deletion, or it needs to not be in the worktree.
   unsatisfiable against step 4c's spec delta and step 5's behavior test, which must
   both carry the clause text.
 
+## Round 4 — Q4 settled, order rewritten clean
+
+- Q4 settled: A, made deterministic (`inline`). The durable order is deleted by the
+  teardown steps themselves, not after a successful dispatch. Teardown is the exact
+  path that fails today, so putting the delete there covers a dead coordinator, an
+  abandoned worker, and a crashed dispatch alike; a delete on the happy path would
+  not. One fact, one implementation: there is no second delete on the collect-result
+  path.
+- The three teardown sites, all already existing: chunk teardown
+  (`skills/drivers/ticket/references/coordinator-mode.md` step 5), ticket teardown
+  (`skills/drivers/ticket/verbs/finalize.md` step 4), and the stale-worktree respin
+  (`skills/drivers/ticket/verbs/revise.md` step 2, which stops when
+  `status --short` is non-empty). The delete precedes `git worktree remove` and that
+  cleanliness check.
+- Measured (`inline`): deleting the file unblocks teardown (`git worktree remove`
+  exits 0). An *ignored* `ORDER.md` also does not block teardown and is invisible to
+  `status --short`, but that route was rejected: it would require a committed
+  `.gitignore` entry in every consuming repo, and it would hide the file from the
+  pre-merge diff read that is the never-committed rule's only enforcement.
+- Consequence accepted (`inline`): the allowlist grows to six skill pages, adding
+  `verbs/finalize.md` and `verbs/revise.md`. Larger than the change first looked,
+  and each page is evidenced rather than speculative.
+- Settled (`inline`): a delegated `start`, `triage`, or `revise` worker is an
+  ordinary adapter-dispatched write-mode worker and gets an `ORDER.md`. Only a flat
+  fence executed directly by the `/ticket start` session does not.
+
 ## Open questions
 
-- Q4. Who deletes the durable order, and when. Blocks redrafting.
+_None. Frontier empty; the order is redrafted clean and goes to a final panel._
 
 ## Spawned tasks
 

--- a/openspec/changes/255-compaction-proof-worker-orders/design.md
+++ b/openspec/changes/255-compaction-proof-worker-orders/design.md
@@ -1,0 +1,24 @@
+# Design
+
+## ADR 255 — The durable order lives in the worker's own worktree
+
+Write the complete prompt bytes to `ORDER.md` at the root of each write-mode
+worker's cwd before dispatch. A compacted worker can rediscover a fixed name in its
+own working directory; a coordinator-side path would itself be context that the
+worker could forget and may be unreadable from the worker's sandbox.
+
+The order file is the original prompt in a second location, not new mid-session
+input. The original-prompt-only worker-input rule therefore remains unchanged: the
+coordinator still supplies the same bytes at dispatch, and later resumes only
+restate the existing constraints or point the worker back to them.
+
+Cleanup belongs to the step that tears the worktree down. An abandoned or crashed
+dispatch can bypass a happy-path cleanup, while the teardown step necessarily runs
+before the operation that an untracked order file would block. The three existing
+teardown sites delete the file immediately before worktree removal or the
+cleanliness check.
+
+No mechanical never-committed enforcement is added. A shared Git exclusion would
+also hide the file from the coordinator's pre-merge diff, and a committed ignore,
+hook, or new gate would exceed the accepted risk contract. The worker instruction
+and the coordinator's existing diff read are the whole enforcement.

--- a/openspec/changes/255-compaction-proof-worker-orders/proposal.md
+++ b/openspec/changes/255-compaction-proof-worker-orders/proposal.md
@@ -1,0 +1,21 @@
+# Keep worker orders available after compaction
+
+## Why
+
+A write-mode worker can lose the constraints in its initial prompt when its context
+compacts. The coordinator's session-scratch copy is outside the worker's own cwd, so
+the worker cannot reliably recover the order and may continue past its closed
+acceptance list.
+
+## What changes
+
+- Put the complete prompt bytes in the write-mode worker's own worktree before
+  dispatch and make that file the worker's standing re-read target.
+- Stop and resume safely when the order is missing or unreadable, and keep resume
+  messages anchored to the durable order.
+- Delete the worktree-local scaffold at the existing teardown sites so it cannot
+  block worktree removal or cleanliness checks.
+- Pin the single normative contract, its pointer-only references, the sub-order
+  instruction, and teardown ordering in a behavior test.
+
+No adapter or worker-lifecycle code changes.

--- a/openspec/changes/255-compaction-proof-worker-orders/specs/planning-and-review/spec.md
+++ b/openspec/changes/255-compaction-proof-worker-orders/specs/planning-and-review/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Write-mode workers retain a durable closed order
+
+Before starting a write-mode worker, the coordinator MUST write the same complete
+prompt bytes supplied to the adapter to `ORDER.md` at the root of the worker's cwd.
+The prompt MUST instruct the worker to re-read that file before each commit and
+before declaring the work done, treat the acceptance list as closed, stop and report
+when it is met, and propose further improvement instead of editing beyond it. Chunk
+sub-order boilerplate MUST carry that instruction; the coordinator MUST author it
+for every other write-mode prompt, including a delegated flat work order.
+
+A worker that cannot find or read the file MUST stop and report instead of
+continuing from memory. The coordinator MUST rewrite it and resume the same worker.
+Every write-mode resume MUST restate the order's constraints or point back to the
+file. A coordinator that cannot write the file MUST report the dispatch unavailable
+and MUST NOT start the worker. Read-mode workers MUST NOT receive the file.
+
+The order file MUST remain uncommitted worktree-local scaffolding. The step that
+removes a worker worktree MUST delete it before worktree removal and before any
+cleanliness check. The repository MUST contain a behavior test that pins the
+canonical guidance, worker-facing instruction, pointer-only references, and cleanup
+ordering.
+
+#### Scenario: A compacted worker re-reads its order
+
+- **WHEN** a write-mode worker's context compacts before its next commit or completion
+- **THEN** the worker re-reads the complete prompt bytes from its own cwd and stops
+  once the closed acceptance list is met
+
+#### Scenario: The durable order is unreadable
+
+- **WHEN** a write-mode worker cannot find or read its order file
+- **THEN** it stops and reports, and the coordinator rewrites the file and resumes
+  that same worker
+
+#### Scenario: The coordinator cannot write the order
+
+- **WHEN** the coordinator cannot write the complete prompt bytes into the worker's
+  cwd before dispatch
+- **THEN** it reports the dispatch unavailable and does not start the worker
+
+#### Scenario: A worker worktree is torn down
+
+- **WHEN** a workflow reaches an existing worktree teardown or stale-worktree
+  cleanliness check
+- **THEN** it deletes the order file before the operation that the untracked file
+  would block
+
+#### Scenario: Durable-order guidance regresses
+
+- **WHEN** the canonical rule, worker-facing instruction, pointer direction, or
+  teardown ordering is removed or weakened
+- **THEN** the behavior test fails

--- a/openspec/changes/255-compaction-proof-worker-orders/tasks.md
+++ b/openspec/changes/255-compaction-proof-worker-orders/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Define the write-mode durable-order contract in the orchestrate skill.
+- [x] Point ticket dispatch guidance at the canonical contract and add the sub-order
+  standing instruction.
+- [x] Delete the worktree-local order at all three existing teardown sites.
+- [x] Record the decision and planning-and-review delta in this OpenSpec change.
+- [x] Verify the contract with `scripts/validate.py` and `tests/test_behavior.py`,
+  then run the full repository gate and strict OpenSpec validation.

--- a/skills/drivers/orchestrate/SKILL.md
+++ b/skills/drivers/orchestrate/SKILL.md
@@ -277,6 +277,35 @@ prompt bytes to session scratch and pass that file's contents as the selected
 adapter's positional prompt. Use one state file per dispatch; state is lifecycle
 metadata only, never the child result.
 
+For this rule, a worker started with `--sandbox workspace-write` is a write-mode
+dispatch, while a worker started with `--sandbox read-only` is a read-mode dispatch.
+Before starting a worker with `--sandbox workspace-write`, the coordinator writes
+the same complete prompt bytes to `ORDER.md` at the root of that worker's own cwd,
+so the order survives the worker's context compaction.
+
+Those prompt bytes carry a standing instruction telling the worker to re-read
+`ORDER.md` before each commit and again before declaring the work done, and to treat
+the order's acceptance list as closed: when it is met, the worker stops and reports,
+and proposes any further improvement rather than making it. On a dispatch whose
+prompt is a chunk sub-order fence, the fence boilerplate supplies that instruction
+because such a prompt admits no coordinator commentary. On every other write-mode
+dispatch the coordinator authors it, including a delegated worker whose prompt
+carries a flat work-order fence; that fence deliberately does not carry the line.
+
+A worker that cannot find or read `ORDER.md` stops and reports rather than continuing
+from memory. The coordinator writes the file again and resumes that same worker.
+Every resume message to a write-mode worker must restate the order's constraints or
+point it back at `ORDER.md`, because a resume is coordinator-authored and is the
+freshest context the worker has.
+
+`ORDER.md` is worktree-local scaffolding: it is never committed to the branch and
+never pushed. This instruction plus the diff the coordinator already reads before
+merging is the whole enforcement. Read-mode workers get no `ORDER.md`; this rule
+covers write-mode dispatch only. A coordinator that cannot write `ORDER.md` into a
+write-mode worker's cwd reports the dispatch unavailable and does not start the
+worker. Whichever step removes a worker's worktree deletes `ORDER.md` first, before
+`git worktree remove` and before any `status --short` cleanliness check.
+
 The result locator is the artifact that carries the child's answer: captured
 launcher stdout, a named worktree or branch for implementation changes, or a
 posted comment when the child declares that handoff. Use the adapter's start,

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -65,6 +65,9 @@ graph-identity rule.
    coordinator decision/action milestone immediately. The shared state-change rule
    still reports any external state change the coordinator caused.
 
+   The durable-order rule for this write-mode dispatch lives at
+   `skills/drivers/orchestrate/SKILL.md` `## Collect child results`.
+
    For chunk `<n>` and dispatch attempt `<attempt>`, the coordinator writes the
    complete prompt bytes to
    `<session-scratch>/ticket-<ticket-id-lowercase>-chunk-<n>-attempt-<attempt>.prompt`
@@ -130,7 +133,8 @@ non-blocking rule.
    so in the report; anything else goes back to the user as a slicing defect. After a
    chunk merges, remove its worktree and delete its branch (run
    `<cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <path>` while that checkout
-   still exists, then `git -C <control checkout> worktree remove <path>` and
+   still exists, then `rm -f <path>/ORDER.md`,
+   `git -C <control checkout> worktree remove <path>`, and
    `git -C <control checkout> branch -D <chunk branch>`). Chunk branches are never
    pushed, so there is no remote branch to delete.
 

--- a/skills/drivers/ticket/references/drafting-conventions.md
+++ b/skills/drivers/ticket/references/drafting-conventions.md
@@ -11,7 +11,8 @@ Adapter prompts are prompt text passed positionally. The coordinator writes each
 complete prompt to session scratch, passes that file's contents as the adapter's
 positional prompt text, and never invents adapter flags or changes. Each dispatch
 has one coordinator-owned state file; state is lifecycle metadata, never the
-worker's result.
+worker's result. The durable-order rule for adapter prompts lives at
+`skills/drivers/orchestrate/SKILL.md` `## Collect child results`.
 
 An expected diff is a closed allowlist of repository-relative paths. It has no
 escape clause. A generated-facts appendix records deterministic commands and their

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -188,6 +188,10 @@ Done when
 <observable acceptance for this chunk alone>
 
 Boundaries
+* Re-read `ORDER.md` before each commit and again before declaring the work done;
+  `Done when` is closed, so when it is met stop and report, and propose any further
+  improvement rather than making it. If `ORDER.md` cannot be found or read, stop and
+  report rather than continuing from memory.
 * Touch only <files/targets this chunk owns>. Another chunk owns <the rest>.
 * A parallel chunk must not implement, revise, or depend on this chunk's private
   capability. Name any shared contract and its one owning sub-order instead.

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -136,6 +136,7 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
 
    ```sh
    <cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <worktree path>
+   rm -f <worktree path>/ORDER.md
    git -C <control checkout> worktree remove <worktree path>
    git -C <control checkout> branch -D <ticket branch>
    git -C <control checkout> worktree prune

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -18,8 +18,9 @@ chunked: the chunks merged long ago and the pull request is one diff.
    request's `headRefName`. Match: work there. Mismatch: the worktree belongs to a
    different round or ticket state, so remove it if clean (run
    `<cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <path>` while the checkout
-   still exists, then `git -C <control checkout> worktree remove <path>`, reporting
-   and stopping if `git -C <worktree> status --short` is non-empty, never forcing)
+   still exists, then `rm -f <path>/ORDER.md`, reporting and stopping if
+   `git -C <worktree> status --short` is non-empty, then
+   `git -C <control checkout> worktree remove <path>`, never forcing)
    and respin fresh. No worktree at all: same respin.
 
    ```sh

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -5261,6 +5261,113 @@ class DelegationAuthorityContractTests(unittest.TestCase):
         self.assertNotIn(self.AUTHORIZATION, self.TRIAGE)
 
 
+class DurableWorkerOrderContractTests(unittest.TestCase):
+    ORCHESTRATE = ROOT / "skills" / "drivers" / "orchestrate" / "SKILL.md"
+    COORDINATOR_MODE = (
+        ROOT / "skills" / "drivers" / "ticket" / "references" / "coordinator-mode.md"
+    )
+    DRAFTING = (
+        ROOT
+        / "skills"
+        / "drivers"
+        / "ticket"
+        / "references"
+        / "drafting-conventions.md"
+    )
+    FINALIZE = ROOT / "skills" / "drivers" / "ticket" / "verbs" / "finalize.md"
+    REVISE = ROOT / "skills" / "drivers" / "ticket" / "verbs" / "revise.md"
+    TEMPLATE = ROOT / "skills" / "drivers" / "ticket" / "templates" / "work-order.md"
+
+    @staticmethod
+    def compact(text: str) -> str:
+        return " ".join(text.split()).lower()
+
+    @staticmethod
+    def section(path: Path, heading: str) -> str:
+        source = path.read_text(encoding="utf-8")
+        anchor = f"{heading}\n\n"
+        assert anchor in source
+        return source.split(anchor, 1)[1].split("\n\n## ", 1)[0]
+
+    @staticmethod
+    def pointer_sentence(path: Path) -> str:
+        source = " ".join(path.read_text(encoding="utf-8").split())
+        return next(
+            sentence.strip()
+            for sentence in source.split(". ")
+            if "durable-order rule" in sentence.lower()
+        )
+
+    def test_write_mode_workers_keep_and_recover_their_closed_order(self):
+        home = self.compact(self.section(self.ORCHESTRATE, "## Collect child results"))
+        for term in (
+            "before starting a worker with `--sandbox workspace-write`",
+            "same complete prompt bytes to `order.md` at the root of that worker's own cwd",
+            "re-read `order.md` before each commit and again before declaring the work done",
+            "acceptance list as closed",
+            "proposes any further improvement rather than making it",
+            "chunk sub-order fence",
+            "every other write-mode dispatch the coordinator authors it",
+            "cannot find or read `order.md` stops and reports",
+            "writes the file again and resumes that same worker",
+            "every resume message to a write-mode worker",
+            "restate the order's constraints or point it back at `order.md`",
+            "worktree-local scaffolding",
+            "never committed to the branch and never pushed",
+            "read-mode workers get no `order.md`",
+            "reports the dispatch unavailable and does not start the worker",
+            "deletes `order.md` first",
+            "before `git worktree remove` and before any `status --short` cleanliness check",
+        ):
+            with self.subTest(home_term=term):
+                self.assertIn(term, home)
+
+        template = self.TEMPLATE.read_text(encoding="utf-8")
+        flat = template.split("## Flat\n", 1)[1].split("\n---\n\n## Chunked", 1)[0]
+        chunked = template.split("## Chunked\n", 1)[1]
+        chunked_header, sub_order = chunked.split("SUB-ORDER 1/<n>", 1)
+        flat = self.compact(flat)
+        chunked_header = self.compact(chunked_header)
+        sub_order = self.compact(sub_order)
+        standing_instruction = (
+            "re-read `order.md` before each commit and again before declaring the work done"
+        )
+        self.assertIn(standing_instruction, sub_order)
+        self.assertIn("`done when` is closed", sub_order)
+        self.assertIn("propose any further improvement rather than making it", sub_order)
+        self.assertIn("stop and report rather than continuing from memory", sub_order)
+        self.assertNotIn(standing_instruction, flat)
+        self.assertNotIn(standing_instruction, chunked_header)
+
+        for path in (self.COORDINATOR_MODE, self.DRAFTING):
+            with self.subTest(pointer=path):
+                pointer = self.pointer_sentence(path)
+                self.assertIn(
+                    "skills/drivers/orchestrate/skill.md", pointer.lower()
+                )
+                self.assertIn("## collect child results", pointer.lower())
+                self.assertNotIn("ORDER.md", pointer)
+                for clause in (
+                    "before each commit",
+                    "acceptance list",
+                    "context compaction",
+                    "never committed",
+                    "cannot find or read",
+                ):
+                    self.assertNotIn(clause, pointer.lower())
+
+        teardown_checks = (
+            (self.COORDINATOR_MODE, "<path>/ORDER.md", "worktree remove <path>"),
+            (self.FINALIZE, "<worktree path>/ORDER.md", "worktree remove <worktree path>"),
+            (self.REVISE, "<path>/ORDER.md", "status --short"),
+        )
+        for path, order_file, later_step in teardown_checks:
+            with self.subTest(teardown=path):
+                source = path.read_text(encoding="utf-8")
+                self.assertIn(order_file, source)
+                self.assertLess(source.index(order_file), source.index(later_step))
+
+
 class LiveProseContractTests(unittest.TestCase):
     def test_reviewer_routing_and_admission_rules_remain_explicit(self):
         routing = (ROOT / "skills/drivers/orchestrate/references/review-routing.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Motivation and Context

Write-mode model workers now keep their complete order in their own working directory and re-read it before each commit and before reporting completion. Previously the recoverable copy lived only in coordinator scratch while the worker relied on context that could compact away.

* The order tells the worker to treat its acceptance list as closed: stop when it is met, and propose later improvements instead of making them. Chunk workers receive that instruction in their self-contained sub-order; other write-mode prompts receive it from the coordinator.
* A worker that cannot read its order stops and reports. A coordinator that cannot write the order does not start the worker; after rewriting a missing order, it resumes the same worker and points the fresh context back to it.
* The order file is untracked worktree scaffolding. The three existing teardown paths remove it before cleanliness checks or worktree removal; read-only workers receive no file.
* The decision and admitted-risk record remains active under `openspec/changes/255-compaction-proof-worker-orders/`. Adapter and worker-lifecycle code are unchanged.

Fixes #255

## How Has This Been Tested?

```text
Fail-first durable-order contract:
Ran 1 test
FAILED (failures=18)
all failures on absent canonical clauses and the sub-order instruction

Post-change durable-order contract:
Ran 1 test
OK

Full repository verification on committed HEAD:
validated 27 skills and 401 files
Ran 472 tests in 84.480s
OK (skipped=23)
py_compile exit=0

Strict OpenSpec validation:
Totals: 4 passed, 0 failed (4 items)

Full two-axis review:
Standards: 14 rules checked, 0 violated
Spec: 11 criteria and 4 risk entries checked, 0 unmet
Converged in round 1
```

The behavior test falsifies drift in the agent-facing contract. It does not enforce the boundary at runtime; no Git exclusion, hook, or coordinator gate was added.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
