### PR TITLE
Remove unread ticket telemetry

### DIFF
--- a/docs/scope/259-remove-unused-ticket-telemetry.md
+++ b/docs/scope/259-remove-unused-ticket-telemetry.md
@@ -1,0 +1,46 @@
+# Scope ledger — ticket 259: remove unused ticket telemetry
+
+## Decisions
+
+- Delete the unread `telemetry.jsonl` write without a replacement aggregate.
+  Why: reviewer memory already persists the same slicing record for its real
+  readers, and there is no current cross-repository consumer. Disposition:
+  `inline`.
+- Preserve `record`'s JSON stdout and move persistence-coupled assertions to that
+  public interface. Why: stdout already carries the complete record consumed by
+  finalization. Disposition: `inline`.
+- Leave `claims.jsonl`, reviewer-memory persistence, existing local telemetry
+  files, frozen ADRs, and archived OpenSpec changes unchanged. Why: they are either
+  load-bearing current state or immutable history, while deleting operator data is
+  outside this ticket. Disposition: `inline`.
+
+### Risk contract
+
+- **Must prevent:** changing `record` stdout or verdicts; changing claim storage or
+  attribution; deleting existing telemetry files; dropping reviewer-memory
+  persistence; secret exposure, irreversible authoritative-data loss, or silent
+  incorrect success.
+- **Must recover:** none.
+- **Accepted failure:** old telemetry files remain inert until manually removed.
+- **Unsupported:** telemetry migration, a cross-repository reader, or automatic
+  slicing-rubric tuning.
+- **Evidence owed:** public-command stdout tests, the finalization behavior pin,
+  OpenSpec validation, and the repository gate.
+- **Why:** this is a local advisory-measurement cleanup; the only load-bearing
+  surfaces are the existing stdout and reviewer-memory contracts.
+- **Disposition:** `inline`.
+
+## Open questions
+
+None.
+
+## Spawned tasks
+
+None.
+
+## Review rounds
+
+- Round 1: 0 `authoring` blockers and 0 `injected` blockers. The grounded order
+  was countersigned without revision. Non-blocking checks confirmed that the full
+  role-aware measurement scenarios stay in the active spec delta and that record
+  field/privacy assertions move to stdout without a replacement helper or store.

--- a/openspec/changes/259-remove-unused-ticket-telemetry/proposal.md
+++ b/openspec/changes/259-remove-unused-ticket-telemetry/proposal.md
@@ -1,0 +1,38 @@
+# Remove the unread ticket telemetry store
+
+## Why
+
+`ticket.py record` appends every measurable slicing verdict to
+`~/.config/ticket/telemetry.jsonl`, but the pack has no reader for that file.
+Finalization already sends the same record to the per-repository reviewer-memory
+store, which is the durable source that triage and review actually consume.
+Keeping the parallel write adds a sandbox failure path and couples public-command
+tests to private persistence without serving a reader.
+
+## What changes
+
+- Stop `record` from creating or appending `telemetry.jsonl`; keep its JSON stdout
+  contract and all verdict calculations unchanged.
+- Move record assertions to the command's stdout and remove tests that exist only
+  for the unused write and its write-denial path.
+- Describe finalization as returning the record for reviewer-memory to persist, and
+  carry a ticket-workflow spec delta that renames the live behavior to role-aware
+  measurement when post-merge finalization archives the change.
+- Leave `claims.jsonl`, reviewer-memory persistence, existing telemetry files, and
+  frozen ADR and archived-change history unchanged. Do not add a cross-repository
+  aggregation helper without a current caller.
+
+## Risk contract
+
+- **Must prevent:** changing `record`'s JSON stdout or verdict semantics; changing
+  claim attribution; deleting or migrating an operator's existing telemetry file;
+  dropping finalization's reviewer-memory append; secret exposure, irreversible
+  authoritative-data loss, or silent incorrect success.
+- **Must recover:** none. The removed store is advisory output with no reader.
+- **Accepted failure:** existing `telemetry.jsonl` files remain as inert local
+  history; an operator who wants them removed does so manually.
+- **Unsupported:** reading or migrating old telemetry records, adding a new
+  cross-repository query, or automatically tuning the slicing rubric.
+- **Evidence owed:** public-interface tests parse `record` stdout for each existing
+  verdict and field assertion; behavior tests keep finalization's reviewer-memory
+  append pinned; OpenSpec validation and the repository gate pass.

