### PR TITLE
Measure archived Codex ticket sessions

### DIFF
--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -31,9 +31,11 @@ CLAIMS_PATH = Path(
         str(Path.home() / ".config" / "ticket" / "claims.jsonl"),
     )
 ).expanduser()
-CODEX_SESSIONS_DIR = Path(
+CODEX_HOME = Path(
     os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
-).expanduser() / "sessions"
+).expanduser()
+CODEX_SESSIONS_DIR = CODEX_HOME / "sessions"
+CODEX_ARCHIVED_SESSIONS_DIR = CODEX_HOME / "archived_sessions"
 
 # Which environment variable carries the running session id, per agent. A verb
 # that cannot read one passes --session instead.
@@ -229,7 +231,11 @@ def transcripts_for(claim: dict, projects_dir: Path) -> list[Path]:
     """
     session_id = claim["session_id"]
     if claim.get("agent") == "codex":
-        return sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
+        live = CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl")
+        archived = CODEX_ARCHIVED_SESSIONS_DIR.glob(
+            f"rollout-*-{session_id}.jsonl"
+        )
+        return sorted([*live, *archived])
     parent_sessions = projects_dir.glob(f"*/{session_id}.jsonl")
     native_workers = projects_dir.glob(f"*/*/subagents/agent-{session_id}.jsonl")
     return sorted([*parent_sessions, *native_workers])

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1107,6 +1107,26 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(len(payload["sessions"][0]["transcripts"]), 2)
         self.assertEqual(payload["peak_context"], 200_000)
 
+    def test_an_archived_codex_session_remains_measurable(self):
+        directory = self.codex_home / "archived_sessions"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / "rollout-2026-01-01T00-00-00-codex-archived.jsonl"
+        path.write_text(
+            "\n".join(
+                [codex_meta_line("codex-archived"), codex_token_line(187_218)]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        self.claim("TICKET-259", "codex-archived", agent="codex")
+
+        result = self.ticket("scan", "TICKET-259")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["sessions"][0]["transcripts"], [str(path)])
+        self.assertEqual(payload["peak_context"], 187_218)
+
     def test_record_flat_order_above_degradation_band_is_under_sliced(self):
         self.worked("TICKET-7", "proj-a", "session-1", [assistant_line(200_000)])
 


### PR DESCRIPTION
## Motivation and Context

Ticket measurement now finds a claimed Codex rollout after Codex moves its thread into archived sessions. Previously the scanner searched only live sessions, so an archived start claim appeared unreadable and could turn a measurable slicing outcome into `unmeasurable`.

* Live and archived rollout matches are measured together, preserving the existing rule that a resumed session contributes its highest observed context peak.
* The regression test exercises the public scan command with an archived-only rollout and requires its path and 187,218-token peak in the result.
* Claims, role and lifecycle attribution, Claude transcript discovery, and verdict thresholds are unchanged.
* Deleted rollouts remain unreadable; this change recovers files that Codex retained under its archive directory.

## How Has This Been Tested?

```text
Fail-first archived-session test:
Ran 1 test in 0.083s
FAILED (failures=1)
scan returned an empty transcript list

Post-change archived-session test:
Ran 1 test in 0.074s
OK

Ticket suite:
Ran 86 tests in 6.549s
OK

Full repository verification:
validated 28 skills and 415 files
Ran 485 tests in 159.086s
OK (skipped=23)
py_compile exit=0
```

The regression covers Codex's live and archived rollout locations. It does not reconstruct a rollout that Codex no longer retains.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have stepped through the README as though I was a new user to ensure clarity.
- [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
- [ ] I have labeled all "TO DO" items with associated Jira ticket number.
- [x] I have removed commented code from PRs to `main`.
- [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
