### PR TITLE
Preflight OpenSpec rename applicability before merge

### DIFF
--- a/docs/scope/265-generated-facts.md
+++ b/docs/scope/265-generated-facts.md
@@ -21,11 +21,32 @@ exit=0
 $ openspec validate 259-remove-unused-ticket-telemetry --strict
 Change '259-remove-unused-ticket-telemetry' is valid
 exit=0
+$ openspec archive 259-remove-unused-ticket-telemetry --json --yes
+stdout:
+{
+  "archive": null,
+  "root": {
+    "path": "/private/tmp/ticket-265-reproduce-259/raw-archive",
+    "source": "nearest"
+  },
+  "status": [
+    {
+      "severity": "error",
+      "code": "archive_spec_update_failed",
+      "message": "ticket-workflow MODIFIED failed for header \"### Requirement: Role-aware measurement and review depth\" - not found",
+      "fix": "Fix the change delta specs and rerun. No files were changed."
+    }
+  ]
+}
+stderr:
+<empty>
+exit=1
 $ /opt/homebrew/opt/python@3.14/bin/python3.14 docs/scope/265-probes/preflight_openspec.py 259-remove-unused-ticket-telemetry --repo .
 ticket: ticket-workflow MODIFIED failed for header "### Requirement: Role-aware measurement and review depth" - not found
 ticket: if this requirement was renamed, add a `## RENAMED Requirements` mapping from its current baseline header to the unmatched delta header; otherwise correct the MODIFIED header.
 exit=1
 source_unchanged=true
+raw_failure_shape_matches=true
 ```
 
 ## Archive command surface
@@ -99,11 +120,12 @@ Output:
 
 ```text
 - Validating...
+✓ change/258-consent-grant-single-source
 ✓ change/265-preflight-openspec-rename-applicability
 ✓ spec/pack-integrity
 ✓ spec/planning-and-review
 ✓ spec/ticket-workflow
-Totals: 4 passed, 0 failed (4 items)
+Totals: 5 passed, 0 failed (5 items)
 ```
 
 ## Host Python runtimes

--- a/docs/scope/265-generated-facts.md
+++ b/docs/scope/265-generated-facts.md
@@ -59,7 +59,7 @@ Options:
 Command:
 
 ```sh
-/opt/homebrew/bin/python3.14 docs/scope/265-probes/discover_changed_openspec.py --repo . --base origin/main
+/opt/homebrew/bin/python3.14 docs/scope/265-probes/discover_changed_openspec.py --repo . --base-ref refs/remotes/origin/HEAD
 ```
 
 Output:

--- a/docs/scope/265-generated-facts.md
+++ b/docs/scope/265-generated-facts.md
@@ -68,6 +68,24 @@ Output:
 265-preflight-openspec-rename-applicability
 ```
 