--- a/openspec/changes/259-remove-unused-ticket-telemetry/specs/ticket-workflow/spec.md
+++ b/openspec/changes/259-remove-unused-ticket-telemetry/specs/ticket-workflow/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Role-aware measurement and review depth
+
+Each participating session MUST be claimable with both its responsibility
+(`coordinator`, `worker`, or `reviewer`) and the ticket lifecycle verb that
+produced the claim. Finalization MUST compute responsibility-tagged and
+verb-tagged costs separately, print the resulting record as JSON, and append that
+same record to the target repository's reviewer-memory store. It MUST NOT create
+or append a second ticket-wide telemetry store. Worker peaks alone MUST calibrate
+chunk sizing; measurable non-reviewer `start` claims alone MUST calibrate a flat
+order; triage, revise, finalize, and reviewer peaks MUST remain independent
+overhead. Claims without a lifecycle verb MUST remain readable as legacy data and
+MUST NOT be guessed into a verb. A session MUST NOT be reused under a different
+lifecycle verb; same-verb resumes remain valid, while a later verb requires a
+fresh session. Review depth MUST be stamped from change scope and sensitivity
+rather than inferred from recorded slicing outcomes.
+
+#### Scenario: A measurable ticket is finalized
+
+- **WHEN** finalization computes a slicing record from attributable claims
+- **THEN** `record` prints the complete JSON record and finalization appends those
+  bytes to reviewer memory without creating a parallel ticket telemetry file
+
+#### Scenario: A flat ticket has expensive lifecycle overhead
+
+- **WHEN** triage, revise, or finalize peaks above the slicing band while the
+  measurable non-reviewer `start` claim remains below it
+- **THEN** the flat verdict is based on the `start` peak and reports lifecycle
+  overhead separately without proposing a slicing-rubric amendment
+
+#### Scenario: A claimed flat ticket has no attributable execution
+
+- **WHEN** at least one attributable claim exists but no measurable non-reviewer
+  `start` claim exists, including when every readable claim predates
+  lifecycle-verb attribution
+- **THEN** finalization returns `unmeasurable` and makes no slicing judgment
+
+#### Scenario: A flat ticket has no attributable claims
+
+- **WHEN** no attributable in-repository claim exists
+- **THEN** finalization preserves the existing `no-data` outcome
+
+#### Scenario: A later lifecycle verb follows execution
+
+- **WHEN** revise or finalize follows the session that executed `start`
+- **THEN** the later verb runs in a fresh session so its context cannot inflate the
+  start-attributed execution peak
+
+#### Scenario: A session is re-claimed under another verb
+
+- **WHEN** `claim` receives a ticket/session pair already persisted under a
+  different lifecycle verb
+- **THEN** it preserves and prints the persisted claim, reports one visible
+  non-blocking conflict naming both verbs, and does not claim that the submitted
+  verb was stored
+
+#### Scenario: A chunked ticket has an expensive review
+
+- **WHEN** finalization records a reviewer peak above the slicing band while the
+  implementation workers remain within it
+- **THEN** the reviewer cost is reported separately and does not make the chunks
+  appear under-sliced or change their stamped review depth
+
+### Requirement: Slicing amendment verdicts
+
+Finalization MUST draft, but MUST NOT apply, a concrete slicing-rubric amendment
+for `under-sliced`, `still-degraded`, or `over-sliced` verdicts. It MUST NOT draft
+such an amendment for `no-data`, `unmeasurable`, `coordinator-only`, or
+`coordination-degraded`, and a threshold proposal MUST update both the rubric prose
+and helper constant together.
+
+#### Scenario: Measured chunks were too large
+
+- **WHEN** role-aware measurement returns `still-degraded`
+- **THEN** finalization reports the misprediction and shows the user a concrete
+  rubric diff without editing the rubric in the ticket branch

--- a/openspec/changes/259-remove-unused-ticket-telemetry/tasks.md
+++ b/openspec/changes/259-remove-unused-ticket-telemetry/tasks.md
@@ -1,11 +1,11 @@
 # Tasks
 
-- [ ] Remove the unused telemetry path, append helper, and record write-denial path
+- [x] Remove the unused telemetry path, append helper, and record write-denial path
       while preserving `record` stdout and claim storage.
-- [ ] Rewrite ticket command tests to assert stdout and remove persistence-only
+- [x] Rewrite ticket command tests to assert stdout and remove persistence-only
       setup, helpers, and cases.
-- [ ] Update finalization guidance and the active ticket-workflow spec delta without
+- [x] Update finalization guidance and the active ticket-workflow spec delta without
       editing the baseline early or rewriting frozen historical records.
-- [ ] Run `openspec validate --all --strict`, `python3 scripts/validate.py`,
+- [x] Run `openspec validate --all --strict`, `python3 scripts/validate.py`,
       `python3 -m unittest tests.test_behavior tests.test_ticket`, and the full
       repository test command from `AGENTS.md`.

--- a/openspec/changes/259-remove-unused-ticket-telemetry/tasks.md
+++ b/openspec/changes/259-remove-unused-ticket-telemetry/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [ ] Remove the unused telemetry path, append helper, and record write-denial path
+      while preserving `record` stdout and claim storage.
+- [ ] Rewrite ticket command tests to assert stdout and remove persistence-only
+      setup, helpers, and cases.
+- [ ] Update finalization guidance and the active ticket-workflow spec delta without
+      editing the baseline early or rewriting frozen historical records.
+- [ ] Run `openspec validate --all --strict`, `python3 scripts/validate.py`,
+      `python3 -m unittest tests.test_behavior tests.test_ticket`, and the full
+      repository test command from `AGENTS.md`.

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -25,12 +25,6 @@ from typing import Iterator, Optional
 PROJECTS_DIR = Path(
     os.environ.get("CLAUDE_PROJECTS_DIR", str(Path.home() / ".claude" / "projects"))
 ).expanduser()
-TELEMETRY_PATH = Path(
-    os.environ.get(
-        "TICKET_TELEMETRY",
-        str(Path.home() / ".config" / "ticket" / "telemetry.jsonl"),
-    )
-).expanduser()
 CLAIMS_PATH = Path(
     os.environ.get(
         "TICKET_CLAIMS",
@@ -569,14 +563,6 @@ def report_write_denial(path: Path, error: OSError) -> None:
     )
 
 
-def append_record(record: dict) -> Path:
-    TELEMETRY_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    with TELEMETRY_PATH.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record) + "\n")
-    TELEMETRY_PATH.chmod(0o600)
-    return TELEMETRY_PATH
-
-
 def command_scan(arguments: argparse.Namespace) -> int:
     ticket_id = validate_ticket_id(arguments.ticket_id)
     current_repo = resolve_repo(Path(arguments.project) if arguments.project else Path.cwd())
@@ -618,11 +604,6 @@ def command_record(arguments: argparse.Namespace) -> int:
         "reason": reason,
         "recorded_at": datetime.now(timezone.utc).isoformat(),
     }
-    if call not in ("no-data", "unmeasurable"):
-        try:
-            append_record(record)
-        except OSError as error:
-            report_write_denial(TELEMETRY_PATH, error)
     print(json.dumps(record, indent=2))
     return 0
 

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -61,10 +61,8 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    Record before removing that target worktree in step 4, so its repository
    identity is still available to the helper.
 