+## Base advances after branch cut
+
+Command:
+
+```sh
+/opt/homebrew/bin/python3.14 docs/scope/265-probes/reproduce_base_advance.py
+```
+
+Output:
+
+```text
+stale_ticket_baseline_exit=0
+ticket: OpenSpec change 265-preflight-openspec-rename-applicability applies cleanly in a disposable copy
+current_base_composite_exit=1
+ticket: ticket-workflow MODIFIED failed for header "### Requirement: Four-verb lifecycle" - not found
+ticket: if this requirement was renamed, add a `## RENAMED Requirements` mapping from its current baseline header to the unmatched delta header; otherwise correct the MODIFIED header.
+```
+
 ## Current OpenSpec validation
 
 Command:

--- a/docs/scope/265-generated-facts.md
+++ b/docs/scope/265-generated-facts.md
@@ -1,0 +1,114 @@
+# Generated facts: issue 265 OpenSpec applicability
+
+Every block below is verbatim output from the named command in the issue 265
+worktree. Regenerate this file after changing the cited probe, OpenSpec change, or
+verification runtime.
+
+## Historical regression
+
+Command:
+
+```sh
+/opt/homebrew/bin/python3.14 docs/scope/265-probes/reproduce_259.py
+```
+
+Output:
+
+```text
+$ openspec --version
+1.11.0
+exit=0
+$ openspec validate 259-remove-unused-ticket-telemetry --strict
+Change '259-remove-unused-ticket-telemetry' is valid
+exit=0
+$ /opt/homebrew/opt/python@3.14/bin/python3.14 docs/scope/265-probes/preflight_openspec.py 259-remove-unused-ticket-telemetry --repo .
+ticket: ticket-workflow MODIFIED failed for header "### Requirement: Role-aware measurement and review depth" - not found
+ticket: if this requirement was renamed, add a `## RENAMED Requirements` mapping from its current baseline header to the unmatched delta header; otherwise correct the MODIFIED header.
+exit=1
+source_unchanged=true
+```
+
+## Archive command surface
+
+Command:
+
+```sh
+openspec archive --help
+```
+
+Output:
+
+```text
+Usage: openspec archive [options] [change-name]
+
+Archive a completed change and update main specs
+
+Options:
+  -y, --yes      Skip confirmation prompts
+  --skip-specs   Skip spec update operations (useful for infrastructure,
+                 tooling, or doc-only changes)
+  --no-validate  Skip validation (not recommended, requires confirmation)
+  --json         Output as JSON (non-interactive)
+  --store <id>   Store id to use as the OpenSpec root (a store is a standalone
+                 OpenSpec repo you've registered)
+  -h, --help     display help for command
+```
+
+## Changed active-change discovery
+
+Command:
+
+```sh
+/opt/homebrew/bin/python3.14 docs/scope/265-probes/discover_changed_openspec.py --repo . --base origin/main
+```
+
+Output:
+
+```text
+265-preflight-openspec-rename-applicability
+```
+
+## Current OpenSpec validation
+
+Command:
+
+```sh
+openspec validate --all --strict
+```
+
+Output:
+
+```text
+- Validating...
+✓ change/265-preflight-openspec-rename-applicability
+✓ spec/pack-integrity
+✓ spec/planning-and-review
+✓ spec/ticket-workflow
+Totals: 4 passed, 0 failed (4 items)
+```
+
+## Host Python runtimes
+
+Command:
+
+```sh
+/opt/homebrew/bin/python3.14 --version
+```
+
+Output:
+
+```text
+Python 3.14.7
+```
+
+Command:
+
+```sh
+python3 --version
+```
+
+Output:
+
+```text
+Python 3.9.6
+```

--- a/docs/scope/265-generated-facts.md
+++ b/docs/scope/265-generated-facts.md
@@ -79,9 +79,10 @@ Command:
 Output:
 
 ```text
-stale_ticket_baseline_exit=0
+before_fetch_exit=0
 ticket: OpenSpec change 265-preflight-openspec-rename-applicability applies cleanly in a disposable copy
-current_base_composite_exit=1
+fetch_exit=0
+after_fetch_exit=1
 ticket: ticket-workflow MODIFIED failed for header "### Requirement: Four-verb lifecycle" - not found
 ticket: if this requirement was renamed, add a `## RENAMED Requirements` mapping from its current baseline header to the unmatched delta header; otherwise correct the MODIFIED header.
 ```

--- a/docs/scope/265-generated-facts.md
+++ b/docs/scope/265-generated-facts.md
@@ -108,6 +108,21 @@ ticket: ticket-workflow MODIFIED failed for header "### Requirement: Four-verb l
 ticket: if this requirement was renamed, add a `## RENAMED Requirements` mapping from its current baseline header to the unmatched delta header; otherwise correct the MODIFIED header.
 ```
 
+## Option-shaped base ref stays local
+
+Command:
+
+```sh
+/opt/homebrew/bin/python3.14 docs/scope/265-probes/discover_changed_openspec.py --repo . --base-ref=--remote=ssh://example.invalid/repo; probe_status=$?; printf 'exit=%s\n' "$probe_status"
+```
+
+Output:
+
+```text
+base ref does not resolve to a local commit: --remote=ssh://example.invalid/repo
+exit=2
+```
+
 ## Current OpenSpec validation
 
 Command:

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -26,6 +26,10 @@
   parsed `archive: null` and `archive_spec_update_failed` shape is load-bearing
   third-party behavior and the existing generated facts suppress those bytes.
   Disposition: inline.
+- Resolve the caller-owned base ref locally with Git's end-of-options form to a
+  verified commit object ID, then use only that object ID for merge-base and export.
+  Why: an option-shaped public argument must not become `git archive --remote` or
+  another Git option. Disposition: inline.
 - Slice implementation into two serial chunks: the public CLI and executable
   contract evidence first; its three workflow consumers and OpenSpec contract
   alignment second. Why: both multiple-deliverable-artifacts and lockstep-copies-of-
@@ -48,8 +52,9 @@
 - **Evidence owed:** public-command tests for historical #259, changed-path
   discovery, JSON shapes, current-base composition, fetch timing/failure, ordinary
   delta kinds, source/base immutability, executable launch failure, base export
-  failure, overlay failure, and temporary-directory cleanup on every recovery path;
-  strict OpenSpec and full repository verification.
+  failure, overlay failure, an option-shaped base ref rejected locally without a
+  remote invocation, and temporary-directory cleanup on every recovery path; strict
+  OpenSpec and full repository verification.
 
 Why: this prices the smallest non-mutating gate that prevents the observed
 post-merge failure. Disposition: inline.
@@ -103,3 +108,10 @@ None.
   eligibility, ordering, base refs, bypass, and outbound boundaries.
 - Renewed cycle, panel 1 re-check: no blockers; same-reviewer `PASS`. A fresh cold
   pass remains required for the load-bearing countersign.
+- Renewed cycle, panel 2 fresh cold pass: two verified `authoring` blockers and one
+  refuted claim. Verified: both chunks claimed portions of `tests/test_ticket.py`,
+  violating start's disjoint-ownership sufficiency check; caller-owned base refs
+  lacked an end-of-options/local-commit boundary before Git archive. Refuted: the
+  initial chunk's `parallel` mode is the schema's predecessor-free form, not a
+  concurrency claim; there is no `serial after 0`, and the successor remains
+  `serial after 1`.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -1,0 +1,65 @@
+# Scope: preflight OpenSpec rename applicability
+
+## Decisions
+
+- Use the existing `ticket.py` command interface rather than a one-caller module.
+  Why: the behavior belongs to ticket execution and the separate module would not
+  survive the deletion test. Disposition: → ADR (ADR 265 in the active change).
+- Export the freshly fetched base ref's current OpenSpec tree, overlay the ticket's
+  one active change, and run the real archive command in that disposable composite.
+  Why: OpenSpec 1.11.0 has no archive dry-run, and the composite catches baseline
+  advances without mutating or rebasing the ticket branch. Disposition: → ADR (ADR
+  265 in the active change).
+- Zero changed active changes is a no-op, exactly one is preflighted, and more than
+  one stops. Why: an ordinary ticket owns one active change and finalization owns one
+  archive; independent multi-change checks cannot prove serial interaction.
+  Disposition: inline.
+- Every caller fetches `origin` immediately before the gate and stops on fetch or
+  base-ref failure. Why: the remote fixture proves a stale tracking ref passes before
+  fetch and fails after refresh. Disposition: inline.
+
+### Risk contract
+
+- **Must prevent:** mutating, folding, moving, or archiving the authoritative active
+  change or baseline before merge; approving a stale-base, null, error, malformed,
+  or wrong-typed archive result; secret exposure, irreversible authoritative-data
+  loss, or silent incorrect success.
+- **Must recover:** temporary export/overlay or CLI failure stops visibly and the
+  disposable directory is cleaned automatically.
+- **Accepted failure:** unexpected third-party output, fetch failure, unresolved
+  base, or several active ticket changes stops for manual correction/re-scoping.
+- **Unsupported:** automatic delta repair, inferring old requirement headers,
+  multi-change ordinary tickets, changing OpenSpec's validator, or replacing the
+  post-merge archive lifecycle.
+- **Evidence owed:** public-command tests for historical #259, changed-path
+  discovery, JSON shapes, current-base composition, fetch timing/failure, ordinary
+  delta kinds, and source/base immutability; strict OpenSpec and full repository
+  verification.
+
+Why: this prices the smallest non-mutating gate that prevents the observed
+post-merge failure. Disposition: inline.
+
+## Open questions
+
+None.
+
+## Spawned tasks
+
+None.
+
+## Review rounds
+
+- Panel 1 initial cold pass: five `authoring` blockers — no durable #259 evidence;
+  unspecified change discovery/chunked caller; revise record edits after push;
+  under-specified JSON shape; missing host-interpreter substitution.
+- Panel 1 re-check 1: one `authoring` blocker (caller-owned base source) and two
+  `injected` blockers (deleted-path discovery and unsound independent multi-change
+  support).
+- Panel 1 re-check 2: one `authoring` blocker (stale ticket baseline copied into the
+  simulation) and one `injected` blocker (chunked spec still said every delta).
+- Panel 1 re-check 3: one `injected` blocker — remote-tracking base was not refreshed
+  immediately before flat/coordinator preflight.
+- Panel 1 re-check 4: one `injected` blocker — revise's earlier rebase fetch left the
+  same stale-ref window before its gate.
+- Panel 1 re-check 5: no blockers; same-reviewer `PASS`. Fresh cold countersign still
+  required.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -17,6 +17,20 @@
 - Every ordinary OpenSpec-backed caller fetches `origin` immediately before the gate
   and stops on fetch or base-ref failure. Why: the remote fixture proves a stale
   tracking ref passes before fetch and fails after refresh. Disposition: inline.
+- Archive applicability mismatch has exactly two ordered `ticket:` stderr lines:
+  the unmatched requirement first, then rename/header correction guidance; every
+  other failure has one diagnostic. Why: this preserves the already-executed public
+  behavior without contradicting the general result contract. Disposition: inline.
+- Capture the complete raw OpenSpec archive stdout, stderr, and exit status for the
+  historical failure before admitting an implementation order. Why: the command's
+  parsed `archive: null` and `archive_spec_update_failed` shape is load-bearing
+  third-party behavior and the existing generated facts suppress those bytes.
+  Disposition: inline.
+- Slice implementation into two serial chunks: the public CLI and executable
+  contract evidence first; its three workflow consumers and OpenSpec contract
+  alignment second. Why: both multiple-deliverable-artifacts and lockstep-copies-of-
+  one-fact fire, matching the repository's shared-interface-plus-consumers anchor.
+  Disposition: inline.
 
 ### Risk contract
 
@@ -33,8 +47,9 @@
   post-merge archive lifecycle.
 - **Evidence owed:** public-command tests for historical #259, changed-path
   discovery, JSON shapes, current-base composition, fetch timing/failure, ordinary
-  delta kinds, and source/base immutability; strict OpenSpec and full repository
-  verification.
+  delta kinds, source/base immutability, executable launch failure, base export
+  failure, overlay failure, and temporary-directory cleanup on every recovery path;
+  strict OpenSpec and full repository verification.
 
 Why: this prices the smallest non-mutating gate that prevents the observed
 post-merge failure. Disposition: inline.
@@ -76,3 +91,9 @@ None.
   had qualified the gate as ordinary OpenSpec-backed only.
 - Panel 2 re-check 4: no blockers; same-reviewer `PASS`. A third fresh cold panel
   remains required for the full-depth countersign.
+- Panel 3 fresh cold pass: four `authoring` blockers — contradictory one-line versus
+  two-line mismatch diagnostics; raw third-party failure JSON absent from generated
+  facts; missing launch/export/overlay cleanup acceptance; and a flat shape despite
+  both multiple-artifact and lockstep-copy traits. The three-panel cap was reached,
+  so the order was not countersigned or posted and these decisions returned to
+  scope.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -14,9 +14,9 @@
   one stops. Why: an ordinary ticket owns one active change and finalization owns one
   archive; independent multi-change checks cannot prove serial interaction.
   Disposition: inline.
-- Every caller fetches `origin` immediately before the gate and stops on fetch or
-  base-ref failure. Why: the remote fixture proves a stale tracking ref passes before
-  fetch and fails after refresh. Disposition: inline.
+- Every ordinary OpenSpec-backed caller fetches `origin` immediately before the gate
+  and stops on fetch or base-ref failure. Why: the remote fixture proves a stale
+  tracking ref passes before fetch and fails after refresh. Disposition: inline.
 
 ### Risk contract
 
@@ -66,3 +66,5 @@ None.
 - Panel 2 fresh cold pass: three `authoring` blockers — missing non-OpenSpec caller
   bypass; incomplete shared CLI invocation/result contract; test plan promised only
   source-tree rather than separate source/base immutability evidence.
+- Panel 2 re-check 1: one `injected` blocker — the new bypass scenario conflicted
+  with universal wording retained in the requirement, proposal, and scope decision.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -97,3 +97,7 @@ None.
   both multiple-artifact and lockstep-copy traits. The three-panel cap was reached,
   so the order was not countersigned or posted and these decisions returned to
   scope.
+- Renewed cycle, panel 1 cold pass: one `authoring` blocker — the order assigned
+  executable stale-remote proof to three Markdown workflow consumers. The public
+  command owns that fixture; consumer evidence is prose-contract assertions for
+  eligibility, ordering, base refs, bypass, and outbound boundaries.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -74,3 +74,5 @@ None.
 - Panel 2 re-check 3: one `injected` blocker — the ADR design retained universal
   caller wording after the requirement, proposal, scope decision, and work order
   had qualified the gate as ordinary OpenSpec-backed only.
+- Panel 2 re-check 4: no blockers; same-reviewer `PASS`. A third fresh cold panel
+  remains required for the full-depth countersign.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -30,6 +30,11 @@
   verified commit object ID, then use only that object ID for merge-base and export.
   Why: an option-shaped public argument must not become `git archive --remote` or
   another Git option. Disposition: inline.
+- Keep the guarantee at the pre-pull-request or pre-push gate and accept that the
+  baseline can advance again before a later human merge. Why: this is a one-operator
+  laptop workflow; merge-time CI or branch-protection enforcement is disproportionate,
+  and a later advance remains a visible, manually correctable finalization stop.
+  Disposition: inline.
 - Slice implementation into two serial chunks: the public CLI and executable
   contract evidence first; its three workflow consumers and OpenSpec contract
   alignment second. Why: both multiple-deliverable-artifacts and lockstep-copies-of-
@@ -39,13 +44,16 @@
 ### Risk contract
 
 - **Must prevent:** mutating, folding, moving, or archiving the authoritative active
-  change or baseline before merge; approving a stale-base, null, error, malformed,
-  or wrong-typed archive result; secret exposure, irreversible authoritative-data
-  loss, or silent incorrect success.
+  change or baseline before merge; gating against a remote-tracking base older than
+  the immediately completed fetch; approving a null, error, malformed, or wrong-
+  typed archive result; secret exposure, irreversible authoritative-data loss, or
+  silent incorrect success.
 - **Must recover:** temporary export/overlay or CLI failure stops visibly and the
   disposable directory is cleaned automatically.
 - **Accepted failure:** unexpected third-party output, fetch failure, unresolved
-  base, or several active ticket changes stops for manual correction/re-scoping.
+  base, or several active ticket changes stops for manual correction/re-scoping; a
+  base advance after the gate but before human merge may still stop finalization for
+  manual delta correction.
 - **Unsupported:** automatic delta repair, inferring old requirement headers,
   multi-change ordinary tickets, changing OpenSpec's validator, or replacing the
   post-merge archive lifecycle.
@@ -122,3 +130,6 @@ None.
   while the risk contract says stale-base approval is must-prevent. The three-panel
   cap was reached; the draft is frozen pending an operator choice between accepting
   that post-gate/pre-merge race or adding a merge-time enforcement owner.
+- Operator disposition at the cap: accept the post-gate/pre-merge race and add no
+  merge-time enforcement. The workflow is a one-person laptop tool; a visible,
+  manually correctable finalization stop is proportionate.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -63,3 +63,6 @@ None.
   same stale-ref window before its gate.
 - Panel 1 re-check 5: no blockers; same-reviewer `PASS`. Fresh cold countersign still
   required.
+- Panel 2 fresh cold pass: three `authoring` blockers — missing non-OpenSpec caller
+  bypass; incomplete shared CLI invocation/result contract; test plan promised only
+  source-tree rather than separate source/base immutability evidence.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -71,3 +71,6 @@ None.
 - Panel 2 re-check 2: two `injected` blockers — generic start/coordinator scenario
   clauses still implied universal preflight, and proposal evidence still named only
   source-tree rather than separate ticket/base digests.
+- Panel 2 re-check 3: one `injected` blocker — the ADR design retained universal
+  caller wording after the requirement, proposal, scope decision, and work order
+  had qualified the gate as ordinary OpenSpec-backed only.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -68,3 +68,6 @@ None.
   source-tree rather than separate source/base immutability evidence.
 - Panel 2 re-check 1: one `injected` blocker — the new bypass scenario conflicted
   with universal wording retained in the requirement, proposal, and scope decision.
+- Panel 2 re-check 2: two `injected` blockers — generic start/coordinator scenario
+  clauses still implied universal preflight, and proposal evidence still named only
+  source-tree rather than separate ticket/base digests.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -101,3 +101,5 @@ None.
   executable stale-remote proof to three Markdown workflow consumers. The public
   command owns that fixture; consumer evidence is prose-contract assertions for
   eligibility, ordering, base refs, bypass, and outbound boundaries.
+- Renewed cycle, panel 1 re-check: no blockers; same-reviewer `PASS`. A fresh cold
+  pass remains required for the load-bearing countersign.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -117,3 +117,8 @@ None.
   `serial after 1`.
 - Renewed cycle, panel 2 re-check: no blockers; both corrections passed and the
   scheduling refutation was confirmed. A final fresh cold pass remains required.
+- Renewed cycle, panel 3 fresh cold pass: one `authoring` blocker — the pre-PR or
+  pre-push gate cannot guarantee the baseline stays unchanged until human merge,
+  while the risk contract says stale-base approval is must-prevent. The three-panel
+  cap was reached; the draft is frozen pending an operator choice between accepting
+  that post-gate/pre-merge race or adding a merge-time enforcement owner.

--- a/docs/scope/265-preflight-openspec-rename-applicability.md
+++ b/docs/scope/265-preflight-openspec-rename-applicability.md
@@ -115,3 +115,5 @@ None.
   initial chunk's `parallel` mode is the schema's predecessor-free form, not a
   concurrency claim; there is no `serial after 0`, and the successor remains
   `serial after 1`.
+- Renewed cycle, panel 2 re-check: no blockers; both corrections passed and the
+  scheduling refutation was confirmed. A final fresh cold pass remains required.

--- a/docs/scope/265-probes/discover_changed_openspec.py
+++ b/docs/scope/265-probes/discover_changed_openspec.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Executable spike for deriving ordinary active changes from a ticket diff."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path, PurePosixPath
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--base", required=True)
+    args = parser.parse_args()
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", args.base, "--", "openspec/changes"],
+        cwd=args.repo.resolve(),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    changes: set[str] = set()
+    for line in result.stdout.splitlines():
+        parts = PurePosixPath(line).parts
+        if len(parts) >= 3 and parts[:2] == ("openspec", "changes") and parts[2] != "archive":
+            changes.add(parts[2])
+    for change in sorted(changes):
+        print(change)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/scope/265-probes/discover_changed_openspec.py
+++ b/docs/scope/265-probes/discover_changed_openspec.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+import sys
 from pathlib import Path, PurePosixPath
 
 
@@ -15,8 +16,28 @@ def main() -> int:
     args = parser.parse_args()
 
     repo = args.repo.resolve()
+    resolved = subprocess.run(
+        [
+            "git",
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            f"{args.base_ref}^{{commit}}",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if resolved.returncode:
+        print(
+            f"base ref does not resolve to a local commit: {args.base_ref}",
+            file=sys.stderr,
+        )
+        return 2
+    base_commit = resolved.stdout.strip()
     merge_base = subprocess.run(
-        ["git", "merge-base", "HEAD", args.base_ref],
+        ["git", "merge-base", "HEAD", base_commit],
         cwd=repo,
         text=True,
         capture_output=True,

--- a/docs/scope/265-probes/discover_changed_openspec.py
+++ b/docs/scope/265-probes/discover_changed_openspec.py
@@ -11,12 +11,20 @@ from pathlib import Path, PurePosixPath
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", type=Path, default=Path.cwd())
-    parser.add_argument("--base", required=True)
+    parser.add_argument("--base-ref", required=True)
     args = parser.parse_args()
 
+    repo = args.repo.resolve()
+    merge_base = subprocess.run(
+        ["git", "merge-base", "HEAD", args.base_ref],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
     result = subprocess.run(
-        ["git", "diff", "--name-only", args.base, "--", "openspec/changes"],
-        cwd=args.repo.resolve(),
+        ["git", "diff", "--name-only", merge_base, "--", "openspec/changes"],
+        cwd=repo,
         text=True,
         capture_output=True,
         check=True,
@@ -24,8 +32,16 @@ def main() -> int:
     changes: set[str] = set()
     for line in result.stdout.splitlines():
         parts = PurePosixPath(line).parts
-        if len(parts) >= 3 and parts[:2] == ("openspec", "changes") and parts[2] != "archive":
+        active = repo / "openspec" / "changes" / parts[2] if len(parts) >= 3 else None
+        if (
+            active is not None
+            and parts[:2] == ("openspec", "changes")
+            and parts[2] != "archive"
+            and active.is_dir()
+        ):
             changes.add(parts[2])
+    if len(changes) > 1:
+        parser.error("ordinary tickets may change at most one active OpenSpec change")
     for change in sorted(changes):
         print(change)
     return 0

--- a/docs/scope/265-probes/preflight_openspec.py
+++ b/docs/scope/265-probes/preflight_openspec.py
@@ -8,6 +8,7 @@ import json
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -16,6 +17,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("change")
     parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--base-ref")
     args = parser.parse_args()
 
     source = args.repo.resolve() / "openspec"
@@ -25,7 +27,27 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="ticket-openspec-preflight-") as scratch:
         root = Path(scratch)
-        shutil.copytree(source, root / "openspec")
+        if args.base_ref:
+            archive_path = root / "openspec.tar"
+            exported = subprocess.run(
+                ["git", "archive", "--format=tar", f"--output={archive_path}", args.base_ref, "openspec"],
+                cwd=args.repo.resolve(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if exported.returncode:
+                print(exported.stderr.strip(), file=sys.stderr)
+                return exported.returncode
+            with tarfile.open(archive_path) as bundle:
+                bundle.extractall(root, filter="data")
+            change_source = source / "changes" / args.change
+            if not change_source.is_dir():
+                print(f"ticket: active OpenSpec change not found: {change_source}", file=sys.stderr)
+                return 2
+            shutil.copytree(change_source, root / "openspec" / "changes" / args.change)
+        else:
+            shutil.copytree(source, root / "openspec")
         result = subprocess.run(
             ["openspec", "archive", args.change, "--json", "--yes"],
             cwd=root,

--- a/docs/scope/265-probes/preflight_openspec.py
+++ b/docs/scope/265-probes/preflight_openspec.py
@@ -42,8 +42,20 @@ def main() -> int:
         print(f"ticket: OpenSpec archive returned invalid JSON: {error}", file=sys.stderr)
         return 2
 
-    errors = [item for item in payload.get("status", []) if item.get("severity") == "error"]
-    if payload.get("archive") is None or errors:
+    if not isinstance(payload, dict):
+        print("ticket: OpenSpec archive JSON must be an object", file=sys.stderr)
+        return 2
+    status = payload.get("status", [])
+    if not isinstance(status, list) or any(not isinstance(item, dict) for item in status):
+        print("ticket: OpenSpec archive status must be a list of objects", file=sys.stderr)
+        return 2
+    archive = payload.get("archive")
+    if archive is not None and not isinstance(archive, dict):
+        print("ticket: OpenSpec archive result must be an object", file=sys.stderr)
+        return 2
+
+    errors = [item for item in status if item.get("severity") == "error"]
+    if archive is None or errors:
         for item in errors:
             message = item.get("message", "OpenSpec archive preflight failed")
             print(f"ticket: {message}", file=sys.stderr)

--- a/docs/scope/265-probes/preflight_openspec.py
+++ b/docs/scope/265-probes/preflight_openspec.py
@@ -28,9 +28,29 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="ticket-openspec-preflight-") as scratch:
         root = Path(scratch)
         if args.base_ref:
+            resolved = subprocess.run(
+                [
+                    "git",
+                    "rev-parse",
+                    "--verify",
+                    "--end-of-options",
+                    f"{args.base_ref}^{{commit}}",
+                ],
+                cwd=args.repo.resolve(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if resolved.returncode:
+                print(
+                    f"ticket: base ref does not resolve to a local commit: {args.base_ref}",
+                    file=sys.stderr,
+                )
+                return 2
+            base_commit = resolved.stdout.strip()
             archive_path = root / "openspec.tar"
             exported = subprocess.run(
-                ["git", "archive", "--format=tar", f"--output={archive_path}", args.base_ref, "openspec"],
+                ["git", "archive", "--format=tar", f"--output={archive_path}", base_commit, "openspec"],
                 cwd=args.repo.resolve(),
                 text=True,
                 capture_output=True,

--- a/docs/scope/265-probes/preflight_openspec.py
+++ b/docs/scope/265-probes/preflight_openspec.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Executable spike for issue 265's non-mutating OpenSpec preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("change")
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    source = args.repo.resolve() / "openspec"
+    if not source.is_dir():
+        print(f"ticket: OpenSpec root not found: {source}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="ticket-openspec-preflight-") as scratch:
+        root = Path(scratch)
+        shutil.copytree(source, root / "openspec")
+        result = subprocess.run(
+            ["openspec", "archive", args.change, "--json", "--yes"],
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        if result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
+        print(f"ticket: OpenSpec archive returned invalid JSON: {error}", file=sys.stderr)
+        return 2
+
+    errors = [item for item in payload.get("status", []) if item.get("severity") == "error"]
+    if payload.get("archive") is None or errors:
+        for item in errors:
+            message = item.get("message", "OpenSpec archive preflight failed")
+            print(f"ticket: {message}", file=sys.stderr)
+            if item.get("code") == "archive_spec_update_failed":
+                print(
+                    "ticket: if this requirement was renamed, add a `## RENAMED "
+                    "Requirements` mapping from its current baseline header to the "
+                    "unmatched delta header; otherwise correct the MODIFIED header.",
+                    file=sys.stderr,
+                )
+        return result.returncode or 1
+
+    if result.returncode:
+        print(result.stderr.strip() or result.stdout.strip(), file=sys.stderr)
+        return result.returncode
+
+    print(f"ticket: OpenSpec change {args.change} applies cleanly in a disposable copy")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/scope/265-probes/reproduce_259.py
+++ b/docs/scope/265-probes/reproduce_259.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Reproduce issue 259 from immutable repository history."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+CHANGE = "259-remove-unused-ticket-telemetry"
+REGRESSION_COMMIT = "fe3317a81e72ec630bd30a829c2489d62bc5cb7e"
+
+
+def run(
+    command: list[str],
+    cwd: Path,
+    display_command: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+    print(f"$ {' '.join(display_command or command)}")
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.stderr:
+        print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
+    print(f"exit={result.returncode}")
+    return result
+
+
+def tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        digest.update(path.relative_to(root).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[3]
+    probe = Path(__file__).with_name("preflight_openspec.py")
+    with tempfile.TemporaryDirectory(prefix="ticket-265-reproduce-") as scratch:
+        fixture = Path(scratch)
+        archive_path = fixture / "repo.tar"
+        archived = subprocess.run(
+            ["git", "archive", "--format=tar", f"--output={archive_path}", REGRESSION_COMMIT],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if archived.returncode:
+            print(archived.stderr, file=sys.stderr)
+            return archived.returncode
+        with tarfile.open(archive_path) as bundle:
+            bundle.extractall(fixture, filter="data")
+        archive_path.unlink()
+
+        version = run(["openspec", "--version"], fixture)
+        validation = run(["openspec", "validate", CHANGE, "--strict"], fixture)
+        before = tree_digest(fixture / "openspec")
+        preflight = run(
+            [sys.executable, str(probe), CHANGE, "--repo", "."],
+            fixture,
+            [sys.executable, "docs/scope/265-probes/preflight_openspec.py", CHANGE, "--repo", "."],
+        )
+        after = tree_digest(fixture / "openspec")
+        print(f"source_unchanged={str(before == after).lower()}")
+
+    return 0 if version.returncode == 0 and validation.returncode == 0 and preflight.returncode == 1 and before == after else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/scope/265-probes/reproduce_259.py
+++ b/docs/scope/265-probes/reproduce_259.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import shutil
 import subprocess
 import sys
 import tarfile
-import tempfile
 from pathlib import Path
 
 
@@ -39,11 +40,37 @@ def tree_digest(root: Path) -> str:
     return digest.hexdigest()
 
 
+def run_raw_archive(source: Path, scratch: Path) -> subprocess.CompletedProcess[str]:
+    root = scratch / "raw-archive"
+    shutil.copytree(source / "openspec", root / "openspec")
+    command = ["openspec", "archive", CHANGE, "--json", "--yes"]
+    result = subprocess.run(
+        command,
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    print(f"$ {' '.join(command)}")
+    print("stdout:")
+    print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    print("stderr:")
+    print(result.stderr if result.stderr else "<empty>", end="" if result.stderr.endswith("\n") else "\n")
+    print(f"exit={result.returncode}")
+    return result
+
+
 def main() -> int:
     repo = Path(__file__).resolve().parents[3]
     probe = Path(__file__).with_name("preflight_openspec.py")
-    with tempfile.TemporaryDirectory(prefix="ticket-265-reproduce-") as scratch:
-        fixture = Path(scratch)
+    fixture = Path("/private/tmp/ticket-265-reproduce-259")
+    try:
+        fixture.mkdir()
+    except FileExistsError:
+        print(f"fixture already exists: {fixture}", file=sys.stderr)
+        return 2
+
+    try:
         archive_path = fixture / "repo.tar"
         archived = subprocess.run(
             ["git", "archive", "--format=tar", f"--output={archive_path}", REGRESSION_COMMIT],
@@ -61,6 +88,7 @@ def main() -> int:
 
         version = run(["openspec", "--version"], fixture)
         validation = run(["openspec", "validate", CHANGE, "--strict"], fixture)
+        raw_archive = run_raw_archive(fixture, fixture)
         before = tree_digest(fixture / "openspec")
         preflight = run(
             [sys.executable, str(probe), CHANGE, "--repo", "."],
@@ -70,7 +98,34 @@ def main() -> int:
         after = tree_digest(fixture / "openspec")
         print(f"source_unchanged={str(before == after).lower()}")
 
-    return 0 if version.returncode == 0 and validation.returncode == 0 and preflight.returncode == 1 and before == after else 1
+        try:
+            raw_payload = json.loads(raw_archive.stdout)
+        except json.JSONDecodeError:
+            raw_payload = None
+        raw_errors = raw_payload.get("status", []) if isinstance(raw_payload, dict) else []
+        raw_shape_matches = (
+            isinstance(raw_payload, dict)
+            and raw_payload.get("archive") is None
+            and isinstance(raw_errors, list)
+            and any(
+                isinstance(item, dict)
+                and item.get("code") == "archive_spec_update_failed"
+                for item in raw_errors
+            )
+        )
+        print(f"raw_failure_shape_matches={str(raw_shape_matches).lower()}")
+        success = (
+            version.returncode == 0
+            and validation.returncode == 0
+            and raw_archive.returncode == 1
+            and raw_shape_matches
+            and preflight.returncode == 1
+            and before == after
+        )
+    finally:
+        shutil.rmtree(fixture)
+
+    return 0 if success else 1
 
 
 if __name__ == "__main__":

--- a/docs/scope/265-probes/reproduce_base_advance.py
+++ b/docs/scope/265-probes/reproduce_base_advance.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Prove the base-ref composite catches applicability drift after branch cut."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+CHANGE = "265-preflight-openspec-rename-applicability"
+
+
+def command(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def main() -> int:
+    source_repo = Path(__file__).resolve().parents[3]
+    probe = Path(__file__).with_name("preflight_openspec.py")
+    with tempfile.TemporaryDirectory(prefix="ticket-265-base-advance-") as scratch:
+        repo = Path(scratch)
+        bundle_path = repo / "openspec.tar"
+        exported = command(
+            ["git", "archive", "--format=tar", f"--output={bundle_path}", "origin/main", "openspec"],
+            source_repo,
+        )
+        if exported.returncode:
+            print(exported.stderr, file=sys.stderr)
+            return exported.returncode
+        with tarfile.open(bundle_path) as bundle:
+            bundle.extractall(repo, filter="data")
+        bundle_path.unlink()
+
+        for args in (
+            ["git", "init", "-b", "main"],
+            ["git", "config", "user.name", "Issue 265 fixture"],
+            ["git", "config", "user.email", "fixture@example.invalid"],
+            ["git", "add", "openspec"],
+            ["git", "commit", "-m", "baseline"],
+            ["git", "switch", "-c", "ticket"],
+        ):
+            result = command(args, repo)
+            if result.returncode:
+                print(result.stderr, file=sys.stderr)
+                return result.returncode
+
+        shutil.copytree(
+            source_repo / "openspec" / "changes" / CHANGE,
+            repo / "openspec" / "changes" / CHANGE,
+        )
+        for args in (["git", "add", "openspec"], ["git", "commit", "-m", "ticket delta"], ["git", "switch", "main"]):
+            result = command(args, repo)
+            if result.returncode:
+                print(result.stderr, file=sys.stderr)
+                return result.returncode
+
+        baseline = repo / "openspec" / "specs" / "ticket-workflow" / "spec.md"
+        baseline.write_text(
+            baseline.read_text(encoding="utf-8").replace(
+                "### Requirement: Four-verb lifecycle",
+                "### Requirement: Renamed lifecycle",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        for args in (
+            ["git", "add", str(baseline.relative_to(repo))],
+            ["git", "commit", "-m", "advance baseline"],
+            ["git", "switch", "ticket"],
+        ):
+            result = command(args, repo)
+            if result.returncode:
+                print(result.stderr, file=sys.stderr)
+                return result.returncode
+
+        stale = command([sys.executable, str(probe), CHANGE, "--repo", "."], repo)
+        current = command(
+            [sys.executable, str(probe), CHANGE, "--repo", ".", "--base-ref", "main"],
+            repo,
+        )
+        print(f"stale_ticket_baseline_exit={stale.returncode}")
+        print(stale.stdout.strip())
+        print(f"current_base_composite_exit={current.returncode}")
+        print(current.stderr.strip())
+
+    return 0 if stale.returncode == 0 and current.returncode == 1 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/scope/265-probes/reproduce_base_advance.py
+++ b/docs/scope/265-probes/reproduce_base_advance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prove the base-ref composite catches applicability drift after branch cut."""
+"""Prove fetch + base-ref composite catches applicability drift after branch cut."""
 
 from __future__ import annotations
 
@@ -18,12 +18,29 @@ def command(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
 
 
+def require(args: list[str], cwd: Path) -> None:
+    result = command(args, cwd)
+    if result.returncode:
+        raise RuntimeError(result.stderr or result.stdout)
+
+
+def configure(repo: Path) -> None:
+    require(["git", "config", "user.name", "Issue 265 fixture"], repo)
+    require(["git", "config", "user.email", "fixture@example.invalid"], repo)
+
+
 def main() -> int:
     source_repo = Path(__file__).resolve().parents[3]
     probe = Path(__file__).with_name("preflight_openspec.py")
     with tempfile.TemporaryDirectory(prefix="ticket-265-base-advance-") as scratch:
-        repo = Path(scratch)
-        bundle_path = repo / "openspec.tar"
+        root = Path(scratch)
+        seed = root / "seed"
+        remote = root / "remote.git"
+        ticket = root / "ticket"
+        updater = root / "updater"
+        seed.mkdir()
+
+        bundle_path = seed / "openspec.tar"
         exported = command(
             ["git", "archive", "--format=tar", f"--output={bundle_path}", "origin/main", "openspec"],
             source_repo,
@@ -32,62 +49,62 @@ def main() -> int:
             print(exported.stderr, file=sys.stderr)
             return exported.returncode
         with tarfile.open(bundle_path) as bundle:
-            bundle.extractall(repo, filter="data")
+            bundle.extractall(seed, filter="data")
         bundle_path.unlink()
 
-        for args in (
-            ["git", "init", "-b", "main"],
-            ["git", "config", "user.name", "Issue 265 fixture"],
-            ["git", "config", "user.email", "fixture@example.invalid"],
-            ["git", "add", "openspec"],
-            ["git", "commit", "-m", "baseline"],
-            ["git", "switch", "-c", "ticket"],
-        ):
-            result = command(args, repo)
-            if result.returncode:
-                print(result.stderr, file=sys.stderr)
-                return result.returncode
+        try:
+            require(["git", "init", "-b", "main"], seed)
+            configure(seed)
+            require(["git", "add", "openspec"], seed)
+            require(["git", "commit", "-m", "baseline"], seed)
+            require(["git", "init", "--bare", "--initial-branch=main", str(remote)], root)
+            require(["git", "remote", "add", "origin", str(remote)], seed)
+            require(["git", "push", "-u", "origin", "main"], seed)
+            require(["git", "clone", str(remote), str(ticket)], root)
+            require(["git", "clone", str(remote), str(updater)], root)
+            configure(ticket)
+            configure(updater)
 
-        shutil.copytree(
-            source_repo / "openspec" / "changes" / CHANGE,
-            repo / "openspec" / "changes" / CHANGE,
+            require(["git", "switch", "-c", "ticket"], ticket)
+            shutil.copytree(
+                source_repo / "openspec" / "changes" / CHANGE,
+                ticket / "openspec" / "changes" / CHANGE,
+            )
+            require(["git", "add", "openspec"], ticket)
+            require(["git", "commit", "-m", "ticket delta"], ticket)
+
+            baseline = updater / "openspec" / "specs" / "ticket-workflow" / "spec.md"
+            baseline.write_text(
+                baseline.read_text(encoding="utf-8").replace(
+                    "### Requirement: Four-verb lifecycle",
+                    "### Requirement: Renamed lifecycle",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            require(["git", "add", str(baseline.relative_to(updater))], updater)
+            require(["git", "commit", "-m", "advance baseline"], updater)
+            require(["git", "push", "origin", "main"], updater)
+        except RuntimeError as error:
+            print(error, file=sys.stderr)
+            return 2
+
+        stale = command(
+            [sys.executable, str(probe), CHANGE, "--repo", ".", "--base-ref", "refs/remotes/origin/HEAD"],
+            ticket,
         )
-        for args in (["git", "add", "openspec"], ["git", "commit", "-m", "ticket delta"], ["git", "switch", "main"]):
-            result = command(args, repo)
-            if result.returncode:
-                print(result.stderr, file=sys.stderr)
-                return result.returncode
-
-        baseline = repo / "openspec" / "specs" / "ticket-workflow" / "spec.md"
-        baseline.write_text(
-            baseline.read_text(encoding="utf-8").replace(
-                "### Requirement: Four-verb lifecycle",
-                "### Requirement: Renamed lifecycle",
-                1,
-            ),
-            encoding="utf-8",
-        )
-        for args in (
-            ["git", "add", str(baseline.relative_to(repo))],
-            ["git", "commit", "-m", "advance baseline"],
-            ["git", "switch", "ticket"],
-        ):
-            result = command(args, repo)
-            if result.returncode:
-                print(result.stderr, file=sys.stderr)
-                return result.returncode
-
-        stale = command([sys.executable, str(probe), CHANGE, "--repo", "."], repo)
+        fetched = command(["git", "fetch", "origin"], ticket)
         current = command(
-            [sys.executable, str(probe), CHANGE, "--repo", ".", "--base-ref", "main"],
-            repo,
+            [sys.executable, str(probe), CHANGE, "--repo", ".", "--base-ref", "refs/remotes/origin/HEAD"],
+            ticket,
         )
-        print(f"stale_ticket_baseline_exit={stale.returncode}")
+        print(f"before_fetch_exit={stale.returncode}")
         print(stale.stdout.strip())
-        print(f"current_base_composite_exit={current.returncode}")
+        print(f"fetch_exit={fetched.returncode}")
+        print(f"after_fetch_exit={current.returncode}")
         print(current.stderr.strip())
 
-    return 0 if stale.returncode == 0 and current.returncode == 1 else 1
+    return 0 if stale.returncode == 0 and fetched.returncode == 0 and current.returncode == 1 else 1
 
 
 if __name__ == "__main__":

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -29,11 +29,11 @@ Flat `start` and chunked coordinator mode fetch `origin` immediately before pass
 ticket worktree; a fetch or unresolved-ref failure stops. Flat start runs after
 review and any resulting change-record edits, immediately before the pull request
 opens. Chunked coordinator mode runs after merged-branch review and change
-recording, before it rejoins pull-request creation. After its existing fetch/rebase
-and base-ref refresh, `revise`
-passes `origin/<baseRefName>`; it completes all active-change/checklist/decision
-edits, runs the gate, then pushes. Finalization remains the only workflow phase that
-archives the authoritative tree.
+recording, before it rejoins pull-request creation. `Revise` completes its existing
+fetch/rebase plus all active-change/checklist/decision edits, then fetches `origin`
+again immediately before passing refreshed `origin/<baseRefName>` to the gate, then
+pushes. Finalization remains the only workflow phase that archives the authoritative
+tree.
 
 ## ADR 265 — Prove applicability through a disposable real archive
 

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -24,12 +24,13 @@ and `archive_spec_update_failed`; parsing the JSON before branching on process
 status preserves the actionable mismatch diagnostic. Temporary-directory cleanup
 is automatic on success and failure.
 
-Flat `start` and chunked coordinator mode pass
+Flat `start` and chunked coordinator mode fetch `origin` immediately before passing
 `refs/remotes/origin/HEAD`, whose merge base names the default-branch base of the
-ticket worktree; an unresolved ref stops. Flat start runs after review and any
-resulting change-record edits, immediately before the pull request opens. Chunked
-coordinator mode runs after merged-branch review and change recording, before it
-rejoins pull-request creation. After its fetch/rebase and base-ref refresh, `revise`
+ticket worktree; a fetch or unresolved-ref failure stops. Flat start runs after
+review and any resulting change-record edits, immediately before the pull request
+opens. Chunked coordinator mode runs after merged-branch review and change
+recording, before it rejoins pull-request creation. After its existing fetch/rebase
+and base-ref refresh, `revise`
 passes `origin/<baseRefName>`; it completes all active-change/checklist/decision
 edits, runs the gate, then pushes. Finalization remains the only workflow phase that
 archives the authoritative tree.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -15,8 +15,10 @@ The public command is `ticket.py preflight-openspec --repo <ticket-worktree>
 --base-ref <ref>`. Both options are required. It returns success for zero changed
 active changes, success with the checked name for one applicable change, a usage-
 class stop naming sorted changes for more than one, and one `ticket:` diagnostic on
-stderr for base/export/CLI/JSON/applicability failures. Workflow callers invoke it
-only after selecting the existing ordinary OpenSpec change-record route.
+stderr for every failure except `archive_spec_update_failed`. That applicability
+failure emits exactly two ordered `ticket:` lines: the CLI's unmatched requirement,
+then rename/header correction guidance. Workflow callers invoke the command only
+after selecting the existing ordinary OpenSpec change-record route.
 
 The command exports the resolved base ref's current `openspec/` tree into a fresh
 temporary directory, overlays only the ticket worktree's one active change
@@ -26,10 +28,11 @@ ref rather than the ticket branch's stale baseline catches an applicability chan
 that landed after branch cut without rebasing or mutating the ticket branch.
 Success requires process exit zero, a top-level JSON object with a non-null archive
 object, and no error-severity entry in an optional status list of objects.
-The reproduced 1.11.0 failure returns exit 1 and a JSON body with `archive: null`
-and `archive_spec_update_failed`; parsing the JSON before branching on process
-status preserves the actionable mismatch diagnostic. Temporary-directory cleanup
-is automatic on success and failure.
+The generated-facts reproduction captures the complete OpenSpec 1.11.0 stdout,
+stderr, and exit status: exit 1, `archive: null`, and an error status whose code is
+`archive_spec_update_failed`. Parsing the JSON before branching on process status
+preserves the actionable mismatch diagnostic. Temporary-directory cleanup is
+automatic on success and every launch, export, overlay, CLI, or parse failure.
 
 For an ordinary OpenSpec-backed ticket, flat `start` and chunked coordinator mode
 fetch `origin` immediately before passing `refs/remotes/origin/HEAD`, whose merge

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -48,6 +48,12 @@ pushes. Other or absent change-record conventions and epic children bypass this
 command unchanged. Finalization remains the only workflow phase that archives the
 authoritative tree.
 
+The gate proves applicability only against the base fetched immediately before that
+gate. It does not lock the default branch through a later human merge. A subsequent
+base advance may still make finalization stop for manual delta correction; adding a
+merge-time check or branch-protection mechanism is deliberately outside this
+one-operator laptop workflow.
+
 ## ADR 265 — Prove applicability through a disposable real archive
 
 **Status:** accepted

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -1,11 +1,13 @@
 # Design
 
 `ticket.py` remains the ticket workflow's command interface and gains one
-applicability-preflight command. Its workflow form receives the checkout and base
-ref, derives every non-archive `openspec/changes/<name>/` directory changed by that
-diff, and preflights each one. No changed active directory is a successful no-op;
-multiple changed active directories are all checked rather than guessed down to
-one. A separate production module would have only one caller and would move the
+applicability-preflight command. Its workflow form receives the checkout and a
+caller-owned base ref, resolves the merge base with the ticket branch, and derives
+non-archive `openspec/changes/<name>/` directories changed by that diff and still
+present in the ticket tree. No changed active directory is a successful no-op;
+exactly one is preflighted; more than one stops visibly because this ordinary-ticket
+lifecycle owns one active change and finalization defines no serial multi-change
+archive. A separate production module would have only one caller and would move the
 same discovery, subprocess, copy, and JSON handling behind another name, so it
 would not survive the deletion test.
 
@@ -19,12 +21,15 @@ and `archive_spec_update_failed`; parsing the JSON before branching on process
 status preserves the actionable mismatch diagnostic. Temporary-directory cleanup
 is automatic on success and failure.
 
-Flat `start` runs the command after review and any resulting change-record edits,
-immediately before the pull request opens. Chunked coordinator mode runs the same
-gate after merged-branch review and change recording, before it rejoins pull-request
-creation. `revise` completes all active-change/checklist/decision edits, then runs
-the gate, then pushes. Finalization remains the only workflow phase that archives
-the authoritative tree.
+Flat `start` and chunked coordinator mode pass
+`refs/remotes/origin/HEAD`, whose merge base names the default-branch base of the
+ticket worktree; an unresolved ref stops. Flat start runs after review and any
+resulting change-record edits, immediately before the pull request opens. Chunked
+coordinator mode runs after merged-branch review and change recording, before it
+rejoins pull-request creation. After its fetch/rebase and base-ref refresh, `revise`
+passes `origin/<baseRefName>`; it completes all active-change/checklist/decision
+edits, runs the gate, then pushes. Finalization remains the only workflow phase that
+archives the authoritative tree.
 
 ## ADR 265 — Prove applicability through a disposable real archive
 
@@ -39,8 +44,10 @@ and has no dry-run flag in OpenSpec 1.11.0. A disposable copy exercises that
 authority while making pre-merge mutation of the active change and baseline
 impossible, and parsing its JSON preserves the precise archive failure.
 
-**Consequences:** preflight cost includes diffing the branch, copying the OpenSpec
-tree, and invoking the CLI once per changed active change; malformed or changed
+**Consequences:** preflight cost includes resolving a merge base, diffing the branch,
+copying the OpenSpec tree, and invoking the CLI once; deleted or renamed-away paths
+do not become false active changes; a multi-change ordinary ticket must be
+re-scoped instead of receiving a misleading independent pass; malformed or changed
 JSON fails closed; diagnostics can identify the unmatched requirement and the
 correction class but do not guess the old baseline header; post-merge archive
 remains unchanged.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -1,23 +1,30 @@
 # Design
 
 `ticket.py` remains the ticket workflow's command interface and gains one
-applicability-preflight command. A separate production module would have only one
-caller and would move the same subprocess, copy, and JSON handling behind another
-name, so it would not survive the deletion test.
+applicability-preflight command. Its workflow form receives the checkout and base
+ref, derives every non-archive `openspec/changes/<name>/` directory changed by that
+diff, and preflights each one. No changed active directory is a successful no-op;
+multiple changed active directories are all checked rather than guessed down to
+one. A separate production module would have only one caller and would move the
+same discovery, subprocess, copy, and JSON handling behind another name, so it
+would not survive the deletion test.
 
 The command copies only the resolved repository's `openspec/` tree into a fresh
 temporary directory and runs the pinned external interface there:
 `openspec archive <change> --json --yes`. It does not emulate OpenSpec's merge
-rules. Success requires process exit zero, a non-null `archive` object, and no
-error-severity status. The reproduced 1.11.0 failure returns exit 1 and a JSON body
-with `archive: null` and `archive_spec_update_failed`; parsing the JSON before
-branching on process status preserves the actionable mismatch diagnostic.
-Temporary-directory cleanup is automatic on success and failure.
+rules. Success requires process exit zero, a top-level JSON object with a non-null
+archive object, and no error-severity entry in an optional status list of objects.
+The reproduced 1.11.0 failure returns exit 1 and a JSON body with `archive: null`
+and `archive_spec_update_failed`; parsing the JSON before branching on process
+status preserves the actionable mismatch diagnostic. Temporary-directory cleanup
+is automatic on success and failure.
 
-`start` runs the command after review and any resulting edits, immediately before
-the pull request opens. `revise` runs the same gate after its review-round edits
-and before push. Finalization remains the only workflow phase that archives the
-authoritative tree.
+Flat `start` runs the command after review and any resulting change-record edits,
+immediately before the pull request opens. Chunked coordinator mode runs the same
+gate after merged-branch review and change recording, before it rejoins pull-request
+creation. `revise` completes all active-change/checklist/decision edits, then runs
+the gate, then pushes. Finalization remains the only workflow phase that archives
+the authoritative tree.
 
 ## ADR 265 — Prove applicability through a disposable real archive
 
@@ -32,7 +39,8 @@ and has no dry-run flag in OpenSpec 1.11.0. A disposable copy exercises that
 authority while making pre-merge mutation of the active change and baseline
 impossible, and parsing its JSON preserves the precise archive failure.
 
-**Consequences:** preflight cost includes copying the OpenSpec tree and invoking
-the CLI; malformed or changed JSON fails closed; diagnostics can identify the
-unmatched requirement and the correction class but do not guess the old baseline
-header; post-merge archive remains unchanged.
+**Consequences:** preflight cost includes diffing the branch, copying the OpenSpec
+tree, and invoking the CLI once per changed active change; malformed or changed
+JSON fails closed; diagnostics can identify the unmatched requirement and the
+correction class but do not guess the old baseline header; post-merge archive
+remains unchanged.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -11,11 +11,14 @@ archive. A separate production module would have only one caller and would move 
 same discovery, subprocess, copy, and JSON handling behind another name, so it
 would not survive the deletion test.
 
-The command copies only the resolved repository's `openspec/` tree into a fresh
-temporary directory and runs the pinned external interface there:
-`openspec archive <change> --json --yes`. It does not emulate OpenSpec's merge
-rules. Success requires process exit zero, a top-level JSON object with a non-null
-archive object, and no error-severity entry in an optional status list of objects.
+The command exports the resolved base ref's current `openspec/` tree into a fresh
+temporary directory, overlays only the ticket worktree's one active change
+directory, and runs the pinned external interface there: `openspec archive
+<change> --json --yes`. It does not emulate OpenSpec's merge rules. Using the base
+ref rather than the ticket branch's stale baseline catches an applicability change
+that landed after branch cut without rebasing or mutating the ticket branch.
+Success requires process exit zero, a top-level JSON object with a non-null archive
+object, and no error-severity entry in an optional status list of objects.
 The reproduced 1.11.0 failure returns exit 1 and a JSON body with `archive: null`
 and `archive_spec_update_failed`; parsing the JSON before branching on process
 status preserves the actionable mismatch diagnostic. Temporary-directory cleanup
@@ -35,9 +38,10 @@ archives the authoritative tree.
 
 **Status:** accepted
 
-**Decision:** run the pinned OpenSpec archive command against a temporary copy and
-judge its JSON result instead of implementing a second delta parser or performing
-a reversible archive in the ticket worktree.
+**Decision:** run the pinned OpenSpec archive command against a temporary composite
+of the base ref's current OpenSpec tree plus the ticket's one active change, and
+judge its JSON result instead of implementing a second delta parser or performing a
+reversible archive in the ticket worktree.
 
 **Why:** the actual archive operation is the existing authority for applicability
 and has no dry-run flag in OpenSpec 1.11.0. A disposable copy exercises that
@@ -45,7 +49,7 @@ authority while making pre-merge mutation of the active change and baseline
 impossible, and parsing its JSON preserves the precise archive failure.
 
 **Consequences:** preflight cost includes resolving a merge base, diffing the branch,
-copying the OpenSpec tree, and invoking the CLI once; deleted or renamed-away paths
+exporting the base OpenSpec tree, overlaying the active change, and invoking the CLI once; deleted or renamed-away paths
 do not become false active changes; a multi-change ordinary ticket must be
 re-scoped instead of receiving a misleading independent pass; malformed or changed
 JSON fails closed; diagnostics can identify the unmatched requirement and the

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -11,6 +11,13 @@ archive. A separate production module would have only one caller and would move 
 same discovery, subprocess, copy, and JSON handling behind another name, so it
 would not survive the deletion test.
 
+The public command is `ticket.py preflight-openspec --repo <ticket-worktree>
+--base-ref <ref>`. Both options are required. It returns success for zero changed
+active changes, success with the checked name for one applicable change, a usage-
+class stop naming sorted changes for more than one, and one `ticket:` diagnostic on
+stderr for base/export/CLI/JSON/applicability failures. Workflow callers invoke it
+only after selecting the existing ordinary OpenSpec change-record route.
+
 The command exports the resolved base ref's current `openspec/` tree into a fresh
 temporary directory, overlays only the ticket worktree's one active change
 directory, and runs the pinned external interface there: `openspec archive

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -2,7 +2,8 @@
 
 `ticket.py` remains the ticket workflow's command interface and gains one
 applicability-preflight command. Its workflow form receives the checkout and a
-caller-owned base ref, resolves the merge base with the ticket branch, and derives
+caller-owned base ref, resolves that ref locally with Git's end-of-options form to a
+verified commit object ID, resolves the merge base with the ticket branch, and derives
 non-archive `openspec/changes/<name>/` directories changed by that diff and still
 present in the ticket tree. No changed active directory is a successful no-op;
 exactly one is preflighted; more than one stops visibly because this ordinary-ticket
@@ -20,11 +21,11 @@ failure emits exactly two ordered `ticket:` lines: the CLI's unmatched requireme
 then rename/header correction guidance. Workflow callers invoke the command only
 after selecting the existing ordinary OpenSpec change-record route.
 
-The command exports the resolved base ref's current `openspec/` tree into a fresh
+The command exports the resolved commit object's current `openspec/` tree into a fresh
 temporary directory, overlays only the ticket worktree's one active change
 directory, and runs the pinned external interface there: `openspec archive
-<change> --json --yes`. It does not emulate OpenSpec's merge rules. Using the base
-ref rather than the ticket branch's stale baseline catches an applicability change
+<change> --json --yes`. It does not emulate OpenSpec's merge rules. Using the locally
+resolved base commit rather than the ticket branch's stale baseline catches an applicability change
 that landed after branch cut without rebasing or mutating the ticket branch.
 Success requires process exit zero, a top-level JSON object with a non-null archive
 object, and no error-severity entry in an optional status list of objects.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -31,16 +31,18 @@ and `archive_spec_update_failed`; parsing the JSON before branching on process
 status preserves the actionable mismatch diagnostic. Temporary-directory cleanup
 is automatic on success and failure.
 
-Flat `start` and chunked coordinator mode fetch `origin` immediately before passing
-`refs/remotes/origin/HEAD`, whose merge base names the default-branch base of the
-ticket worktree; a fetch or unresolved-ref failure stops. Flat start runs after
-review and any resulting change-record edits, immediately before the pull request
-opens. Chunked coordinator mode runs after merged-branch review and change
-recording, before it rejoins pull-request creation. `Revise` completes its existing
+For an ordinary OpenSpec-backed ticket, flat `start` and chunked coordinator mode
+fetch `origin` immediately before passing `refs/remotes/origin/HEAD`, whose merge
+base names the default-branch base of the ticket worktree; a fetch or unresolved-ref
+failure stops. Flat start runs after review and any resulting change-record edits,
+immediately before the pull request opens. Chunked coordinator mode runs after
+merged-branch review and change recording, before it rejoins pull-request creation.
+For an ordinary OpenSpec-backed `revise`, the workflow completes its existing
 fetch/rebase plus all active-change/checklist/decision edits, then fetches `origin`
 again immediately before passing refreshed `origin/<baseRefName>` to the gate, then
-pushes. Finalization remains the only workflow phase that archives the authoritative
-tree.
+pushes. Other or absent change-record conventions and epic children bypass this
+command unchanged. Finalization remains the only workflow phase that archives the
+authoritative tree.
 
 ## ADR 265 — Prove applicability through a disposable real archive
 

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -29,11 +29,13 @@ resolved base commit rather than the ticket branch's stale baseline catches an a
 that landed after branch cut without rebasing or mutating the ticket branch.
 Success requires process exit zero, a top-level JSON object with a non-null archive
 object, and no error-severity entry in an optional status list of objects.
-The generated-facts reproduction captures the complete OpenSpec 1.11.0 stdout,
-stderr, and exit status: exit 1, `archive: null`, and an error status whose code is
-`archive_spec_update_failed`. Parsing the JSON before branching on process status
-preserves the actionable mismatch diagnostic. Temporary-directory cleanup is
-automatic on success and every launch, export, overlay, CLI, or parse failure.
+The real semantic regression test captures the OpenSpec 1.11.0 validation result
+and asserts the public command's exact stdout, stderr, and exit status for the
+archive mismatch: exit 1, an unmatched-requirement diagnostic, and the ordered
+rename/header correction guidance derived from `archive_spec_update_failed` with a
+null archive. Parsing the JSON before branching on process status preserves that
+actionable mismatch diagnostic. Temporary-directory cleanup is automatic on
+success and every launch, export, overlay, CLI, or parse failure.
 
 For an ordinary OpenSpec-backed ticket, flat `start` and chunked coordinator mode
 fetch `origin` immediately before passing `refs/remotes/origin/HEAD`, whose merge

--- a/openspec/changes/265-preflight-openspec-rename-applicability/design.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/design.md
@@ -1,0 +1,38 @@
+# Design
+
+`ticket.py` remains the ticket workflow's command interface and gains one
+applicability-preflight command. A separate production module would have only one
+caller and would move the same subprocess, copy, and JSON handling behind another
+name, so it would not survive the deletion test.
+
+The command copies only the resolved repository's `openspec/` tree into a fresh
+temporary directory and runs the pinned external interface there:
+`openspec archive <change> --json --yes`. It does not emulate OpenSpec's merge
+rules. Success requires process exit zero, a non-null `archive` object, and no
+error-severity status. The reproduced 1.11.0 failure returns exit 1 and a JSON body
+with `archive: null` and `archive_spec_update_failed`; parsing the JSON before
+branching on process status preserves the actionable mismatch diagnostic.
+Temporary-directory cleanup is automatic on success and failure.
+
+`start` runs the command after review and any resulting edits, immediately before
+the pull request opens. `revise` runs the same gate after its review-round edits
+and before push. Finalization remains the only workflow phase that archives the
+authoritative tree.
+
+## ADR 265 — Prove applicability through a disposable real archive
+
+**Status:** accepted
+
+**Decision:** run the pinned OpenSpec archive command against a temporary copy and
+judge its JSON result instead of implementing a second delta parser or performing
+a reversible archive in the ticket worktree.
+
+**Why:** the actual archive operation is the existing authority for applicability
+and has no dry-run flag in OpenSpec 1.11.0. A disposable copy exercises that
+authority while making pre-merge mutation of the active change and baseline
+impossible, and parsing its JSON preserves the precise archive failure.
+
+**Consequences:** preflight cost includes copying the OpenSpec tree and invoking
+the CLI; malformed or changed JSON fails closed; diagnostics can identify the
+unmatched requirement and the correction class but do not guess the old baseline
+header; post-merge archive remains unchanged.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -35,8 +35,9 @@ delta repair before ticket finalization can complete.
   archive JSON reports no archive or an error; secret exposure, irreversible loss
   of authoritative data, accepting an unexpected JSON shape, or silent incorrect
   success.
-- **Must recover:** temporary-copy creation or CLI execution failure must stop the
-  workflow visibly and clean up the disposable copy.
+- **Must recover:** executable launch, base export, overlay, temporary-copy, or CLI
+  execution failure must stop the workflow visibly and clean up the disposable
+  copy.
 - **Accepted failure:** malformed or unexpected third-party CLI output stops the
   pull request with the raw diagnostic available for manual investigation; no
   automatic recovery is required.
@@ -45,5 +46,6 @@ delta repair before ticket finalization can complete.
 - **Evidence owed:** public-command tests reproduce strict-validation success
   followed by archive applicability failure, prove a correct rename passes, and
   compare separate before/after digests for the ticket worktree and base-ref
-  OpenSpec trees on both success and archive failure; OpenSpec validation and the
-  repository gate pass.
+  OpenSpec trees on both success and archive failure; boundary-fake tests cover
+  executable launch, base export, and overlay failure with nonzero diagnostics and
+  temporary-directory cleanup; OpenSpec validation and the repository gate pass.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -31,7 +31,8 @@ delta repair before ticket finalization can complete.
 ## Risk contract
 
 - **Must prevent:** mutating, folding, moving, or archiving the authoritative
-  active change or baseline before merge; accepting process exit zero when the
+  active change or baseline before merge; gating against a remote-tracking base
+  older than the immediately completed fetch; accepting process exit zero when the
   archive JSON reports no archive or an error; secret exposure, irreversible loss
   of authoritative data, accepting an unexpected JSON shape, or silent incorrect
   success.
@@ -39,10 +40,12 @@ delta repair before ticket finalization can complete.
   execution failure must stop the workflow visibly and clean up the disposable
   copy.
 - **Accepted failure:** malformed or unexpected third-party CLI output stops the
-  pull request with the raw diagnostic available for manual investigation; no
-  automatic recovery is required.
+  pull request with the raw diagnostic available for manual investigation; a base
+  advance after the gate but before human merge may still stop finalization for
+  manual delta correction; no automatic recovery is required.
 - **Unsupported:** repairing deltas automatically, inferring a missing old header,
-  changing OpenSpec's validator, or replacing post-merge archive guidance.
+  changing OpenSpec's validator, replacing post-merge archive guidance, or adding
+  merge-time CI or branch-protection enforcement.
 - **Evidence owed:** public-command tests reproduce strict-validation success
   followed by archive applicability failure, prove a correct rename passes, and
   compare separate before/after digests for the ticket worktree and base-ref

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -1,0 +1,40 @@
+# Preflight OpenSpec applicability before merge
+
+## Why
+
+OpenSpec 1.11.0 strict validation accepts a structurally valid change whose
+`MODIFIED Requirements` header does not exist in the current baseline. The first
+applicability check is then the post-merge `openspec archive` operation. Issue
+259 demonstrated that this leaves a merged implementation waiting on a manual
+delta repair before ticket finalization can complete.
+
+## What changes
+
+- Add a ticket command that proves an active OpenSpec change can archive by
+  running the pinned CLI against a disposable copy of the repository's OpenSpec
+  tree and inspecting its JSON result.
+- Make `start` run that preflight after the final implementation/review edits and
+  before opening the pull request; make `revise` repeat it before pushing an
+  amended OpenSpec-backed change.
+- Report an unmatched modified requirement and direct the author to add the
+  missing `RENAMED Requirements` mapping or correct the modified header.
+- Preserve the authoritative active change and baseline until the existing
+  post-merge archive lifecycle runs.
+
+## Risk contract
+
+- **Must prevent:** mutating, folding, moving, or archiving the authoritative
+  active change or baseline before merge; accepting process exit zero when the
+  archive JSON reports no archive or an error; secret exposure, irreversible loss
+  of authoritative data, or silent incorrect success.
+- **Must recover:** temporary-copy creation or CLI execution failure must stop the
+  workflow visibly and clean up the disposable copy.
+- **Accepted failure:** malformed or unexpected third-party CLI output stops the
+  pull request with the raw diagnostic available for manual investigation; no
+  automatic recovery is required.
+- **Unsupported:** repairing deltas automatically, inferring a missing old header,
+  changing OpenSpec's validator, or replacing post-merge archive guidance.
+- **Evidence owed:** public-command tests reproduce strict-validation success
+  followed by archive applicability failure, prove a correct rename passes, and
+  prove the source OpenSpec tree is byte-for-byte untouched; OpenSpec validation
+  and the repository gate pass.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -19,7 +19,8 @@ delta repair before ticket finalization can complete.
   one active change because finalization owns only one serial archive.
 - Make flat and chunked `start` run that preflight after the final
   implementation/review/change-record edits and before opening the pull request;
-  make `revise` update its change record and repeat the gate before pushing.
+  refresh the remote base immediately before that gate, and make `revise` update
+  its change record and repeat the gate after its existing fetch/rebase.
 - Report an unmatched modified requirement and direct the author to add the
   missing `RENAMED Requirements` mapping or correct the modified header.
 - Preserve the authoritative active change and baseline until the existing

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -19,8 +19,8 @@ delta repair before ticket finalization can complete.
   one active change because finalization owns only one serial archive.
 - Make flat and chunked `start` run that preflight after the final
   implementation/review/change-record edits and before opening the pull request;
-  refresh the remote base immediately before that gate, and make `revise` update
-  its change record and repeat the gate after its existing fetch/rebase.
+  refresh the remote base immediately before that gate in every caller, and make
+  `revise` update its change record before its own final refresh and gate.
 - Report an unmatched modified requirement and direct the author to add the
   missing `RENAMED Requirements` mapping or correct the modified header.
 - Preserve the authoritative active change and baseline until the existing

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -12,8 +12,8 @@ delta repair before ticket finalization can complete.
 
 - Add a ticket command that discovers the active OpenSpec change modified by an
   ordinary ticket branch relative to a caller-owned base ref, then proves it can archive by
-  running the pinned CLI against a disposable copy of the repository's OpenSpec
-  tree and inspecting its JSON result.
+  overlaying that ticket change onto a disposable export of the base ref's current
+  OpenSpec tree, running the pinned CLI there, and inspecting its JSON result.
 - Treat no changed active change as a non-OpenSpec no-op, ignore historical paths
   absent from the ticket tree, and stop when one ordinary ticket changes more than
   one active change because finalization owns only one serial archive.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -10,12 +10,13 @@ delta repair before ticket finalization can complete.
 
 ## What changes
 
-- Add a ticket command that proves an active OpenSpec change can archive by
+- Add a ticket command that discovers every active OpenSpec change modified by an
+  ordinary ticket branch relative to its base, then proves each can archive by
   running the pinned CLI against a disposable copy of the repository's OpenSpec
   tree and inspecting its JSON result.
-- Make `start` run that preflight after the final implementation/review edits and
-  before opening the pull request; make `revise` repeat it before pushing an
-  amended OpenSpec-backed change.
+- Make flat and chunked `start` run that preflight after the final
+  implementation/review/change-record edits and before opening the pull request;
+  make `revise` update its change record and repeat the gate before pushing.
 - Report an unmatched modified requirement and direct the author to add the
   missing `RENAMED Requirements` mapping or correct the modified header.
 - Preserve the authoritative active change and baseline until the existing
@@ -26,7 +27,8 @@ delta repair before ticket finalization can complete.
 - **Must prevent:** mutating, folding, moving, or archiving the authoritative
   active change or baseline before merge; accepting process exit zero when the
   archive JSON reports no archive or an error; secret exposure, irreversible loss
-  of authoritative data, or silent incorrect success.
+  of authoritative data, accepting an unexpected JSON shape, or silent incorrect
+  success.
 - **Must recover:** temporary-copy creation or CLI execution failure must stop the
   workflow visibly and clean up the disposable copy.
 - **Accepted failure:** malformed or unexpected third-party CLI output stops the

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -44,5 +44,6 @@ delta repair before ticket finalization can complete.
   changing OpenSpec's validator, or replacing post-merge archive guidance.
 - **Evidence owed:** public-command tests reproduce strict-validation success
   followed by archive applicability failure, prove a correct rename passes, and
-  prove the source OpenSpec tree is byte-for-byte untouched; OpenSpec validation
-  and the repository gate pass.
+  compare separate before/after digests for the ticket worktree and base-ref
+  OpenSpec trees on both success and archive failure; OpenSpec validation and the
+  repository gate pass.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -17,6 +17,8 @@ delta repair before ticket finalization can complete.
 - Treat no changed active change as a non-OpenSpec no-op, ignore historical paths
   absent from the ticket tree, and stop when one ordinary ticket changes more than
   one active change because finalization owns only one serial archive.
+- Invoke the gate only for ordinary tickets using the OpenSpec change-record path;
+  leave other/no change-record conventions and epic children unchanged.
 - Make flat and chunked `start` run that preflight after the final
   implementation/review/change-record edits and before opening the pull request;
   refresh the remote base immediately before that gate in every caller, and make

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -14,7 +14,7 @@ delta repair before ticket finalization can complete.
   ordinary ticket branch relative to a caller-owned base ref, then proves it can archive by
   overlaying that ticket change onto a disposable export of the base ref's current
   OpenSpec tree, running the pinned CLI there, and inspecting its JSON result.
-- Treat no changed active change as a non-OpenSpec no-op, ignore historical paths
+- Treat no changed active change as a command no-op, ignore historical paths
   absent from the ticket tree, and stop when one ordinary ticket changes more than
   one active change because finalization owns only one serial archive.
 - Invoke the gate only for ordinary tickets using the OpenSpec change-record path;

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -48,4 +48,5 @@ delta repair before ticket finalization can complete.
   compare separate before/after digests for the ticket worktree and base-ref
   OpenSpec trees on both success and archive failure; boundary-fake tests cover
   executable launch, base export, and overlay failure with nonzero diagnostics and
-  temporary-directory cleanup; OpenSpec validation and the repository gate pass.
+  temporary-directory cleanup; an option-shaped base ref is rejected locally without
+  a remote invocation; OpenSpec validation and the repository gate pass.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/proposal.md
@@ -10,10 +10,13 @@ delta repair before ticket finalization can complete.
 
 ## What changes
 
-- Add a ticket command that discovers every active OpenSpec change modified by an
-  ordinary ticket branch relative to its base, then proves each can archive by
+- Add a ticket command that discovers the active OpenSpec change modified by an
+  ordinary ticket branch relative to a caller-owned base ref, then proves it can archive by
   running the pinned CLI against a disposable copy of the repository's OpenSpec
   tree and inspecting its JSON result.
+- Treat no changed active change as a non-OpenSpec no-op, ignore historical paths
+  absent from the ticket tree, and stop when one ordinary ticket changes more than
+  one active change because finalization owns only one serial archive.
 - Make flat and chunked `start` run that preflight after the final
   implementation/review/change-record edits and before opening the pull request;
   make `revise` update its change record and repeat the gate before pushing.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -15,15 +15,16 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 
 #### Scenario: A ticket reaches implementation
 
-- **WHEN** `start` finds a sufficient newest work order and a compatible session
+- **WHEN** `start` finds a sufficient newest work order and a compatible session for
+  an ordinary OpenSpec-backed ticket
 - **THEN** it reuses the ticket's branch and worktree, implements and verifies the
   order, proves its changed active OpenSpec delta applies in a disposable copy,
   opens one pull request, and stops for human review
 
 #### Scenario: A chunked ticket reaches pull-request creation
 
-- **WHEN** coordinator mode has merged and reviewed all chunks and recorded the
-  ordinary ticket's active change
+- **WHEN** coordinator mode has merged and reviewed all chunks for an ordinary
+  OpenSpec-backed ticket and recorded its active change
 - **THEN** it proves its one changed active OpenSpec delta applies before rejoining
   pull-request creation
 

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -60,3 +60,10 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
   present in the ticket tree
 - **THEN** preflight stops visibly because ordinary-ticket finalization owns one
   archive unit instead of independently approving interacting deltas
+
+#### Scenario: A ticket uses another change-record convention
+
+- **WHEN** flat start, chunked coordinator mode, or revise operates a repository
+  whose ordinary ticket is not backed by an OpenSpec active change
+- **THEN** it preserves that repository's existing verification and pull-request or
+  push path without invoking the OpenSpec applicability command

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -34,6 +34,14 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 - **THEN** it fetches the remote immediately before exporting the current default-
   branch OpenSpec tree, and a fetch or base-ref failure stops pull-request creation
 
+#### Scenario: A base ref resembles a Git option
+
+- **WHEN** the public applicability command receives a base-ref value that could be
+  parsed as a Git option rather than a local revision
+- **THEN** it resolves the value with Git's end-of-options form to a verified local
+  commit before merge-base or export, and an unresolved value stops locally without
+  invoking a remote
+
 #### Scenario: A structurally valid delta cannot apply
 
 - **WHEN** strict validation passes but a disposable archive reports an unmatched

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -6,7 +6,7 @@ The ticket workflow MUST expose one verb at a time: `triage` grounds the ticket 
 posts a locked work order after unconditional `/scope`; `start` executes the newest
 order in an isolated ticket worktree, proves in both flat and chunked execution
 that the one active OpenSpec change modified by the ordinary ticket branch can apply
-to the current baseline without mutating either authoritative tree, and opens a
+to a freshly fetched current baseline without mutating either authoritative tree, and opens a
 pull request; `revise` actions one review round, completes its active-change edits,
 and repeats that applicability proof before pushing; and `finalize`
 reconciles a merged or explicitly abandoned pull request with the tracker and local
@@ -25,6 +25,12 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
   ordinary ticket's active change
 - **THEN** it proves its one changed active OpenSpec delta applies before rejoining
   pull-request creation
+
+#### Scenario: The default branch advanced after ticket branch cut
+
+- **WHEN** flat or chunked `start` reaches applicability preflight
+- **THEN** it fetches the remote immediately before exporting the current default-
+  branch OpenSpec tree, and a fetch or base-ref failure stops pull-request creation
 
 #### Scenario: A structurally valid delta cannot apply
 

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -23,7 +23,7 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 
 - **WHEN** coordinator mode has merged and reviewed all chunks and recorded the
   ordinary ticket's active change
-- **THEN** it proves every changed active OpenSpec delta applies before rejoining
+- **THEN** it proves its one changed active OpenSpec delta applies before rejoining
   pull-request creation
 
 #### Scenario: A structurally valid delta cannot apply

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -5,7 +5,7 @@
 The ticket workflow MUST expose one verb at a time: `triage` grounds the ticket and
 posts a locked work order after unconditional `/scope`; `start` executes the newest
 order in an isolated ticket worktree, proves in both flat and chunked execution
-that every active OpenSpec change modified by the ordinary ticket branch can apply
+that the one active OpenSpec change modified by the ordinary ticket branch can apply
 to the current baseline without mutating either authoritative tree, and opens a
 pull request; `revise` actions one review round, completes its active-change edits,
 and repeats that applicability proof before pushing; and `finalize`
@@ -16,7 +16,7 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 
 - **WHEN** `start` finds a sufficient newest work order and a compatible session
 - **THEN** it reuses the ticket's branch and worktree, implements and verifies the
-  order, proves every changed active OpenSpec delta applies in a disposable copy,
+  order, proves its changed active OpenSpec delta applies in a disposable copy,
   opens one pull request, and stops for human review
 
 #### Scenario: A chunked ticket reaches pull-request creation
@@ -46,3 +46,10 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 - **WHEN** `revise` changes an ordinary ticket's checklist or decision record
 - **THEN** it completes those active-change edits, proves the resulting bytes apply,
   and only then pushes the branch
+
+#### Scenario: An ordinary ticket changes several active changes
+
+- **WHEN** base-diff discovery finds more than one active OpenSpec change still
+  present in the ticket tree
+- **THEN** preflight stops visibly because ordinary-ticket finalization owns one
+  archive unit instead of independently approving interacting deltas

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -42,6 +42,13 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
   commit before merge-base or export, and an unresolved value stops locally without
   invoking a remote
 
+#### Scenario: The baseline advances after the gate
+
+- **WHEN** the freshly fetched baseline passes applicability preflight and then
+  advances again before the later human merge
+- **THEN** the workflow makes no merge-time guarantee or enforcement claim, and a
+  resulting post-merge archive mismatch stops finalization for manual correction
+
 #### Scenario: A structurally valid delta cannot apply
 
 - **WHEN** strict validation passes but a disposable archive reports an unmatched

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -4,11 +4,12 @@
 
 The ticket workflow MUST expose one verb at a time: `triage` grounds the ticket and
 posts a locked work order after unconditional `/scope`; `start` executes the newest
-order in an isolated ticket worktree, proves in both flat and chunked execution
-that the one active OpenSpec change modified by the ordinary ticket branch can apply
-to a freshly fetched current baseline without mutating either authoritative tree, and opens a
-pull request; `revise` actions one review round, completes its active-change edits,
-and repeats that applicability proof before pushing; and `finalize`
+order in an isolated ticket worktree and, for an ordinary OpenSpec-backed ticket,
+proves in both flat and chunked execution that its one active change can apply to a
+freshly fetched current baseline without mutating either authoritative tree, then
+opens a pull request; `revise` actions one review round and, for an ordinary
+OpenSpec-backed ticket, completes its active-change edits and repeats that
+applicability proof before pushing; and `finalize`
 reconciles a merged or explicitly abandoned pull request with the tracker and local
 worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge.
 

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -4,10 +4,11 @@
 
 The ticket workflow MUST expose one verb at a time: `triage` grounds the ticket and
 posts a locked work order after unconditional `/scope`; `start` executes the newest
-order in an isolated ticket worktree, proves that any ordinary active OpenSpec
-change can apply to the current baseline without mutating either authoritative
-tree, and opens a pull request; `revise` actions one review round and repeats that
-applicability proof before pushing a changed OpenSpec delta; and `finalize`
+order in an isolated ticket worktree, proves in both flat and chunked execution
+that every active OpenSpec change modified by the ordinary ticket branch can apply
+to the current baseline without mutating either authoritative tree, and opens a
+pull request; `revise` actions one review round, completes its active-change edits,
+and repeats that applicability proof before pushing; and `finalize`
 reconciles a merged or explicitly abandoned pull request with the tracker and local
 worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge.
 
@@ -15,8 +16,15 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 
 - **WHEN** `start` finds a sufficient newest work order and a compatible session
 - **THEN** it reuses the ticket's branch and worktree, implements and verifies the
-  order, proves any active OpenSpec delta applies in a disposable copy, opens one
-  pull request, and stops for human review
+  order, proves every changed active OpenSpec delta applies in a disposable copy,
+  opens one pull request, and stops for human review
+
+#### Scenario: A chunked ticket reaches pull-request creation
+
+- **WHEN** coordinator mode has merged and reviewed all chunks and recorded the
+  ordinary ticket's active change
+- **THEN** it proves every changed active OpenSpec delta applies before rejoining
+  pull-request creation
 
 #### Scenario: A structurally valid delta cannot apply
 
@@ -32,3 +40,9 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
   header to its modified header
 - **THEN** the disposable archive succeeds and the existing pre-merge and
   post-merge lifecycle continues without altering the authoritative tree early
+
+#### Scenario: Review changes an active delta
+
+- **WHEN** `revise` changes an ordinary ticket's checklist or decision record
+- **THEN** it completes those active-change edits, proves the resulting bytes apply,
+  and only then pushes the branch

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -38,9 +38,18 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 
 - **WHEN** strict validation passes but a disposable archive reports an unmatched
   modified requirement and no archive result
-- **THEN** the workflow stops before the pull request, names the unmatched
-  requirement, directs the author to add the missing rename mapping or correct the
-  modified header, and leaves the active change and baseline unchanged
+- **THEN** the workflow stops before the pull request and emits exactly two ordered
+  `ticket:` stderr lines: the unmatched requirement first, then direction to add
+  the missing rename mapping or correct the modified header; it leaves the active
+  change and baseline unchanged
+
+#### Scenario: Applicability infrastructure fails
+
+- **WHEN** executable launch, base export, active-change overlay, or archive CLI
+  execution fails during the disposable applicability proof
+- **THEN** the public command exits nonzero with one `ticket:` stderr diagnostic,
+  removes its temporary directory, and leaves the ticket worktree and base-ref
+  OpenSpec trees unchanged
 
 #### Scenario: A correctly renamed requirement is preflighted
 

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -50,8 +50,9 @@ worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge
 #### Scenario: Review changes an active delta
 
 - **WHEN** `revise` changes an ordinary ticket's checklist or decision record
-- **THEN** it completes those active-change edits, proves the resulting bytes apply,
-  and only then pushes the branch
+- **THEN** it completes those active-change edits, fetches the remote immediately
+  before proving the resulting bytes against refreshed `origin/<baseRefName>`, and
+  only then pushes the branch
 
 #### Scenario: An ordinary ticket changes several active changes
 

--- a/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/specs/ticket-workflow/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Four-verb lifecycle
+
+The ticket workflow MUST expose one verb at a time: `triage` grounds the ticket and
+posts a locked work order after unconditional `/scope`; `start` executes the newest
+order in an isolated ticket worktree, proves that any ordinary active OpenSpec
+change can apply to the current baseline without mutating either authoritative
+tree, and opens a pull request; `revise` actions one review round and repeats that
+applicability proof before pushing a changed OpenSpec delta; and `finalize`
+reconciles a merged or explicitly abandoned pull request with the tracker and local
+worktree state. Agents MUST stop at the pull request boundary and MUST NOT merge.
+
+#### Scenario: A ticket reaches implementation
+
+- **WHEN** `start` finds a sufficient newest work order and a compatible session
+- **THEN** it reuses the ticket's branch and worktree, implements and verifies the
+  order, proves any active OpenSpec delta applies in a disposable copy, opens one
+  pull request, and stops for human review
+
+#### Scenario: A structurally valid delta cannot apply
+
+- **WHEN** strict validation passes but a disposable archive reports an unmatched
+  modified requirement and no archive result
+- **THEN** the workflow stops before the pull request, names the unmatched
+  requirement, directs the author to add the missing rename mapping or correct the
+  modified header, and leaves the active change and baseline unchanged
+
+#### Scenario: A correctly renamed requirement is preflighted
+
+- **WHEN** a change contains a valid mapping from the current baseline requirement
+  header to its modified header
+- **THEN** the disposable archive succeeds and the existing pre-merge and
+  post-merge lifecycle continues without altering the authoritative tree early

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -1,16 +1,16 @@
 # Tasks
 
-- [ ] Add the non-mutating OpenSpec applicability command to the ticket command
+- [x] Add the non-mutating OpenSpec applicability command to the ticket command
       interface, including JSON-success checks and actionable diagnostics.
-- [ ] Gate flat and chunked OpenSpec-backed `start` and `revise` after their final
+- [x] Gate flat and chunked OpenSpec-backed `start` and `revise` after their final
       change-record edits at the pre-pull-request or pre-push boundary without
       changing finalization's archive ownership or non-OpenSpec/epic-child paths.
-- [ ] Add public-command tests for base-ref, deleted/renamed path, and zero/one/
+- [x] Add public-command tests for base-ref, deleted/renamed path, and zero/one/
       unsupported-multiple active-change discovery; issue 259's
       validate-pass/archive-fail shape, a correct rename, unexpected output shapes,
       a base advance after branch cut, executable-launch/export/overlay failures,
       option-shaped base-ref rejection without remote access, temporary-directory
       cleanup, and separate ticket/base-tree immutability.
-- [ ] Update the ticket-workflow baseline delta and behavior-contract tests.
-- [ ] Run `openspec validate --all --strict` and the full repository test command
+- [x] Update the ticket-workflow baseline delta and behavior-contract tests.
+- [x] Run `openspec validate --all --strict` and the full repository test command
       from `AGENTS.md`.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -5,7 +5,8 @@
 - [ ] Gate flat and chunked OpenSpec-backed `start` and `revise` after their final
       change-record edits at the pre-pull-request or pre-push boundary without
       changing finalization's archive ownership.
-- [ ] Add public-command tests for changed-active-change discovery, issue 259's
+- [ ] Add public-command tests for base-ref, deleted/renamed path, and zero/one/
+      unsupported-multiple active-change discovery; issue 259's
       validate-pass/archive-fail shape, a correct rename, unexpected output shapes,
       and source-tree immutability.
 - [ ] Update the ticket-workflow baseline delta and behavior-contract tests.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -8,7 +8,8 @@
 - [ ] Add public-command tests for base-ref, deleted/renamed path, and zero/one/
       unsupported-multiple active-change discovery; issue 259's
       validate-pass/archive-fail shape, a correct rename, unexpected output shapes,
-      a base advance after branch cut, and separate ticket/base-tree immutability.
+      a base advance after branch cut, executable-launch/export/overlay failures,
+      temporary-directory cleanup, and separate ticket/base-tree immutability.
 - [ ] Update the ticket-workflow baseline delta and behavior-contract tests.
 - [ ] Run `openspec validate --all --strict` and the full repository test command
       from `AGENTS.md`.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -4,11 +4,11 @@
       interface, including JSON-success checks and actionable diagnostics.
 - [ ] Gate flat and chunked OpenSpec-backed `start` and `revise` after their final
       change-record edits at the pre-pull-request or pre-push boundary without
-      changing finalization's archive ownership.
+      changing finalization's archive ownership or non-OpenSpec/epic-child paths.
 - [ ] Add public-command tests for base-ref, deleted/renamed path, and zero/one/
       unsupported-multiple active-change discovery; issue 259's
       validate-pass/archive-fail shape, a correct rename, unexpected output shapes,
-      a base advance after branch cut, and source-tree immutability.
+      a base advance after branch cut, and separate ticket/base-tree immutability.
 - [ ] Update the ticket-workflow baseline delta and behavior-contract tests.
 - [ ] Run `openspec validate --all --strict` and the full repository test command
       from `AGENTS.md`.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -8,7 +8,7 @@
 - [ ] Add public-command tests for base-ref, deleted/renamed path, and zero/one/
       unsupported-multiple active-change discovery; issue 259's
       validate-pass/archive-fail shape, a correct rename, unexpected output shapes,
-      and source-tree immutability.
+      a base advance after branch cut, and source-tree immutability.
 - [ ] Update the ticket-workflow baseline delta and behavior-contract tests.
 - [ ] Run `openspec validate --all --strict` and the full repository test command
       from `AGENTS.md`.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [ ] Add the non-mutating OpenSpec applicability command to the ticket command
+      interface, including JSON-success checks and actionable diagnostics.
+- [ ] Gate OpenSpec-backed `start` and `revise` at their last pre-pull-request or
+      pre-push boundary without changing finalization's archive ownership.
+- [ ] Add public-command tests for issue 259's validate-pass/archive-fail shape,
+      a correct rename, unexpected output, and source-tree immutability.
+- [ ] Update the ticket-workflow baseline delta and behavior-contract tests.
+- [ ] Run `openspec validate --all --strict` and the full repository test command
+      from `AGENTS.md`.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -2,10 +2,12 @@
 
 - [ ] Add the non-mutating OpenSpec applicability command to the ticket command
       interface, including JSON-success checks and actionable diagnostics.
-- [ ] Gate OpenSpec-backed `start` and `revise` at their last pre-pull-request or
-      pre-push boundary without changing finalization's archive ownership.
-- [ ] Add public-command tests for issue 259's validate-pass/archive-fail shape,
-      a correct rename, unexpected output, and source-tree immutability.
+- [ ] Gate flat and chunked OpenSpec-backed `start` and `revise` after their final
+      change-record edits at the pre-pull-request or pre-push boundary without
+      changing finalization's archive ownership.
+- [ ] Add public-command tests for changed-active-change discovery, issue 259's
+      validate-pass/archive-fail shape, a correct rename, unexpected output shapes,
+      and source-tree immutability.
 - [ ] Update the ticket-workflow baseline delta and behavior-contract tests.
 - [ ] Run `openspec validate --all --strict` and the full repository test command
       from `AGENTS.md`.

--- a/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
+++ b/openspec/changes/265-preflight-openspec-rename-applicability/tasks.md
@@ -9,7 +9,8 @@
       unsupported-multiple active-change discovery; issue 259's
       validate-pass/archive-fail shape, a correct rename, unexpected output shapes,
       a base advance after branch cut, executable-launch/export/overlay failures,
-      temporary-directory cleanup, and separate ticket/base-tree immutability.
+      option-shaped base-ref rejection without remote access, temporary-directory
+      cleanup, and separate ticket/base-tree immutability.
 - [ ] Update the ticket-workflow baseline delta and behavior-contract tests.
 - [ ] Run `openspec validate --all --strict` and the full repository test command
       from `AGENTS.md`.

--- a/skills/drivers/ticket/references/coordinator-mode.md
+++ b/skills/drivers/ticket/references/coordinator-mode.md
@@ -8,7 +8,7 @@ whose chunk agent is already gone (step 8) are fixed in place and mentioned in t
 report. Anything larger than mechanical goes back to a delegate.
 
 What follows is what this skill adds on top. It replaces `start` steps 8 through
-11, and rejoins that verb at step 12 when the last chunk has merged.
+12, and rejoins that verb at step 13 when the last chunk has merged.
 
 An epic child creates no per-child change record. Coordinator work preserves the
 parent-plan bytes that triage committed, carries them through the child pull request,
@@ -159,3 +159,21 @@ non-blocking rule.
    branch, at the depth [review-depth.md](review-depth.md) sets for a whole diff.
    Findings route back to the chunk agent that owns the file when its session is
    still alive, and otherwise the coordinator fixes them and says so.
+
+9. **Preflight the outbound OpenSpec change.** Only an ordinary OpenSpec-backed
+   ticket uses this gate. After all chunks merge, whole-diff review and fixes finish,
+   and the coordinator records the active change, run `git fetch origin` immediately
+   before:
+
+   ```sh
+   python3 <ticket-skill-directory>/scripts/ticket.py preflight-openspec \
+     --repo <ticket-worktree> \
+     --base-ref refs/remotes/origin/HEAD
+   ```
+
+   The fetch refreshes the base that the command resolves locally. A ticket using
+   another or no change-record convention, or an epic child, bypasses this gate
+   unchanged. Fetch, ref, or preflight failure stops visibly; do not rejoin pull
+   request creation. This adds no chunk integration or review ownership, preserves
+   one branch and one pull request, and leaves finalization the sole authoritative
+   archive owner.

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -13,6 +13,7 @@ session.
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import os
 import re
@@ -757,6 +758,11 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
                 raise OpenSpecPreflightError("could not export the base OpenSpec tree")
             try:
                 with tarfile.open(bundle_path) as bundle:
+                    extract_options = (
+                        {"filter": "data"}
+                        if "filter" in inspect.signature(bundle.extract).parameters
+                        else {}
+                    )
                     for member in bundle.getmembers():
                         destination = root / member.name
                         try:
@@ -765,7 +771,7 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
                             raise OpenSpecPreflightError("could not export the base OpenSpec tree") from error
                         if not (member.isdir() or member.isreg()):
                             raise OpenSpecPreflightError("could not export the base OpenSpec tree")
-                        bundle.extract(member, root)
+                        bundle.extract(member, root, **extract_options)
             except (OSError, tarfile.TarError) as error:
                 raise OpenSpecPreflightError("could not export the base OpenSpec tree") from error
 

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -16,10 +16,13 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tarfile
+import tempfile
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterator, Optional
 
 PROJECTS_DIR = Path(
@@ -60,6 +63,14 @@ FLOOR_PEAK = 120_000
 
 class TelemetryError(RuntimeError):
     """A safe, user-facing telemetry failure."""
+
+
+class OpenSpecPreflightError(RuntimeError):
+    """A safe, user-facing failure while proving an OpenSpec change applies."""
+
+    def __init__(self, message: str, exit_status: int = 1) -> None:
+        super().__init__(message)
+        self.exit_status = exit_status
 
 
 def validate_ticket_id(value: str) -> str:
@@ -644,6 +655,173 @@ def command_claim(arguments: argparse.Namespace) -> int:
     return 0
 
 
+def command_preflight_openspec(arguments: argparse.Namespace) -> int:
+    """Prove the one changed active OpenSpec change applies without mutating either tree."""
+    repo = arguments.repo.expanduser().resolve()
+    source = repo / "openspec"
+    if not source.is_dir():
+        raise OpenSpecPreflightError(f"OpenSpec root not found: {source}", 2)
+
+    try:
+        resolved = subprocess.run(
+            [
+                "git",
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{arguments.base_ref}^{{commit}}",
+            ],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as error:
+        raise OpenSpecPreflightError(f"could not resolve base ref: {error}", 2) from error
+    if resolved.returncode or not resolved.stdout.strip():
+        raise OpenSpecPreflightError(
+            f"base ref does not resolve to a local commit: {arguments.base_ref}", 2
+        )
+    base_commit = resolved.stdout.strip()
+
+    try:
+        merged = subprocess.run(
+            ["git", "merge-base", "HEAD", base_commit],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        changed_paths = subprocess.run(
+            ["git", "diff", "--name-only", merged.stdout.strip(), "--", "openspec/changes"],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as error:
+        raise OpenSpecPreflightError(f"could not discover changed OpenSpec changes: {error}") from error
+    if merged.returncode or not merged.stdout.strip() or changed_paths.returncode:
+        raise OpenSpecPreflightError("could not discover changed OpenSpec changes")
+
+    changes: set[str] = set()
+    for line in changed_paths.stdout.splitlines():
+        parts = PurePosixPath(line).parts
+        active = source / "changes" / parts[2] if len(parts) >= 3 else None
+        if (
+            active is not None
+            and parts[:2] == ("openspec", "changes")
+            and parts[2] != "archive"
+            and active.is_dir()
+        ):
+            changes.add(parts[2])
+    if not changes:
+        print("ticket: no changed active OpenSpec change")
+        return 0
+    if len(changes) > 1:
+        raise OpenSpecPreflightError(
+            "more than one changed active OpenSpec change: " + ", ".join(sorted(changes)), 2
+        )
+    change = next(iter(changes))
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="ticket-openspec-preflight-") as temporary:
+            root = Path(temporary)
+            bundle_path = root / "openspec.tar"
+            exported = subprocess.run(
+                [
+                    "git",
+                    "archive",
+                    "--format=tar",
+                    f"--output={bundle_path}",
+                    base_commit,
+                    "openspec",
+                ],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if exported.returncode:
+                raise OpenSpecPreflightError("could not export the base OpenSpec tree")
+            try:
+                with tarfile.open(bundle_path) as bundle:
+                    for member in bundle.getmembers():
+                        destination = root / member.name
+                        try:
+                            destination.resolve().relative_to(root.resolve())
+                        except ValueError as error:
+                            raise OpenSpecPreflightError("could not export the base OpenSpec tree") from error
+                        if not (member.isdir() or member.isreg()):
+                            raise OpenSpecPreflightError("could not export the base OpenSpec tree")
+                        bundle.extract(member, root)
+            except (OSError, tarfile.TarError) as error:
+                raise OpenSpecPreflightError("could not export the base OpenSpec tree") from error
+
+            copied_change = source / "changes" / change
+            disposable_change = root / "openspec" / "changes" / change
+            if not (root / "openspec").is_dir() or not copied_change.is_dir():
+                raise OpenSpecPreflightError("could not overlay the active OpenSpec change", 2)
+            try:
+                if disposable_change.exists():
+                    shutil.rmtree(disposable_change)
+                shutil.copytree(copied_change, disposable_change, symlinks=True)
+            except OSError as error:
+                raise OpenSpecPreflightError("could not overlay the active OpenSpec change") from error
+
+            try:
+                result = subprocess.run(
+                    ["openspec", "archive", change, "--json", "--yes"],
+                    cwd=root,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+            except OSError as error:
+                raise OpenSpecPreflightError(f"could not launch OpenSpec archive: {error}") from error
+    except OSError as error:
+        raise OpenSpecPreflightError(f"could not prepare disposable OpenSpec tree: {error}") from error
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise OpenSpecPreflightError("OpenSpec archive returned invalid JSON") from error
+    if not isinstance(payload, dict):
+        raise OpenSpecPreflightError("OpenSpec archive JSON must be an object")
+    status = payload.get("status", [])
+    if not isinstance(status, list) or any(not isinstance(item, dict) for item in status):
+        raise OpenSpecPreflightError("OpenSpec archive status must be a list of objects")
+    errors = [item for item in status if item.get("severity") == "error"]
+    if errors:
+        spec_update_error = next(
+            (item for item in errors if item.get("code") == "archive_spec_update_failed"), None
+        )
+        if spec_update_error is not None:
+            message = spec_update_error.get("message")
+            unmatched = message if isinstance(message, str) and message else "OpenSpec archive preflight failed"
+            print(f"ticket: {unmatched}", file=sys.stderr)
+            print(
+                "ticket: if this requirement was renamed, add a `## RENAMED Requirements` "
+                "mapping from its current baseline header to the unmatched delta header; "
+                "otherwise correct the MODIFIED header.",
+                file=sys.stderr,
+            )
+            return result.returncode or 1
+        message = errors[0].get("message")
+        raise OpenSpecPreflightError(
+            message if isinstance(message, str) and message else "OpenSpec archive preflight failed",
+            result.returncode or 1,
+        )
+    archive = payload.get("archive")
+    if not isinstance(archive, dict):
+        raise OpenSpecPreflightError("OpenSpec archive result must be a non-null object")
+    if result.returncode:
+        raise OpenSpecPreflightError(f"OpenSpec archive exited with status {result.returncode}", result.returncode)
+
+    print(f"ticket: OpenSpec change {change} applies cleanly in a disposable copy")
+    return 0
+
+
 def add_common_flags(target: argparse.ArgumentParser) -> None:
     target.add_argument("ticket_id", help="ticket id, exactly as the tracker names it")
 
@@ -720,6 +898,18 @@ def parse_arguments() -> argparse.Namespace:
     )
     record_parser.set_defaults(handler=command_record)
 
+    preflight_openspec_parser = subparsers.add_parser(
+        "preflight-openspec",
+        help="prove the changed active OpenSpec change applies without mutating its source",
+    )
+    preflight_openspec_parser.add_argument(
+        "--repo", type=Path, required=True, help="ticket worktree containing the OpenSpec change"
+    )
+    preflight_openspec_parser.add_argument(
+        "--base-ref", required=True, help="local Git ref naming the base OpenSpec tree"
+    )
+    preflight_openspec_parser.set_defaults(handler=command_preflight_openspec)
+
     return parser.parse_args()
 
 
@@ -730,6 +920,9 @@ def main() -> int:
     except TelemetryError as error:
         print(f"ticket: {error}", file=sys.stderr)
         return 1
+    except OpenSpecPreflightError as error:
+        print(f"ticket: {error}", file=sys.stderr)
+        return error.exit_status
 
 
 if __name__ == "__main__":

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -655,6 +655,16 @@ def command_claim(arguments: argparse.Namespace) -> int:
     return 0
 
 
+def contains_symlink(root: Path) -> bool:
+    """Reject links before an OpenSpec subprocess can traverse a copied change."""
+    if root.is_symlink():
+        return True
+    for directory, directories, files in os.walk(root, followlinks=False):
+        if any((Path(directory) / name).is_symlink() for name in [*directories, *files]):
+            return True
+    return False
+
+
 def command_preflight_openspec(arguments: argparse.Namespace) -> int:
     """Prove the one changed active OpenSpec change applies without mutating either tree."""
     repo = arguments.repo.expanduser().resolve()
@@ -676,7 +686,7 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
             capture_output=True,
             check=False,
         )
-    except OSError as error:
+    except (OSError, UnicodeDecodeError) as error:
         raise OpenSpecPreflightError(f"could not resolve base ref: {error}", 2) from error
     if resolved.returncode or not resolved.stdout.strip():
         raise OpenSpecPreflightError(
@@ -699,7 +709,7 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
             capture_output=True,
             check=False,
         )
-    except OSError as error:
+    except (OSError, UnicodeDecodeError) as error:
         raise OpenSpecPreflightError(f"could not discover changed OpenSpec changes: {error}") from error
     if merged.returncode or not merged.stdout.strip() or changed_paths.returncode:
         raise OpenSpecPreflightError("could not discover changed OpenSpec changes")
@@ -762,11 +772,15 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
             disposable_change = root / "openspec" / "changes" / change
             if not (root / "openspec").is_dir() or not copied_change.is_dir():
                 raise OpenSpecPreflightError("could not overlay the active OpenSpec change", 2)
+            if contains_symlink(copied_change):
+                raise OpenSpecPreflightError("active OpenSpec change contains a symlink", 2)
             try:
                 if disposable_change.exists():
                     shutil.rmtree(disposable_change)
                 shutil.copytree(copied_change, disposable_change, symlinks=True)
-            except OSError as error:
+                if contains_symlink(disposable_change):
+                    raise OpenSpecPreflightError("active OpenSpec change contains a symlink", 2)
+            except (OSError, shutil.Error) as error:
                 raise OpenSpecPreflightError("could not overlay the active OpenSpec change") from error
 
             try:
@@ -777,9 +791,9 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
                     capture_output=True,
                     check=False,
                 )
-            except OSError as error:
+            except (OSError, UnicodeDecodeError) as error:
                 raise OpenSpecPreflightError(f"could not launch OpenSpec archive: {error}") from error
-    except OSError as error:
+    except (OSError, UnicodeDecodeError) as error:
         raise OpenSpecPreflightError(f"could not prepare disposable OpenSpec tree: {error}") from error
 
     try:

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -669,6 +669,8 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
     """Prove the one changed active OpenSpec change applies without mutating either tree."""
     repo = arguments.repo.expanduser().resolve()
     source = repo / "openspec"
+    if source.is_symlink():
+        raise OpenSpecPreflightError(f"OpenSpec root must not be a symlink: {source}", 2)
     if not source.is_dir():
         raise OpenSpecPreflightError(f"OpenSpec root not found: {source}", 2)
 
@@ -718,12 +720,11 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
     for line in changed_paths.stdout.splitlines():
         parts = PurePosixPath(line).parts
         active = source / "changes" / parts[2] if len(parts) >= 3 else None
-        if (
-            active is not None
-            and parts[:2] == ("openspec", "changes")
-            and parts[2] != "archive"
-            and active.is_dir()
-        ):
+        if active is None or parts[:2] != ("openspec", "changes") or parts[2] == "archive":
+            continue
+        if active.is_symlink():
+            raise OpenSpecPreflightError("active OpenSpec change contains a symlink", 2)
+        if active.is_dir():
             changes.add(parts[2])
     if not changes:
         print("ticket: no changed active OpenSpec change")
@@ -799,7 +800,11 @@ def command_preflight_openspec(arguments: argparse.Namespace) -> int:
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as error:
-        raise OpenSpecPreflightError("OpenSpec archive returned invalid JSON") from error
+        message = "OpenSpec archive returned invalid JSON"
+        raw_diagnostic = result.stderr.rstrip("\r\n")
+        if raw_diagnostic:
+            message += f": {json.dumps(raw_diagnostic)[1:-1]}"
+        raise OpenSpecPreflightError(message) from error
     if not isinstance(payload, dict):
         raise OpenSpecPreflightError("OpenSpec archive JSON must be an object")
     status = payload.get("status", [])

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -81,16 +81,34 @@ chunked: the chunks merged long ago and the pull request is one diff.
    coordinator does not re-ask. Credentials, secrets, patient data, `.env`, and
    real database contents are excluded.
 
-8. **Push and respond.** Push to the same branch. Reply to each addressed comment on
-   the pull request, resolving or answering it. Outside an epic, update the active
-   change record if its checklist moved, and update its decision record if a
-   decision changed during review; its active change and deltas remain reviewable
-   until the human merge, so do not fold or archive them. An epic child creates no
-   per-child change record. Preserve the parent-plan bytes already carried by the
-   branch, including grounded review fixes to that amendment; the parent epic's
-   active change remains authoritative.
+8. **Update the reviewable change record.** Outside an epic, update the active change
+   record if its checklist moved, and update its decision record if a decision
+   changed during review; its active change and deltas remain reviewable until the
+   human merge, so do not fold or archive them. An epic child creates no per-child
+   change record. Preserve the parent-plan bytes already carried by the branch,
+   including grounded review fixes to that amendment; the parent epic's active
+   change remains authoritative.
 
-9. **Status.** Comment on the ticket (attribution first) only if the round
+9. **Preflight the outbound OpenSpec change.** Only an ordinary OpenSpec-backed
+   ticket uses this gate. After the rebase and every active-change, checklist, and
+   decision edit, run `git fetch origin` again immediately before:
+
+   ```sh
+   python3 <ticket-skill-directory>/scripts/ticket.py preflight-openspec \
+     --repo <ticket-worktree> \
+     --base-ref origin/<baseRefName>
+   ```
+
+   The earlier rebase fetch does not satisfy this final refresh. A ticket using
+   another or no change-record convention, or an epic child, bypasses this gate
+   unchanged. Fetch, ref, or preflight failure stops visibly; do not push. The gate
+   never archives the authoritative change: finalization remains the sole
+   authoritative archive owner.
+
+10. **Push and respond.** Push to the same branch. Reply to each addressed comment
+    on the pull request, resolving or answering it.
+
+11. **Status.** Comment on the ticket (attribution first) only if the round
    materially changed the plan. Routine fix-and-push rounds need no ticket comment.
 
 ## Refusals

--- a/skills/drivers/ticket/verbs/revise.md
+++ b/skills/drivers/ticket/verbs/revise.md
@@ -81,15 +81,15 @@ chunked: the chunks merged long ago and the pull request is one diff.
    coordinator does not re-ask. Credentials, secrets, patient data, `.env`, and
    real database contents are excluded.
 
-8. **Update the reviewable change record.** Outside an epic, update the active change
-   record if its checklist moved, and update its decision record if a decision
-   changed during review; its active change and deltas remain reviewable until the
-   human merge, so do not fold or archive them. An epic child creates no per-child
-   change record. Preserve the parent-plan bytes already carried by the branch,
-   including grounded review fixes to that amendment; the parent epic's active
-   change remains authoritative.
+8. **Push and respond.** Before pushing, update the reviewable change record. Outside
+   an epic, update the active change record if its checklist moved, and update its
+   decision record if a decision changed during review; its active change and deltas
+   remain reviewable until the human merge, so do not fold or archive them. An epic
+   child creates no per-child change record. Preserve the parent-plan bytes already
+   carried by the branch, including grounded review fixes to that amendment; the
+   parent epic's active change remains authoritative.
 
-9. **Preflight the outbound OpenSpec change.** Only an ordinary OpenSpec-backed
+   **Preflight the outbound OpenSpec change.** Only an ordinary OpenSpec-backed
    ticket uses this gate. After the rebase and every active-change, checklist, and
    decision edit, run `git fetch origin` again immediately before:
 
@@ -105,10 +105,10 @@ chunked: the chunks merged long ago and the pull request is one diff.
    never archives the authoritative change: finalization remains the sole
    authoritative archive owner.
 
-10. **Push and respond.** Push to the same branch. Reply to each addressed comment
-    on the pull request, resolving or answering it.
+   After the gate succeeds, push to the same branch. Reply to each addressed comment
+   on the pull request, resolving or answering it.
 
-11. **Status.** Comment on the ticket (attribution first) only if the round
+9. **Status.** Comment on the ticket (attribution first) only if the round
    materially changed the plan. Routine fix-and-push rounds need no ticket comment.
 
 ## Refusals

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -52,7 +52,7 @@ Execute a locked work order in a fresh session. Ends at the open pull request.
 6. **Chunked order: switch to coordinator mode.** If the `Execution:` line says
    `chunked`, load `/orchestrate` now, then follow
    [references/coordinator-mode.md](../references/coordinator-mode.md) instead of
-   steps 8 through 11, and rejoin at step 12. Flat orders skip this and continue at
+   steps 8 through 12, and rejoin at step 13. Flat orders skip this and continue at
    step 7.
 
 7. **Read the standing decisions**, per the skill page's standing-decisions slot,
@@ -135,10 +135,25 @@ Before declaring the change ready, run each check below.
 11. **Preserve the change record for merge.** Outside an epic, the active change
     and its deltas remain reviewable in the pull request. Do not fold or archive
     them before merge. An epic child creates no per-child change record and
-    preserves the parent-plan bytes with implementation in the pull request. After
-    a human merge, `finalize` leaves the parent active for epic-owned archive.
+   preserves the parent-plan bytes with implementation in the pull request. After
+   a human merge, `finalize` leaves the parent active for epic-owned archive.
 
-12. **Open the pull request.** `gh pr create` against the default branch. The body
+12. **Preflight the outbound OpenSpec change.** Only an ordinary OpenSpec-backed
+   ticket uses this gate. After implementation, review, and all active-change fixes
+   are complete, run `git fetch origin` immediately before the command, then run:
+
+   ```sh
+   python3 <ticket-skill-directory>/scripts/ticket.py preflight-openspec \
+     --repo <ticket-worktree> \
+     --base-ref refs/remotes/origin/HEAD
+   ```
+
+   The fetch refreshes the base that the command resolves locally. A ticket using
+   another or no change-record convention, or an epic child, bypasses this gate
+   unchanged. Fetch, ref, or preflight failure stops visibly; do not open the pull
+   request. Finalization remains the sole authoritative archive owner.
+
+13. **Open the pull request.** `gh pr create` against the default branch. The body
     follows an existing template when one exists, in this order: the repo's
     `.github/pull_request_template.md` (or its `PULL_REQUEST_TEMPLATE/` directory),
     then the organization default in the organization's `.github` repo. Keep the
@@ -163,7 +178,7 @@ Before declaring the change ready, run each check below.
     the built revision. Missing lifecycle evidence is a blocking gap, not a nit;
     `revise` never invents a lock manifest or fidelity ledger after the fact.
 
-13. **Stop.** Report the pull request URL, the verification evidence, review
+14. **Stop.** Report the pull request URL, the verification evidence, review
     findings fixed or carried, and anything from the order left undone and why. On a
     chunked order also report each chunk's outcome and tier. Do not merge, do not
     self-approve, and do not respond to reviews; that is `/ticket revise`.

--- a/skills/drivers/ticket/verbs/start.md
+++ b/skills/drivers/ticket/verbs/start.md
@@ -135,8 +135,8 @@ Before declaring the change ready, run each check below.
 11. **Preserve the change record for merge.** Outside an epic, the active change
     and its deltas remain reviewable in the pull request. Do not fold or archive
     them before merge. An epic child creates no per-child change record and
-   preserves the parent-plan bytes with implementation in the pull request. After
-   a human merge, `finalize` leaves the parent active for epic-owned archive.
+    preserves the parent-plan bytes with implementation in the pull request. After
+    a human merge, `finalize` leaves the parent active for epic-owned archive.
 
 12. **Preflight the outbound OpenSpec change.** Only an ordinary OpenSpec-backed
    ticket uses this gate. After implementation, review, and all active-change fixes

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -2000,15 +2000,17 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         hooks = Path(self.temporary.name) / "filter-capable-tar"
         hooks.mkdir()
         (hooks / "sitecustomize.py").write_text(
-            "import tarfile, warnings\n"
+            "import inspect, tarfile, warnings\n"
             "original_extract = tarfile.TarFile.extract\n"
             "missing = object()\n"
             "def extract(self, member, path='', set_attrs=True, *, "
             "numeric_owner=False, filter=missing):\n"
             "    if filter is missing:\n"
             "        warnings.warn('default extraction filter used', DeprecationWarning)\n"
+            "    options = ({'filter': filter} if "
+            "'filter' in inspect.signature(original_extract).parameters else {})\n"
             "    return original_extract(self, member, path, set_attrs, "
-            "numeric_owner=numeric_owner)\n"
+            "numeric_owner=numeric_owner, **options)\n"
             "tarfile.TarFile.extract = extract\n",
             encoding="utf-8",
         )

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -31,6 +33,39 @@ def run(command: list[str], *, cwd: Path, env: Optional[dict[str, str]] = None):
         command, cwd=cwd, env=env, text=True, stdout=subprocess.PIPE,
         stderr=subprocess.PIPE, check=False,
     )
+
+
+def directory_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        digest.update(path.relative_to(root).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def git_directory_digest(repo: Path, revision: str, root: str) -> str:
+    listed = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", revision, "--", root],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    digest = hashlib.sha256()
+    for name in listed.stdout.splitlines():
+        blob = subprocess.run(
+            ["git", "show", f"{revision}:{name}"],
+            cwd=repo,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        digest.update(name.encode())
+        digest.update(b"\0")
+        digest.update(blob.stdout)
+    return digest.hexdigest()
 
 
 def user_line(text: str, timestamp: str = "2026-01-01T00:00:00Z") -> str:
@@ -1890,7 +1925,6 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
             "#!/usr/bin/env python3\n"
             "import json, os, sys\n"
             "mode = os.environ.get('FAKE_OPENSPEC_MODE', 'ok')\n"
-            "if len(sys.argv) > 1 and sys.argv[1] == 'validate': print(json.dumps({'valid': True})); sys.exit(0)\n"
             "if mode == 'launch': raise OSError('launch denied')\n"
             "if mode == 'nonjson': print('not json')\n"
             "elif mode == 'array': print('[]')\n"
@@ -1988,43 +2022,6 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         self.assertEqual(multiple.returncode, 2)
         self.assertIn("more than one changed active OpenSpec change: three, two", multiple.stderr)
 
-    def test_discovery_selects_one_active_change_for_add_modify_remove_and_rename(self):
-        added = self.preflight()
-        self.assertEqual(added.returncode, 0, added.stderr)
-        self.assertEqual(
-            added.stdout,
-            "ticket: OpenSpec change one applies cleanly in a disposable copy\n",
-        )
-
-        proposal = self.repo / "openspec/changes/one/proposal.md"
-        self.base = self.git("rev-parse", "HEAD").stdout.strip()
-        proposal.write_text("# Changed\n", encoding="utf-8")
-        self.git("add", "openspec")
-        self.git("commit", "-m", "modify change")
-        modified = self.preflight()
-        self.assertEqual(modified.returncode, 0, modified.stderr)
-        self.assertIn("OpenSpec change one applies cleanly", modified.stdout)
-
-        self.base = self.git("rev-parse", "HEAD").stdout.strip()
-        proposal.unlink()
-        self.git("add", "-A")
-        self.git("commit", "-m", "remove change content")
-        removed = self.preflight()
-        self.assertEqual(removed.returncode, 0, removed.stderr)
-        self.assertIn("OpenSpec change one applies cleanly", removed.stdout)
-
-        before = self.repo / "openspec/changes/one/before.md"
-        before.write_text("# Before\n", encoding="utf-8")
-        self.git("add", "openspec")
-        self.git("commit", "-m", "restore change content")
-        self.base = self.git("rev-parse", "HEAD").stdout.strip()
-        before.rename(before.with_name("after.md"))
-        self.git("add", "-A")
-        self.git("commit", "-m", "rename change content")
-        renamed = self.preflight()
-        self.assertEqual(renamed.returncode, 0, renamed.stderr)
-        self.assertIn("OpenSpec change one applies cleanly", renamed.stdout)
-
     def test_archive_json_contract_and_rename_diagnostic_leave_authoritative_trees_intact(self):
         for mode, diagnostic in (
             ("nonjson", "ticket: OpenSpec archive returned invalid JSON\n"),
@@ -2054,20 +2051,6 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
                     self.assertEqual(result.stderr, diagnostic)
                 self.assertEqual(before, (self.tree(), self.tree(self.base)))
                 self.assertEqual(self.git("status", "--short").stdout, "")
-
-    def test_strict_validation_can_pass_while_issue_259_archive_composition_fails(self):
-        environment = self.environment.copy()
-        environment["FAKE_OPENSPEC_MODE"] = "rename"
-        validated = run(
-            ["openspec", "validate", "--all", "--strict", "--json"],
-            cwd=self.repo,
-            env=environment,
-        )
-        self.assertEqual(validated.returncode, 0, validated.stderr)
-
-        result = self.preflight(mode="rename")
-        self.assertEqual(result.returncode, 1)
-        self.assertIn("## RENAMED Requirements", result.stderr)
 
     def test_launch_export_and_symlink_failures_are_clean_and_disposable(self):
         fake = self.bin / "openspec"
@@ -2108,6 +2091,8 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
     def test_overlay_failure_is_diagnostic_and_cleans_the_disposable_tree(self):
         wrapper = self.bin / "git"
         moved_change = Path(self.temporary.name) / "moved-change"
+        ticket_before = directory_digest(self.repo / "openspec")
+        base_before = git_directory_digest(self.repo, self.base, "openspec")
         wrapper.write_text(
             "#!/bin/sh\n"
             "/usr/bin/git \"$@\"\n"
@@ -2118,11 +2103,32 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         )
         wrapper.chmod(0o755)
 
-        result = self.preflight()
+        environment = self.environment.copy()
+        environment["FAKE_OPENSPEC_MODE"] = "ok"
+        try:
+            result = run(
+                [
+                    sys.executable,
+                    str(TICKET_SCRIPT),
+                    "preflight-openspec",
+                    "--repo",
+                    str(self.repo),
+                    "--base-ref",
+                    self.base,
+                ],
+                cwd=self.repo,
+                env=environment,
+            )
+        finally:
+            if moved_change.exists():
+                moved_change.rename(self.repo / "openspec/changes/one")
 
-        self.assertEqual(result.returncode, 2)
+        self.assertNotEqual(result.returncode, 0)
         self.assertEqual(result.stderr, "ticket: could not overlay the active OpenSpec change\n")
         self.assertNotIn("Traceback", result.stderr)
+        self.assertEqual(ticket_before, directory_digest(self.repo / "openspec"))
+        self.assertEqual(base_before, git_directory_digest(self.repo, self.base, "openspec"))
+        self.assertEqual(list(self.preflight_tmp.glob("ticket-openspec-preflight-*")), [])
 
     def test_stale_tracking_base_passes_until_a_real_fetch_refreshes_it(self):
         remote = Path(self.temporary.name) / "remote.git"
@@ -2156,6 +2162,241 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
             self.repo = original_repo
         self.assertNotEqual(refreshed.returncode, 0)
         self.assertIn("base advanced", refreshed.stderr)
+
+
+class TicketOpenSpecRealSemanticTests(unittest.TestCase):
+    BASELINE = """# Widget
+
+## Purpose
+
+Define the manufactured widget behavior.
+
+## Requirements
+
+### Requirement: Existing behavior
+
+The widget MUST preserve its existing behavior.
+
+#### Scenario: Existing behavior is requested
+
+- **WHEN** a caller requests existing behavior
+- **THEN** the widget preserves it
+
+### Requirement: Stable behavior
+
+The widget MUST preserve its stable behavior.
+
+#### Scenario: Stable behavior is requested
+
+- **WHEN** a caller requests stable behavior
+- **THEN** the widget preserves it
+"""
+    ISSUE_259_DELTA = """## MODIFIED Requirements
+
+### Requirement: Renamed behavior
+
+The widget MUST preserve its renamed behavior.
+
+#### Scenario: Renamed behavior is requested
+
+- **WHEN** a caller requests renamed behavior
+- **THEN** the widget preserves it
+"""
+    APPLICABLE_DELTAS = {
+        "added": """## ADDED Requirements
+
+### Requirement: Added behavior
+
+The widget MUST provide added behavior.
+
+#### Scenario: Added behavior is requested
+
+- **WHEN** a caller requests added behavior
+- **THEN** the widget provides it
+""",
+        "modified": """## MODIFIED Requirements
+
+### Requirement: Existing behavior
+
+The widget MUST preserve its updated existing behavior.
+
+#### Scenario: Existing behavior is requested
+
+- **WHEN** a caller requests updated existing behavior
+- **THEN** the widget preserves the updated behavior
+""",
+        "removed": """## REMOVED Requirements
+
+### Requirement: Existing behavior
+
+**Reason**: The manufactured behavior is no longer required.
+""",
+        "renamed": """## MODIFIED Requirements
+
+### Requirement: Renamed behavior
+
+The widget MUST preserve its renamed behavior.
+
+#### Scenario: Existing behavior is requested
+
+- **WHEN** a caller requests renamed behavior
+- **THEN** the widget preserves it
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Existing behavior`
+- TO: `### Requirement: Renamed behavior`
+""",
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        executable = shutil.which("openspec")
+        if executable is None:
+            raise AssertionError("real installed OpenSpec executable is required")
+        cls.openspec = Path(executable)
+        version = subprocess.run(
+            [str(cls.openspec), "--version"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if version.returncode or version.stdout.strip() != "1.11.0":
+            raise AssertionError(
+                f"OpenSpec 1.11.0 is required, got {version.stdout.strip()!r}: {version.stderr}"
+            )
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.preflight_tmp = self.root / "preflight-tmp"
+        self.preflight_tmp.mkdir()
+        self.environment = os.environ.copy()
+        self.environment["PATH"] = (
+            f"{self.openspec.parent}{os.pathsep}{self.environment['PATH']}"
+        )
+        self.environment["TMPDIR"] = str(self.preflight_tmp)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def make_repo(self, change: str, delta: str) -> tuple[Path, str]:
+        repo = self.root / change
+        repo.mkdir()
+        for command in (
+            ["git", "init", "-b", "main"],
+            ["git", "config", "user.email", "ticket@example.test"],
+            ["git", "config", "user.name", "Ticket test"],
+        ):
+            subprocess.run(command, cwd=repo, check=True, stdout=subprocess.DEVNULL)
+        (repo / "openspec/specs/widget").mkdir(parents=True)
+        (repo / "openspec/config.yaml").write_text("schema: spec-driven\n", encoding="utf-8")
+        (repo / "openspec/specs/widget/spec.md").write_text(
+            self.BASELINE, encoding="utf-8"
+        )
+        subprocess.run(["git", "add", "openspec"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"],
+            cwd=repo,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        base = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        change_root = repo / "openspec/changes" / change
+        (change_root / "specs/widget").mkdir(parents=True)
+        (change_root / "proposal.md").write_text(
+            f"# {change}\n\n## Why\n\nManufactured semantic regression.\n\n"
+            "## What Changes\n\n- Exercise real OpenSpec composition.\n",
+            encoding="utf-8",
+        )
+        (change_root / "tasks.md").write_text(
+            "## 1. Verification\n\n- [ ] Exercise the manufactured delta.\n",
+            encoding="utf-8",
+        )
+        (change_root / "specs/widget/spec.md").write_text(delta, encoding="utf-8")
+        subprocess.run(["git", "add", "openspec"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", change],
+            cwd=repo,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        return repo, base
+
+    def validate(self, repo: Path, change: str):
+        return run(
+            [str(self.openspec), "validate", change, "--strict"],
+            cwd=repo,
+            env=self.environment,
+        )
+
+    def preflight(self, repo: Path, base: str):
+        result = run(
+            [
+                sys.executable,
+                str(TICKET_SCRIPT),
+                "preflight-openspec",
+                "--repo",
+                str(repo),
+                "--base-ref",
+                base,
+            ],
+            cwd=repo,
+            env=self.environment,
+        )
+        self.assertEqual(list(self.preflight_tmp.glob("ticket-openspec-preflight-*")), [])
+        return result
+
+    def test_real_issue_259_delta_validates_strictly_but_fails_archive_applicability(self):
+        change = "issue-259"
+        repo, base = self.make_repo(change, self.ISSUE_259_DELTA)
+        ticket_before = directory_digest(repo / "openspec")
+        base_before = git_directory_digest(repo, base, "openspec")
+
+        validated = self.validate(repo, change)
+        result = self.preflight(repo, base)
+
+        self.assertEqual(validated.returncode, 0, validated.stderr)
+        self.assertEqual(validated.stdout, "Change 'issue-259' is valid\n")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(
+            result.stderr,
+            "ticket: widget MODIFIED failed for header \"### Requirement: Renamed behavior\" - not found\n"
+            "ticket: if this requirement was renamed, add a `## RENAMED Requirements` "
+            "mapping from its current baseline header to the unmatched delta header; "
+            "otherwise correct the MODIFIED header.\n",
+        )
+        self.assertEqual(ticket_before, directory_digest(repo / "openspec"))
+        self.assertEqual(base_before, git_directory_digest(repo, base, "openspec"))
+
+    def test_real_added_modified_removed_and_renamed_deltas_apply_cleanly(self):
+        for operation, delta in self.APPLICABLE_DELTAS.items():
+            with self.subTest(operation=operation):
+                repo, base = self.make_repo(operation, delta)
+                ticket_before = directory_digest(repo / "openspec")
+                base_before = git_directory_digest(repo, base, "openspec")
+
+                validated = self.validate(repo, operation)
+                result = self.preflight(repo, base)
+
+                self.assertEqual(validated.returncode, 0, validated.stderr)
+                self.assertEqual(validated.stdout, f"Change '{operation}' is valid\n")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stderr, "")
+                self.assertEqual(
+                    result.stdout,
+                    f"ticket: OpenSpec change {operation} applies cleanly in a disposable copy\n",
+                )
+                self.assertEqual(ticket_before, directory_digest(repo / "openspec"))
+                self.assertEqual(base_before, git_directory_digest(repo, base, "openspec"))
 
 
 class TicketLiveProseContractTests(unittest.TestCase):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1859,7 +1859,159 @@ class TicketTelemetryTests(unittest.TestCase):
         self.assertEqual(payload["unattributable"], [])
 
 
+class TicketOpenSpecPreflightTests(unittest.TestCase):
+    """Exercise the shipped command against disposable Git and OpenSpec inputs."""
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name) / "ticket"
+        self.repo.mkdir()
+        for command in (
+            ["git", "init", "-b", "main"],
+            ["git", "config", "user.email", "ticket@example.test"],
+            ["git", "config", "user.name", "Ticket test"],
+        ):
+            subprocess.run(command, cwd=self.repo, check=True, stdout=subprocess.DEVNULL)
+        (self.repo / "openspec/specs/widget").mkdir(parents=True)
+        (self.repo / "openspec/specs/widget/spec.md").write_text("# Widget\n", encoding="utf-8")
+        self.git("add", "openspec")
+        self.git("commit", "-m", "base")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        self.change("one")
+        self.git("add", "openspec")
+        self.git("commit", "-m", "change one")
+        self.bin = Path(self.temporary.name) / "bin"
+        self.bin.mkdir()
+        fake = self.bin / "openspec"
+        fake.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys\n"
+            "mode = os.environ.get('FAKE_OPENSPEC_MODE', 'ok')\n"
+            "if mode == 'launch': raise OSError('launch denied')\n"
+            "if mode == 'nonjson': print('not json')\n"
+            "elif mode == 'array': print('[]')\n"
+            "elif mode == 'missing': print(json.dumps({'status': []}))\n"
+            "elif mode == 'badstatus': print(json.dumps({'status': [1], 'archive': {}}))\n"
+            "elif mode == 'error': print(json.dumps({'status': [{'severity': 'error', 'message': 'archive failed'}], 'archive': {}}))\n"
+            "elif mode == 'rename': print(json.dumps({'status': [{'severity': 'error', 'code': 'archive_spec_update_failed', 'message': 'unmatched requirement'}], 'archive': {}}))\n"
+            "else: print(json.dumps({'status': [], 'archive': {}}))\n"
+            "sys.exit(7 if mode == 'nonzero' else 0)\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        self.environment = os.environ.copy()
+        self.environment["PATH"] = f"{self.bin}{os.pathsep}{self.environment['PATH']}"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def git(self, *arguments: str):
+        return run(["git", *arguments], cwd=self.repo)
+
+    def change(self, name: str):
+        directory = self.repo / "openspec/changes" / name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "proposal.md").write_text("# Change\n", encoding="utf-8")
+
+    def preflight(self, base: str | None = None, mode: str = "ok"):
+        environment = self.environment.copy()
+        environment["FAKE_OPENSPEC_MODE"] = mode
+        base_argument = f"--base-ref={base}" if (base or "").startswith("-") else "--base-ref"
+        return run(
+            ["python3", str(TICKET_SCRIPT), "preflight-openspec", "--repo", str(self.repo),
+             base_argument, *( [base] if base_argument == "--base-ref" else [])] if base else
+            ["python3", str(TICKET_SCRIPT), "preflight-openspec", "--repo", str(self.repo),
+             "--base-ref", self.base],
+            cwd=self.repo,
+            env=environment,
+        )
+
+    def tree(self, revision: str = "HEAD") -> str:
+        return self.git("rev-parse", f"{revision}:openspec").stdout.strip()
+
+    def test_success_resolves_local_non_main_base_and_keeps_both_trees_unchanged(self):
+        self.git("branch", "release-base", self.base)
+        ticket_tree, base_tree = self.tree(), self.tree("release-base")
+        result = self.preflight("release-base")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("OpenSpec change one applies cleanly", result.stdout)
+        self.assertEqual((ticket_tree, base_tree), (self.tree(), self.tree("release-base")))
+        self.assertEqual(self.git("status", "--short").stdout, "")
+
+    def test_unresolved_and_option_shaped_bases_do_not_invoke_a_remote(self):
+        for base in ("missing", "--not-a-ref", "HEAD^{tree}"):
+            with self.subTest(base=base):
+                result = self.preflight(base)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(f"base ref does not resolve to a local commit: {base}", result.stderr)
+
+    def test_discovery_handles_zero_deleted_and_multiple_active_changes(self):
+        active = self.repo / "openspec/changes/one"
+        (self.repo / "openspec/changes/archive").mkdir()
+        active.rename(self.repo / "openspec/changes/archive/one")
+        self.git("add", "-A")
+        self.git("commit", "-m", "archive change")
+        deleted = self.preflight()
+        self.assertEqual(deleted.returncode, 0)
+        self.assertIn("no changed active OpenSpec change", deleted.stdout)
+        self.change("two")
+        self.git("add", "openspec")
+        self.git("commit", "-m", "change two")
+        self.change("three")
+        self.git("add", "openspec")
+        self.git("commit", "-m", "change three")
+        multiple = self.preflight()
+        self.assertEqual(multiple.returncode, 2)
+        self.assertIn("more than one changed active OpenSpec change: three, two", multiple.stderr)
+
+    def test_archive_json_contract_and_rename_diagnostic_leave_authoritative_trees_intact(self):
+        for mode, diagnostic in (
+            ("nonjson", "OpenSpec archive returned invalid JSON"),
+            ("array", "OpenSpec archive JSON must be an object"),
+            ("missing", "OpenSpec archive result must be a non-null object"),
+            ("badstatus", "OpenSpec archive status must be a list of objects"),
+            ("error", "archive failed"),
+            ("nonzero", "OpenSpec archive exited with status 7"),
+            ("rename", "## RENAMED Requirements"),
+        ):
+            with self.subTest(mode=mode):
+                before = (self.tree(), self.tree(self.base))
+                result = self.preflight(mode=mode)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(diagnostic, result.stderr)
+                self.assertEqual(before, (self.tree(), self.tree(self.base)))
+                self.assertEqual(self.git("status", "--short").stdout, "")
+
+
 class TicketLiveProseContractTests(unittest.TestCase):
+    def test_openspec_preflight_callers_gate_only_ordinary_openspec_tickets_at_exit(self):
+        start = (TICKET_DIRECTORY / "verbs/start.md").read_text(encoding="utf-8")
+        coordinator = (TICKET_DIRECTORY / "references/coordinator-mode.md").read_text(
+            encoding="utf-8"
+        )
+        revise = (TICKET_DIRECTORY / "verbs/revise.md").read_text(encoding="utf-8")
+        finalize = (TICKET_DIRECTORY / "verbs/finalize.md").read_text(encoding="utf-8")
+
+        for contract, base_ref, boundary in (
+            (start, "refs/remotes/origin/HEAD", "gh pr create"),
+            (coordinator, "refs/remotes/origin/HEAD", "pull request"),
+            (revise, "origin/<baseRefName>", "Push and respond"),
+        ):
+            with self.subTest(base_ref=base_ref):
+                self.assertIn("ordinary OpenSpec-backed", contract)
+                self.assertIn("other or no change-record convention", contract)
+                self.assertIn("epic child", contract)
+                self.assertIn("git fetch origin", contract)
+                self.assertIn("preflight-openspec", contract)
+                self.assertIn(base_ref, contract)
+                self.assertLess(contract.rindex("git fetch origin"), contract.rindex("preflight-openspec"))
+                self.assertLess(contract.rindex("preflight-openspec"), contract.rindex(boundary))
+
+        for contract in (start, coordinator, revise):
+            self.assertIn("fetch, ref, or preflight failure stops", contract.lower())
+        self.assertIn("finalization", finalize)
+        self.assertIn("openspec archive", finalize)
+
     def test_triage_selected_ticket_mutation_boundary_admits_lifecycle_state_and_reauthorizes_external_work(self):
         shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
         triage = (TICKET_DIRECTORY / "verbs/triage.md").read_text(encoding="utf-8")

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -1864,6 +1865,8 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
 
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
+        self.preflight_tmp = Path(self.temporary.name) / "preflight-tmp"
+        self.preflight_tmp.mkdir()
         self.repo = Path(self.temporary.name) / "ticket"
         self.repo.mkdir()
         for command in (
@@ -1890,10 +1893,14 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
             "if mode == 'launch': raise OSError('launch denied')\n"
             "if mode == 'nonjson': print('not json')\n"
             "elif mode == 'array': print('[]')\n"
+            "elif mode == 'nostatus': print(json.dumps({'archive': {}}))\n"
             "elif mode == 'missing': print(json.dumps({'status': []}))\n"
+            "elif mode == 'nullarchive': print(json.dumps({'status': [], 'archive': None}))\n"
+            "elif mode == 'badarchive': print(json.dumps({'status': [], 'archive': 'wrong'}))\n"
             "elif mode == 'badstatus': print(json.dumps({'status': [1], 'archive': {}}))\n"
             "elif mode == 'error': print(json.dumps({'status': [{'severity': 'error', 'message': 'archive failed'}], 'archive': {}}))\n"
             "elif mode == 'rename': print(json.dumps({'status': [{'severity': 'error', 'code': 'archive_spec_update_failed', 'message': 'unmatched requirement'}], 'archive': {}}))\n"
+            "elif mode == 'base-sensitive' and 'new baseline' in open('openspec/specs/widget/spec.md').read(): print(json.dumps({'status': [{'severity': 'error', 'message': 'base advanced'}], 'archive': {}}))\n"
             "else: print(json.dumps({'status': [], 'archive': {}}))\n"
             "sys.exit(7 if mode == 'nonzero' else 0)\n",
             encoding="utf-8",
@@ -1901,6 +1908,7 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         fake.chmod(0o755)
         self.environment = os.environ.copy()
         self.environment["PATH"] = f"{self.bin}{os.pathsep}{self.environment['PATH']}"
+        self.environment["TMPDIR"] = str(self.preflight_tmp)
 
     def tearDown(self):
         self.temporary.cleanup()
@@ -1917,14 +1925,16 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         environment = self.environment.copy()
         environment["FAKE_OPENSPEC_MODE"] = mode
         base_argument = f"--base-ref={base}" if (base or "").startswith("-") else "--base-ref"
-        return run(
-            ["python3", str(TICKET_SCRIPT), "preflight-openspec", "--repo", str(self.repo),
+        result = run(
+            [sys.executable, str(TICKET_SCRIPT), "preflight-openspec", "--repo", str(self.repo),
              base_argument, *( [base] if base_argument == "--base-ref" else [])] if base else
-            ["python3", str(TICKET_SCRIPT), "preflight-openspec", "--repo", str(self.repo),
+            [sys.executable, str(TICKET_SCRIPT), "preflight-openspec", "--repo", str(self.repo),
              "--base-ref", self.base],
             cwd=self.repo,
             env=environment,
         )
+        self.assertEqual(list(self.preflight_tmp.glob("ticket-openspec-preflight-*")), [])
+        return result
 
     def tree(self, revision: str = "HEAD") -> str:
         return self.git("rev-parse", f"{revision}:openspec").stdout.strip()
@@ -1939,11 +1949,24 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         self.assertEqual(self.git("status", "--short").stdout, "")
 
     def test_unresolved_and_option_shaped_bases_do_not_invoke_a_remote(self):
+        calls = Path(self.temporary.name) / "git-calls"
+        real_git = subprocess.run(["git", "--exec-path"], text=True, capture_output=True).returncode
+        self.assertEqual(real_git, 0)
+        wrapper = self.bin / "git"
+        wrapper.write_text(
+            "#!/bin/sh\n"
+            f"printf '%s\\n' \"$*\" >> {calls}\n"
+            "exec /usr/bin/git \"$@\"\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
         for base in ("missing", "--not-a-ref", "HEAD^{tree}"):
             with self.subTest(base=base):
                 result = self.preflight(base)
                 self.assertEqual(result.returncode, 2)
                 self.assertIn(f"base ref does not resolve to a local commit: {base}", result.stderr)
+        recorded = calls.read_text(encoding="utf-8")
+        self.assertNotRegex(recorded, r"(?:fetch|pull|push|ls-remote|remote)")
 
     def test_discovery_handles_zero_deleted_and_multiple_active_changes(self):
         active = self.repo / "openspec/changes/one"
@@ -1968,7 +1991,10 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         for mode, diagnostic in (
             ("nonjson", "OpenSpec archive returned invalid JSON"),
             ("array", "OpenSpec archive JSON must be an object"),
+            ("nostatus", None),
             ("missing", "OpenSpec archive result must be a non-null object"),
+            ("nullarchive", "OpenSpec archive result must be a non-null object"),
+            ("badarchive", "OpenSpec archive result must be a non-null object"),
             ("badstatus", "OpenSpec archive status must be a list of objects"),
             ("error", "archive failed"),
             ("nonzero", "OpenSpec archive exited with status 7"),
@@ -1977,10 +2003,82 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
             with self.subTest(mode=mode):
                 before = (self.tree(), self.tree(self.base))
                 result = self.preflight(mode=mode)
-                self.assertNotEqual(result.returncode, 0)
-                self.assertIn(diagnostic, result.stderr)
+                if diagnostic is None:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(diagnostic, result.stderr)
                 self.assertEqual(before, (self.tree(), self.tree(self.base)))
                 self.assertEqual(self.git("status", "--short").stdout, "")
+
+    def test_launch_export_and_symlink_failures_are_clean_and_disposable(self):
+        fake = self.bin / "openspec"
+        fake.rename(self.bin / "openspec.saved")
+        fake.mkdir()
+        (self.bin / "git").symlink_to("/usr/bin/git")
+        self.environment["PATH"] = str(self.bin)
+        launch = self.preflight()
+        self.assertNotEqual(launch.returncode, 0)
+        self.assertIn("could not launch OpenSpec archive", launch.stderr)
+        self.assertNotIn("Traceback", launch.stderr)
+
+        fake.rmdir()
+        (self.bin / "openspec.saved").rename(fake)
+        (self.bin / "git").unlink()
+        self.environment["PATH"] = f"{self.bin}{os.pathsep}{os.environ['PATH']}"
+        wrapper = self.bin / "git"
+        wrapper.write_text(
+            "#!/bin/sh\n"
+            "if [ \"$1\" = archive ]; then exit 9; fi\n"
+            "exec /usr/bin/git \"$@\"\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+        exported = self.preflight()
+        self.assertNotEqual(exported.returncode, 0)
+        self.assertIn("could not export the base OpenSpec tree", exported.stderr)
+        self.assertNotIn("Traceback", exported.stderr)
+
+        wrapper.unlink()
+        link = self.repo / "openspec/changes/one/link"
+        link.symlink_to("proposal.md")
+        linked = self.preflight()
+        self.assertEqual(linked.returncode, 2)
+        self.assertIn("active OpenSpec change contains a symlink", linked.stderr)
+        self.assertNotIn("Traceback", linked.stderr)
+
+    def test_stale_tracking_base_passes_until_a_real_fetch_refreshes_it(self):
+        remote = Path(self.temporary.name) / "remote.git"
+        upstream = Path(self.temporary.name) / "upstream"
+        subprocess.run(["git", "init", "--bare", str(remote)], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "clone", str(self.repo), str(upstream)], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(upstream), "remote", "set-url", "origin", str(remote)], check=True)
+        subprocess.run(["git", "-C", str(upstream), "push", "-u", "origin", "main"], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main"], check=True)
+        ticket = Path(self.temporary.name) / "ticket-clone"
+        subprocess.run(["git", "clone", str(remote), str(ticket)], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(ticket), "config", "user.email", "ticket@example.test"], check=True)
+        subprocess.run(["git", "-C", str(ticket), "config", "user.name", "Ticket test"], check=True)
+        change = ticket / "openspec/changes/gate"
+        change.mkdir(parents=True)
+        (change / "proposal.md").write_text("# Gate\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(ticket), "add", "openspec"], check=True)
+        subprocess.run(["git", "-C", str(ticket), "commit", "-m", "gate"], check=True, stdout=subprocess.DEVNULL)
+        (upstream / "openspec/specs/widget/spec.md").write_text("# Widget\nnew baseline\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(upstream), "add", "openspec"], check=True)
+        subprocess.run(["git", "-C", str(upstream), "commit", "-m", "advance"], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(upstream), "push"], check=True, stdout=subprocess.DEVNULL)
+        original_repo = self.repo
+        self.repo = ticket
+        try:
+            stale = self.preflight("origin/main", "base-sensitive")
+            self.assertEqual(stale.returncode, 0, stale.stderr)
+            subprocess.run(["git", "-C", str(ticket), "fetch", "origin"], check=True, stdout=subprocess.DEVNULL)
+            refreshed = self.preflight("origin/main", "base-sensitive")
+        finally:
+            self.repo = original_repo
+        self.assertNotEqual(refreshed.returncode, 0)
+        self.assertIn("base advanced", refreshed.stderr)
 
 
 class TicketLiveProseContractTests(unittest.TestCase):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1927,6 +1927,8 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
             "mode = os.environ.get('FAKE_OPENSPEC_MODE', 'ok')\n"
             "if mode == 'launch': raise OSError('launch denied')\n"
             "if mode == 'nonjson': print('not json')\n"
+            "elif mode == 'nonjson-stderr': print('not json'); "
+            "print('archive parser failed\\ninspect change delta', file=sys.stderr)\n"
             "elif mode == 'array': print('[]')\n"
             "elif mode == 'nostatus': print(json.dumps({'archive': {}}))\n"
             "elif mode == 'missing': print(json.dumps({'status': []}))\n"
@@ -1973,6 +1975,17 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
 
     def tree(self, revision: str = "HEAD") -> str:
         return self.git("rev-parse", f"{revision}:openspec").stdout.strip()
+
+    def install_command_recorders(self, calls: Path):
+        for name, executable in (("git", "/usr/bin/git"), ("openspec", None)):
+            wrapper = self.bin / name
+            wrapper.write_text(
+                "#!/bin/sh\n"
+                f"printf '%s\\n' \"{name} $*\" >> {calls}\n"
+                + (f'exec {executable} "$@"\n' if executable else "exit 0\n"),
+                encoding="utf-8",
+            )
+            wrapper.chmod(0o755)
 
     def test_success_resolves_local_non_main_base_and_keeps_both_trees_unchanged(self):
         self.git("branch", "release-base", self.base)
@@ -2052,6 +2065,19 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
                 self.assertEqual(before, (self.tree(), self.tree(self.base)))
                 self.assertEqual(self.git("status", "--short").stdout, "")
 
+    def test_malformed_archive_stdout_preserves_stderr_in_one_diagnostic(self):
+        result = self.preflight(mode="nonjson-stderr")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(
+            result.stderr,
+            "ticket: OpenSpec archive returned invalid JSON: "
+            "archive parser failed\\ninspect change delta\n",
+        )
+        self.assertEqual(result.stderr.count("ticket:"), 1)
+        self.assertNotIn("Traceback", result.stderr)
+
     def test_launch_export_and_symlink_failures_are_clean_and_disposable(self):
         fake = self.bin / "openspec"
         fake.rename(self.bin / "openspec.saved")
@@ -2087,6 +2113,75 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         self.assertEqual(linked.returncode, 2)
         self.assertIn("active OpenSpec change contains a symlink", linked.stderr)
         self.assertNotIn("Traceback", linked.stderr)
+
+    def test_symlinked_openspec_root_is_rejected_before_external_reads_or_commands(self):
+        external = Path(self.temporary.name) / "external-openspec"
+        shutil.copytree(self.repo / "openspec", external)
+        external_before = directory_digest(external)
+        base_before = git_directory_digest(self.repo, self.base, "openspec")
+        shutil.rmtree(self.repo / "openspec")
+        (self.repo / "openspec").symlink_to(external, target_is_directory=True)
+
+        calls = Path(self.temporary.name) / "external-calls"
+        self.install_command_recorders(calls)
+
+        result = self.preflight()
+
+        self.assertEqual(
+            result.returncode,
+            2,
+            result.stdout
+            + result.stderr
+            + (calls.read_text(encoding="utf-8") if calls.exists() else ""),
+        )
+        self.assertEqual(
+            result.stderr,
+            f"ticket: OpenSpec root must not be a symlink: {self.repo.resolve() / 'openspec'}\n",
+        )
+        self.assertEqual(result.stdout, "")
+        self.assertNotIn("Traceback", result.stderr)
+        self.assertFalse(calls.exists())
+        self.assertEqual(external_before, directory_digest(external))
+        self.assertEqual(
+            base_before, git_directory_digest(self.repo, self.base, "openspec")
+        )
+
+    def test_symlinked_active_change_is_rejected_before_export_or_archive(self):
+        active = self.repo / "openspec/changes/one"
+        external = Path(self.temporary.name) / "external-change"
+        shutil.copytree(active, external)
+        external_before = directory_digest(external)
+        base_before = git_directory_digest(self.repo, self.base, "openspec")
+        shutil.rmtree(active)
+        active.symlink_to(external, target_is_directory=True)
+        self.git("add", "-A")
+        self.git("commit", "-m", "replace active change with symlink")
+
+        calls = Path(self.temporary.name) / "external-calls"
+        self.install_command_recorders(calls)
+
+        result = self.preflight()
+
+        self.assertEqual(
+            result.returncode,
+            2,
+            result.stdout
+            + result.stderr
+            + (calls.read_text(encoding="utf-8") if calls.exists() else ""),
+        )
+        self.assertEqual(
+            result.stderr,
+            "ticket: active OpenSpec change contains a symlink\n",
+        )
+        self.assertEqual(result.stdout, "")
+        self.assertNotIn("Traceback", result.stderr)
+        recorded = calls.read_text(encoding="utf-8")
+        self.assertNotIn("git archive ", recorded)
+        self.assertNotIn("openspec ", recorded)
+        self.assertEqual(external_before, directory_digest(external))
+        self.assertEqual(
+            base_before, git_directory_digest(self.repo, self.base, "openspec")
+        )
 
     def test_overlay_failure_is_diagnostic_and_cleans_the_disposable_tree(self):
         wrapper = self.bin / "git"

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Optional
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -2278,6 +2279,8 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         subprocess.run(["git", "init", "--bare", str(remote)], check=True, stdout=subprocess.DEVNULL)
         subprocess.run(["git", "clone", str(self.repo), str(upstream)], check=True, stdout=subprocess.DEVNULL)
         subprocess.run(["git", "-C", str(upstream), "remote", "set-url", "origin", str(remote)], check=True)
+        subprocess.run(["git", "-C", str(upstream), "config", "user.email", "ticket@example.test"], check=True)
+        subprocess.run(["git", "-C", str(upstream), "config", "user.name", "Ticket test"], check=True)
         subprocess.run(["git", "-C", str(upstream), "push", "-u", "origin", "main"], check=True, stdout=subprocess.DEVNULL)
         subprocess.run(["git", "--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main"], check=True)
         ticket = Path(self.temporary.name) / "ticket-clone"
@@ -2291,7 +2294,15 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         subprocess.run(["git", "-C", str(ticket), "commit", "-m", "gate"], check=True, stdout=subprocess.DEVNULL)
         (upstream / "openspec/specs/widget/spec.md").write_text("# Widget\nnew baseline\n", encoding="utf-8")
         subprocess.run(["git", "-C", str(upstream), "add", "openspec"], check=True)
-        subprocess.run(["git", "-C", str(upstream), "commit", "-m", "advance"], check=True, stdout=subprocess.DEVNULL)
+        identity_environment = os.environ.copy()
+        identity_environment["GIT_CONFIG_GLOBAL"] = os.devnull
+        identity_environment["GIT_CONFIG_NOSYSTEM"] = "1"
+        subprocess.run(
+            ["git", "-C", str(upstream), "commit", "-m", "advance"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            env=identity_environment,
+        )
         subprocess.run(["git", "-C", str(upstream), "push"], check=True, stdout=subprocess.DEVNULL)
         original_repo = self.repo
         self.repo = ticket
@@ -2395,7 +2406,7 @@ The widget MUST preserve its renamed behavior.
     def setUpClass(cls):
         executable = shutil.which("openspec")
         if executable is None:
-            raise AssertionError("real installed OpenSpec executable is required")
+            raise unittest.SkipTest("real installed OpenSpec executable is required")
         cls.openspec = Path(executable)
         version = subprocess.run(
             [str(cls.openspec), "--version"],
@@ -2539,6 +2550,33 @@ The widget MUST preserve its renamed behavior.
                 )
                 self.assertEqual(ticket_before, directory_digest(repo / "openspec"))
                 self.assertEqual(base_before, git_directory_digest(repo, base, "openspec"))
+
+
+class TicketOpenSpecRealSemanticSetupTests(unittest.TestCase):
+    def test_missing_openspec_skips_real_semantic_tests(self):
+        with mock.patch.object(shutil, "which", return_value=None):
+            with self.assertRaisesRegex(
+                unittest.SkipTest, "real installed OpenSpec executable is required"
+            ):
+                TicketOpenSpecRealSemanticTests.setUpClass()
+
+    def test_wrong_or_failing_openspec_version_remains_a_hard_failure(self):
+        versions = (
+            subprocess.CompletedProcess(
+                ["openspec", "--version"], 0, stdout="1.10.0\n", stderr=""
+            ),
+            subprocess.CompletedProcess(
+                ["openspec", "--version"], 7, stdout="", stderr="version failed\n"
+            ),
+        )
+        for version in versions:
+            with self.subTest(returncode=version.returncode, stdout=version.stdout):
+                with mock.patch.object(shutil, "which", return_value="/tmp/openspec"):
+                    with mock.patch.object(subprocess, "run", return_value=version):
+                        with self.assertRaisesRegex(
+                            AssertionError, "OpenSpec 1.11.0 is required"
+                        ):
+                            TicketOpenSpecRealSemanticTests.setUpClass()
 
 
 class TicketLiveProseContractTests(unittest.TestCase):

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1996,6 +1996,51 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         self.assertEqual((ticket_tree, base_tree), (self.tree(), self.tree("release-base")))
         self.assertEqual(self.git("status", "--short").stdout, "")
 
+    def test_filter_capable_tar_api_keeps_public_stderr_clean(self):
+        hooks = Path(self.temporary.name) / "filter-capable-tar"
+        hooks.mkdir()
+        (hooks / "sitecustomize.py").write_text(
+            "import tarfile, warnings\n"
+            "original_extract = tarfile.TarFile.extract\n"
+            "missing = object()\n"
+            "def extract(self, member, path='', set_attrs=True, *, "
+            "numeric_owner=False, filter=missing):\n"
+            "    if filter is missing:\n"
+            "        warnings.warn('default extraction filter used', DeprecationWarning)\n"
+            "    return original_extract(self, member, path, set_attrs, "
+            "numeric_owner=numeric_owner)\n"
+            "tarfile.TarFile.extract = extract\n",
+            encoding="utf-8",
+        )
+        self.environment["PYTHONPATH"] = str(hooks)
+        self.environment["PYTHONWARNINGS"] = "error::DeprecationWarning"
+
+        result = self.preflight()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+
+    def test_legacy_tar_api_keeps_public_stderr_clean(self):
+        hooks = Path(self.temporary.name) / "legacy-tar"
+        hooks.mkdir()
+        (hooks / "sitecustomize.py").write_text(
+            "import inspect, tarfile\n"
+            "original_extract = tarfile.TarFile.extract\n"
+            "options = ({'filter': 'data'} if "
+            "'filter' in inspect.signature(original_extract).parameters else {})\n"
+            "def extract(self, member, path='', set_attrs=True, *, numeric_owner=False):\n"
+            "    return original_extract(self, member, path, set_attrs, "
+            "numeric_owner=numeric_owner, **options)\n"
+            "tarfile.TarFile.extract = extract\n",
+            encoding="utf-8",
+        )
+        self.environment["PYTHONPATH"] = str(hooks)
+
+        result = self.preflight()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+
     def test_unresolved_and_option_shaped_bases_do_not_invoke_a_remote(self):
         calls = Path(self.temporary.name) / "git-calls"
         real_git = subprocess.run(["git", "--exec-path"], text=True, capture_output=True).returncode

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1890,6 +1890,7 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
             "#!/usr/bin/env python3\n"
             "import json, os, sys\n"
             "mode = os.environ.get('FAKE_OPENSPEC_MODE', 'ok')\n"
+            "if len(sys.argv) > 1 and sys.argv[1] == 'validate': print(json.dumps({'valid': True})); sys.exit(0)\n"
             "if mode == 'launch': raise OSError('launch denied')\n"
             "if mode == 'nonjson': print('not json')\n"
             "elif mode == 'array': print('[]')\n"
@@ -1987,18 +1988,61 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         self.assertEqual(multiple.returncode, 2)
         self.assertIn("more than one changed active OpenSpec change: three, two", multiple.stderr)
 
+    def test_discovery_selects_one_active_change_for_add_modify_remove_and_rename(self):
+        added = self.preflight()
+        self.assertEqual(added.returncode, 0, added.stderr)
+        self.assertEqual(
+            added.stdout,
+            "ticket: OpenSpec change one applies cleanly in a disposable copy\n",
+        )
+
+        proposal = self.repo / "openspec/changes/one/proposal.md"
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        proposal.write_text("# Changed\n", encoding="utf-8")
+        self.git("add", "openspec")
+        self.git("commit", "-m", "modify change")
+        modified = self.preflight()
+        self.assertEqual(modified.returncode, 0, modified.stderr)
+        self.assertIn("OpenSpec change one applies cleanly", modified.stdout)
+
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        proposal.unlink()
+        self.git("add", "-A")
+        self.git("commit", "-m", "remove change content")
+        removed = self.preflight()
+        self.assertEqual(removed.returncode, 0, removed.stderr)
+        self.assertIn("OpenSpec change one applies cleanly", removed.stdout)
+
+        before = self.repo / "openspec/changes/one/before.md"
+        before.write_text("# Before\n", encoding="utf-8")
+        self.git("add", "openspec")
+        self.git("commit", "-m", "restore change content")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        before.rename(before.with_name("after.md"))
+        self.git("add", "-A")
+        self.git("commit", "-m", "rename change content")
+        renamed = self.preflight()
+        self.assertEqual(renamed.returncode, 0, renamed.stderr)
+        self.assertIn("OpenSpec change one applies cleanly", renamed.stdout)
+
     def test_archive_json_contract_and_rename_diagnostic_leave_authoritative_trees_intact(self):
         for mode, diagnostic in (
-            ("nonjson", "OpenSpec archive returned invalid JSON"),
-            ("array", "OpenSpec archive JSON must be an object"),
+            ("nonjson", "ticket: OpenSpec archive returned invalid JSON\n"),
+            ("array", "ticket: OpenSpec archive JSON must be an object\n"),
             ("nostatus", None),
-            ("missing", "OpenSpec archive result must be a non-null object"),
-            ("nullarchive", "OpenSpec archive result must be a non-null object"),
-            ("badarchive", "OpenSpec archive result must be a non-null object"),
-            ("badstatus", "OpenSpec archive status must be a list of objects"),
-            ("error", "archive failed"),
-            ("nonzero", "OpenSpec archive exited with status 7"),
-            ("rename", "## RENAMED Requirements"),
+            ("missing", "ticket: OpenSpec archive result must be a non-null object\n"),
+            ("nullarchive", "ticket: OpenSpec archive result must be a non-null object\n"),
+            ("badarchive", "ticket: OpenSpec archive result must be a non-null object\n"),
+            ("badstatus", "ticket: OpenSpec archive status must be a list of objects\n"),
+            ("error", "ticket: archive failed\n"),
+            ("nonzero", "ticket: OpenSpec archive exited with status 7\n"),
+            (
+                "rename",
+                "ticket: unmatched requirement\n"
+                "ticket: if this requirement was renamed, add a `## RENAMED Requirements` "
+                "mapping from its current baseline header to the unmatched delta header; "
+                "otherwise correct the MODIFIED header.\n",
+            ),
         ):
             with self.subTest(mode=mode):
                 before = (self.tree(), self.tree(self.base))
@@ -2007,9 +2051,23 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
                     self.assertEqual(result.returncode, 0, result.stderr)
                 else:
                     self.assertNotEqual(result.returncode, 0)
-                    self.assertIn(diagnostic, result.stderr)
+                    self.assertEqual(result.stderr, diagnostic)
                 self.assertEqual(before, (self.tree(), self.tree(self.base)))
                 self.assertEqual(self.git("status", "--short").stdout, "")
+
+    def test_strict_validation_can_pass_while_issue_259_archive_composition_fails(self):
+        environment = self.environment.copy()
+        environment["FAKE_OPENSPEC_MODE"] = "rename"
+        validated = run(
+            ["openspec", "validate", "--all", "--strict", "--json"],
+            cwd=self.repo,
+            env=environment,
+        )
+        self.assertEqual(validated.returncode, 0, validated.stderr)
+
+        result = self.preflight(mode="rename")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("## RENAMED Requirements", result.stderr)
 
     def test_launch_export_and_symlink_failures_are_clean_and_disposable(self):
         fake = self.bin / "openspec"
@@ -2046,6 +2104,25 @@ class TicketOpenSpecPreflightTests(unittest.TestCase):
         self.assertEqual(linked.returncode, 2)
         self.assertIn("active OpenSpec change contains a symlink", linked.stderr)
         self.assertNotIn("Traceback", linked.stderr)
+
+    def test_overlay_failure_is_diagnostic_and_cleans_the_disposable_tree(self):
+        wrapper = self.bin / "git"
+        moved_change = Path(self.temporary.name) / "moved-change"
+        wrapper.write_text(
+            "#!/bin/sh\n"
+            "/usr/bin/git \"$@\"\n"
+            "status=$?\n"
+            f"if [ \"$1\" = archive ]; then mv {self.repo / 'openspec/changes/one'} {moved_change}; fi\n"
+            "exit $status\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+
+        result = self.preflight()
+
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stderr, "ticket: could not overlay the active OpenSpec change\n")
+        self.assertNotIn("Traceback", result.stderr)
 
     def test_stale_tracking_base_passes_until_a_real_fetch_refreshes_it(self):
         remote = Path(self.temporary.name) / "remote.git"
@@ -2090,25 +2167,46 @@ class TicketLiveProseContractTests(unittest.TestCase):
         revise = (TICKET_DIRECTORY / "verbs/revise.md").read_text(encoding="utf-8")
         finalize = (TICKET_DIRECTORY / "verbs/finalize.md").read_text(encoding="utf-8")
 
-        for contract, base_ref, boundary in (
-            (start, "refs/remotes/origin/HEAD", "gh pr create"),
-            (coordinator, "refs/remotes/origin/HEAD", "pull request"),
-            (revise, "origin/<baseRefName>", "Push and respond"),
+        start_gate = start.split("12. **Preflight the outbound OpenSpec change.**", 1)[1].split(
+            "13. **Open the pull request.**", 1
+        )[0]
+        coordinator_gate = coordinator.split(
+            "9. **Preflight the outbound OpenSpec change.**", 1
+        )[1]
+        revise_gate = revise.split("   **Preflight the outbound OpenSpec change.**", 1)[1].split(
+            "   After the gate succeeds, push", 1
+        )[0]
+
+        for gate, base_ref in (
+            (start_gate, "refs/remotes/origin/HEAD"),
+            (coordinator_gate, "refs/remotes/origin/HEAD"),
+            (revise_gate, "origin/<baseRefName>"),
         ):
             with self.subTest(base_ref=base_ref):
-                self.assertIn("ordinary OpenSpec-backed", contract)
-                self.assertIn("other or no change-record convention", contract)
-                self.assertIn("epic child", contract)
-                self.assertIn("git fetch origin", contract)
-                self.assertIn("preflight-openspec", contract)
-                self.assertIn(base_ref, contract)
-                self.assertLess(contract.rindex("git fetch origin"), contract.rindex("preflight-openspec"))
-                self.assertLess(contract.rindex("preflight-openspec"), contract.rindex(boundary))
+                normalized_gate = " ".join(gate.split())
+                self.assertIn("ordinary OpenSpec-backed", gate)
+                self.assertIn("other or no change-record convention", gate)
+                self.assertIn("epic child", gate)
+                self.assertEqual(gate.count("git fetch origin"), 1)
+                self.assertEqual(gate.count("preflight-openspec"), 1)
+                self.assertIn(base_ref, gate)
+                self.assertLess(gate.index("git fetch origin"), gate.index("preflight-openspec"))
+                self.assertIn("fetch, ref, or preflight failure stops", gate.lower())
+                self.assertIn("sole authoritative archive owner", normalized_gate.lower())
+                self.assertNotIn("openspec archive ", gate.lower())
 
-        for contract in (start, coordinator, revise):
-            self.assertIn("fetch, ref, or preflight failure stops", contract.lower())
-        self.assertIn("finalization", finalize)
-        self.assertIn("openspec archive", finalize)
+        self.assertIn("implementation, review, and all active-change fixes", start_gate)
+        self.assertIn("immediately before the command", start_gate)
+        self.assertIn("After all chunks merge, whole-diff review and fixes finish", coordinator_gate)
+        self.assertIn("the coordinator records the active change", coordinator_gate)
+        self.assertIn("immediately\n   before", coordinator_gate)
+        self.assertIn("After the rebase and every active-change, checklist, and\n   decision edit", revise_gate)
+        self.assertIn("again immediately before", revise_gate)
+        self.assertIn("earlier rebase fetch does not satisfy this final refresh", revise_gate)
+        self.assertIn("do not open the pull\n   request", start_gate)
+        self.assertIn("do not rejoin pull\n   request creation", coordinator_gate)
+        self.assertIn("do not push", revise_gate)
+        self.assertIn("openspec archive <change-name> --json --yes", finalize.lower())
 
     def test_triage_selected_ticket_mutation_boundary_admits_lifecycle_state_and_reauthorizes_external_work(self):
         shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What this is

Ordinary OpenSpec-backed ticket work now proves its one active change applies to the freshly fetched baseline before a pull request opens or a revised branch pushes. Previously, strict validation could pass a renamed requirement and leave the first applicability failure until post-merge finalization.

## What changed

* The public ticket command composes the current baseline with the ticket's active change in a disposable copy and accepts only a successful real archive result.
* Missing rename mappings stop with the unmatched requirement followed by rename-mapping or modified-header correction guidance. Malformed output, unsafe symlinks, export failures, and archive failures stop without changing either authoritative tree.
* Added, modified, removed, and correctly renamed requirements keep the existing lifecycle. Finalization remains the sole authoritative archive owner, and a baseline advance after this gate can still require manual correction.

The decision, risk contract, and applicability bounds remain with the active OpenSpec change.

Fixes #265

## Verification

* Structural validation: 28 skills and 440 files.
* Complete repository suite: 512 passed, 23 skipped.
* Strict OpenSpec validation: 4 passed, 0 failed.
* DCO audit: 31 commits passed. Final refreshed-baseline applicability preflight passed.
* GitHub Python 3.12 checks: documentation build passed in 54 seconds; Validate passed in 1 minute 47 seconds.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