-   The helper appends one record under `~/.config/ticket/` and returns one verdict.
-   A sandboxed session that cannot write that record sees the same one-line
-   denial as the claim step, naming the path and the fix: rerun the same
-   record command outside the sandbox or with escalated permissions.
+   The helper prints one JSON record and returns one verdict. The existing next
+   step appends those same captured bytes to reviewer memory.
 
    Retain a successful record command's standard output in `record_json` and
    print it once for the coordinator. Then pipe those same captured bytes, without

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -802,14 +802,12 @@ class TicketTelemetryTests(unittest.TestCase):
         self.projects = self.scratch / "projects"
         self.projects.mkdir()
         self.codex_home = self.scratch / "codex-home"
-        self.telemetry = self.scratch / "config" / "ticket" / "telemetry.jsonl"
         self.claims = self.scratch / "config" / "ticket" / "claims.jsonl"
         self.environment = os.environ.copy()
         self.environment.pop("CLAUDE_CODE_SESSION_ID", None)
         self.environment.pop("CODEX_SESSION_ID", None)
         self.environment["CLAUDE_PROJECTS_DIR"] = str(self.projects)
         self.environment["CODEX_HOME"] = str(self.codex_home)
-        self.environment["TICKET_TELEMETRY"] = str(self.telemetry)
         self.environment["TICKET_CLAIMS"] = str(self.claims)
 
     def tearDown(self):
@@ -864,15 +862,6 @@ class TicketTelemetryTests(unittest.TestCase):
         """The ordinary case: a session ran the ticket, so it claimed it."""
         self.write_session(project, session_id, lines)
         self.claim(ticket_id, session_id, role=role, verb=verb)
-
-    def telemetry_records(self) -> list[dict]:
-        if not self.telemetry.exists():
-            return []
-        return [
-            json.loads(line)
-            for line in self.telemetry.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
 
     def test_claim_records_the_running_session_without_being_told_which(self):
         environment = self.environment.copy()
@@ -1049,7 +1038,6 @@ class TicketTelemetryTests(unittest.TestCase):
 
         self.assertEqual(json.loads(gone.stdout)["verdict"], "unmeasurable")
         self.assertIn("transcripts are gone", json.loads(gone.stdout)["reason"])
-        self.assertEqual(self.telemetry_records(), [])
 
         # A deleted transcript must not reach the durable record as a session
         # that cost nothing: that is the reading adr-70 rules out.
@@ -1059,7 +1047,7 @@ class TicketTelemetryTests(unittest.TestCase):
         )
 
         self.assertEqual(recorded.returncode, 0, recorded.stderr)
-        record = self.telemetry_records()[0]
+        record = json.loads(recorded.stdout)
         self.assertEqual(record["session_peaks"], [190_000])
         self.assertEqual(record["claim_count"], 2)
         self.assertEqual(record["unreadable"], ["session-gone"])
@@ -1130,9 +1118,7 @@ class TicketTelemetryTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["verdict"], "under-sliced")
 
-        records = self.telemetry_records()
-        self.assertEqual(len(records), 1)
-        record = records[0]
+        record = payload
         self.assertEqual(record["ticket_id"], "TICKET-7")
         self.assertEqual(record["verbs"], ["start"])
         self.assertEqual(record["traits"], ["large-diff"])
@@ -1152,7 +1138,6 @@ class TicketTelemetryTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(json.loads(result.stdout)["verdict"], "ok")
-        self.assertEqual(self.telemetry_records()[0]["verdict"], "ok")
 
     def test_flat_verdict_uses_only_non_reviewer_start_execution(self):
         self.worked(
@@ -1187,7 +1172,6 @@ class TicketTelemetryTests(unittest.TestCase):
             {"triage": 200_000, "start": 260_000, "revise": 230_000,
              "finalize": 240_000, "legacy": 0},
         )
-        self.assertEqual(self.telemetry_records()[0]["verb_peaks"], payload["verb_peaks"])
 
     def test_record_without_a_usable_peak_is_unmeasurable(self):
         # A rollout can name its session yet contain no token-count event. It
@@ -1203,7 +1187,6 @@ class TicketTelemetryTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["verdict"], "unmeasurable")
         self.assertIn("no usable context peak", payload["reason"])
-        self.assertEqual(self.telemetry_records(), [])
 
     def test_flat_claims_without_measurable_start_execution_are_unmeasurable(self):
         self.worked(
@@ -1240,8 +1223,6 @@ class TicketTelemetryTests(unittest.TestCase):
                 self.assertEqual(payload["verdict"], "unmeasurable")
                 self.assertIn(reason_fragment, payload["reason"])
 
-        self.assertEqual(self.telemetry_records(), [])
-
     def test_missing_codex_rollout_is_unmeasurable_not_no_data(self):
         self.claim("TICKET-129B", "codex-gone", agent="codex")
 
@@ -1254,7 +1235,6 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(payload["verdict"], "unmeasurable")
         self.assertIn("Codex session", payload["reason"])
         self.assertIn("rollout files", payload["reason"])
-        self.assertEqual(self.telemetry_records(), [])
 
     def test_record_chunked_order_still_degraded_when_a_chunk_peaks_high(self):
         # The chunk's cost is its own claimed worker session, not a sidechain
@@ -1307,9 +1287,6 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertIn("0 claim(s) carried an implementation-worker role", payload["reason"])
         self.assertEqual(payload["coordinator_peak"], 387_156)
         self.assertEqual(payload["worker_peaks"], [])
-        # Unlike no-data, the cost is real and is kept.
-        self.assertEqual(self.telemetry_records()[0]["verdict"], "coordinator-only")
-        self.assertEqual(self.telemetry_records()[0]["coordinator_peak"], 387_156)
 
     def test_a_coordinator_over_the_band_degrades_an_otherwise_held_slice(self):
         self.worked("TICKET-25", "proj-a", "coordinator-1", [assistant_line(300_000)])
@@ -1626,28 +1603,7 @@ class TicketTelemetryTests(unittest.TestCase):
             {"triage-1": "triage", "start-1": "start", "start-2": "start", "legacy-1": "legacy"},
         )
 
-    def test_record_write_denied_by_sandbox_reports_and_exits_zero(self):
-        self.worked("TICKET-41", "proj-a", "session-1", [assistant_line(50_000)])
-        denied_root = self.scratch / "no-write-telemetry"
-        denied_root.mkdir()
-        denied_root.chmod(0o500)
-        denied_path = denied_root / "telemetry" / "telemetry.jsonl"
-        environment = self.environment.copy()
-        environment["TICKET_TELEMETRY"] = str(denied_path)
-
-        result = self.ticket(
-            "record", "TICKET-41", "--verb", "start", "--trait", "small-diff",
-            "--depth", "light", environment=environment,
-        )
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        payload = json.loads(result.stdout)
-        self.assertEqual(payload["verdict"], "ok")
-        self.assertIn(str(denied_path), result.stderr)
-        self.assertIn("escalated", result.stderr)
-        self.assertFalse((denied_root / "telemetry").exists())
-
-    def test_record_with_no_claim_is_no_data_and_writes_nothing(self):
+    def test_record_with_no_claim_is_no_data(self):
         result = self.ticket(
             "record", "TICKET-11", "--verb", "start", "--trait", "any", "--depth", "light"
         )
@@ -1655,8 +1611,6 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["verdict"], "no-data")
-        self.assertEqual(self.telemetry_records(), [])
-        self.assertFalse(self.telemetry.exists())
 
     def test_subagent_peak_is_counted_separately_from_the_main_session_peak(self):
         self.worked(
@@ -1691,7 +1645,7 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(payload["session_count"], 1)
         self.assertEqual(payload["sessions"][0]["peak_context"], 70_000)
 
-    def test_empty_and_whitespace_ids_are_rejected_and_write_nothing(self):
+    def test_empty_and_whitespace_ids_are_rejected(self):
         for bad_id in ("", "TICKET 14", " "):
             with self.subTest(bad_id=bad_id):
                 result = self.ticket(
@@ -1699,23 +1653,8 @@ class TicketTelemetryTests(unittest.TestCase):
                 )
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("ticket:", result.stderr)
-                self.assertEqual(self.telemetry_records(), [])
 
-    def test_telemetry_parent_directory_is_created_when_absent(self):
-        # The claim already created the shared parent, so this asserts the
-        # record path creates what it needs from a clean directory.
-        self.worked("TICKET-15", "proj-a", "session-1", [assistant_line(10_000)])
-        self.assertFalse(self.telemetry.exists())
-
-        result = self.ticket(
-            "record", "TICKET-15", "--verb", "start", "--trait", "any", "--depth", "light"
-        )
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertTrue(self.telemetry.parent.exists())
-        self.assertEqual(len(self.telemetry_records()), 1)
-
-    def test_appended_record_carries_no_prose_from_the_session(self):
+    def test_record_stdout_carries_no_prose_from_the_session(self):
         secret_prose = "quietly worried this deadline is unrealistic and stressful"
         self.worked(
             "TICKET-16",
@@ -1729,9 +1668,8 @@ class TicketTelemetryTests(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        written = self.telemetry.read_text(encoding="utf-8")
-        self.assertNotIn("unrealistic", written)
-        self.assertNotIn(secret_prose, written)
+        self.assertNotIn("unrealistic", result.stdout)
+        self.assertNotIn(secret_prose, result.stdout)
         claimed = self.claims.read_text(encoding="utf-8")
         self.assertNotIn("unrealistic", claimed)
         self.assertNotIn(secret_prose, claimed)
@@ -1828,7 +1766,7 @@ class TicketTelemetryTests(unittest.TestCase):
         payload = json.loads(record.stdout)
         self.assertEqual(payload["verdict"], "under-sliced")
         self.assertEqual(payload["excluded_claims"], 0)
-        self.assertEqual(self.telemetry_records()[0]["repo"], "example.com/org/target")
+        self.assertEqual(payload["repo"], "example.com/org/target")
 
     def test_unlabelled_legacy_claim_is_unattributable_not_counted(self):
         # A claim written before `repo` existed carries no such key at all.
@@ -1867,12 +1805,6 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(payload["unattributable"], ["legacy-session"])
         self.assertEqual(payload["session_count"], 1)
         self.assertEqual(payload["peak_context"], 55_000)
-
-        persisted = self.telemetry_records()[0]
-        self.assertEqual(persisted["unattributable"], ["legacy-session"])
-        self.assertEqual(persisted["session_count"], 1)
-        self.assertEqual(persisted["peak_context"], 55_000)
-
 
     def test_ssh_and_https_remotes_for_one_repository_collide_to_the_same_identity(self):
         # An ssh remote and an https remote naming the same repository must


### PR DESCRIPTION
## Motivation and Context

Ticket measurement now returns each slicing record through JSON stdout, and finalization persists those same bytes to per-repository reviewer memory. Previously each measurable result was also appended to an unread flat telemetry file, which added a second persistence path and its sandbox-denial branch.

* Claims remain the source for participating sessions, and their attribution and write-denial handling are unchanged.
* Ticket tests inspect the command result directly. The telemetry fixture and persistence-only cases are gone, while the no-session-prose regression still covers stdout and claims.
* Existing telemetry files remain inert. This change does not read, migrate, aggregate, or delete them.
* The decision and admitted-risk record remains active under `openspec/changes/259-remove-unused-ticket-telemetry/` for post-merge finalization.

Fixes #259

## How Has This Been Tested?

```text
Fail-first public-command test:
Ran 1 test in 0.084s
FAILED (failures=1)
telemetry.jsonl existed after record returned its stdout payload

Focused behavior and ticket suites:
Ran 315 tests in 65.947s
OK (skipped=1)

Strict OpenSpec validation on final HEAD:
Totals: 4 passed, 0 failed (4 items)

Full repository verification on final HEAD:
validated 28 skills and 415 files
Ran 484 tests in 85.698s
OK (skipped=23)
py_compile exit=0

Targeted two-axis review:
Standards: 17 rules checked, 0 violated
Spec: 18 criteria and risk entries checked, 0 unmet
Converged in round 1
```

The command tests cover stdout, verdicts, claim attribution, and finalization's reviewer-memory handoff. They do not inspect or remove existing telemetry files.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
