### PR TITLE
Codify the revision round method in ui-craft

### DIFF
--- a/openspec/changes/revision-round-method/.openspec.yaml
+++ b/openspec/changes/revision-round-method/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+skip_specs: true

--- a/openspec/changes/revision-round-method/design.md
+++ b/openspec/changes/revision-round-method/design.md
@@ -1,0 +1,35 @@
+# Design
+
+## ADR harmonic-219 — Revision rounds bind through ui-craft
+
+**Context.** The method was discovered in one repository's revision session, and
+it could have been recorded in that repository's agent brief. That brief is read
+by every agent working there, so the rules would bind immediately and could name
+the repository's own gates, surfaces and file paths concretely.
+
+But the failure the method prevents is not specific to that repository. It is the
+shape of shipped-surface revision itself: direction settled by iterating in a
+running app never converges, and a written record does not follow a behavior that
+moves unless something makes it. Any repository revising a shipped surface through
+`revise` meets both. Recording the method in one consuming repository leaves every
+other one to rediscover it, and a second repository learning the same lesson would
+produce a second, drifting copy.
+
+**Decision.** The method lives in `ui-craft` — extending `revise` and
+`behavior-sweep` rather than adding a skill or a reference page — and consuming
+repositories' agent briefs get nothing. Each addition lands in the section that
+already owns its neighboring rule, contributes only the residue that section does
+not already state, and cites the existing rule rather than restating it.
+Repository-specific names stay out of the skill text; the illustrating failures
+are described by their shape.
+
+**Consequences.** The rules bind wherever the pack is installed, and a consuming
+repository revising a surface inherits them without an edit of its own. The cost
+is generality: a repository whose gates, sandboxes or surfaces make one of these
+obligations concrete has to translate it, and the skill text cannot name the
+gate to run. That is the same trade every other rule in this pack makes.
+
+The round method binds interactive divergent work only. `revise`'s headless rule
+is unchanged and stands above it: a headless session goes straight to an app
+branch, never opens a wireframe phase, and returns an unsettleable direction as a
+decision instead of inventing one.

--- a/openspec/changes/revision-round-method/design.md
+++ b/openspec/changes/revision-round-method/design.md
@@ -33,3 +33,26 @@ The round method binds interactive divergent work only. `revise`'s headless rule
 is unchanged and stands above it: a headless session goes straight to an app
 branch, never opens a wireframe phase, and returns an unsettleable direction as a
 decision instead of inventing one.
+
+## ADR harmonic-219 — One page enumerates what a retirement owes
+
+**Context.** Adding the premise obligation to a retirement exposed how many pages
+already stated that contract. `revise`, `resettle` and `behavior-sweep` each
+carried their own enumeration of the change set, and `build` carried its status
+mapping. Two review rounds each surfaced one more copy than the round before:
+the first found `revise` stale, the second found `resettle` stale. Both were
+consistent with the others at the time they were written and went stale when a
+fifth obligation arrived, which is the failure mode of every restated list.
+
+**Decision.** `behavior-sweep` §5 enumerates what a retirement owes, once, and
+every other page names the case and points at that list instead of repeating it.
+`revise`'s Retired case and its before-landing check, and `resettle`'s post-lock
+`retired` change set, now defer. `build` keeps its own concern — how a replay
+result maps to a ledger status — because that is not the list.
+
+**Consequences.** A new obligation lands in one place and every path inherits it,
+which is what neither review round could rely on before. A reader of `revise` or
+`resettle` takes one hop to see the full set, which is the cost. The test pins
+the enumeration's home and asserts the sanction template appears on exactly one
+page, so a page that re-grows its own copy fails rather than drifting quietly;
+that guard was proven to fail before it was relied on.

--- a/openspec/changes/revision-round-method/proposal.md
+++ b/openspec/changes/revision-round-method/proposal.md
@@ -1,0 +1,56 @@
+# Codify the revision round method in ui-craft
+
+## Why
+
+A UI revision that iterates in the running app while direction is still unsettled
+does not converge. One attended revision session recovered by refusing the app,
+diverging on paper, and narrowing one question per round — and then hit a second
+class of failure once the surface actually moved: five gates red, none of them a
+defect in the shipped app, every one a written record that did not move with the
+behavior it described.
+
+`ui-craft` already licenses throwaway wireframes for divergent work, but says
+nothing about how the rounds are run, and its behavior ledger has no case for a
+behavior that changes which surface owns it. A retirement's guard asserts the
+absence it produced but not the premise it reasoned from, so a later change that
+kills the premise passes silently.
+
+## What changes
+
+- `revise` §3 gains a round-running subsection, scoped to interactive divergent
+  work and deferring to the existing headless rule: one narrowing question per
+  round with nothing ruled reopening, conceptually distinct options each carrying
+  a stated cost, measured rather than asserted claims, the operator's eye
+  outranking a metric that measures the wrong thing, and building only once the
+  direction is ruled.
+- `revise` §4's behavior cases gain **Moved** beside Preserved / Added / Changed /
+  Retired, with the same ceremony as a removal, plus the sweeps a move, a
+  duplication or a rename owes outside the ledger.
+- `revise` §5's before-landing checklist requires the story-replaying gates to
+  have actually run for a round that moved a surface, launched by whoever can
+  launch them.
+- `behavior-sweep` §4's retired guard asserts the retirement's premise as well as
+  the absence, and a failed premise is a QUESTION-round trigger rather than a
+  `replayed-fail`; §5's worked example and `build`'s RETIRED replay enumeration
+  follow.
+
+The method binds through the skill pack, so every consuming repository inherits
+it without an agent brief of its own. No mode, route, lock manifest, sanction
+contract or headless rule changes.
+
+## Risk contract
+
+- **Must prevent:** silently weakening an existing `ui-craft` rule — the behavior
+  ledger, the sanction line, the lock contract, or the headless restriction —
+  while merging the new material; naming a consuming repository's internals in
+  skill text.
+- **Must recover:** none. Documentation-only and revertible by pull request.
+- **Accepted failure:** the generalized wording misses a nuance of the session it
+  came from; a follow-up round fixes it.
+- **Unsupported:** binding workflows outside `ui-craft`; retroactive application
+  to revisions already landed; changing the sanction line's named-person
+  requirement.
+- **Evidence owed:** a `tests/test_behavior.py` pin on the new subsection and the
+  retired-premise rule across all three pages, proven to fail when the subsection
+  heading is removed; OpenSpec strict validation, the structural validator, and
+  the repository test command pass.

--- a/openspec/changes/revision-round-method/tasks.md
+++ b/openspec/changes/revision-round-method/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+- [x] Add the interactive-scoped round-running subsection to `revise` §3, citing
+      the existing wireframe constraints rather than restating them.
+- [x] Add the **Moved** behavior case and the selector, conditional-absence and
+      rename sweeps to `revise` §4, and the gate-launch clause to §5's
+      before-landing checklist.
+- [x] Make a retired story assert its premise in `behavior-sweep` §4, with the §5
+      worked example and `build`'s RETIRED replay enumeration consistent.
+- [x] Pin the new subsection and the retired-premise rule in
+      `tests/test_behavior.py`, and prove the pin fails without them.
+- [x] Run `scripts/validate.py`, `tests.test_behavior` and the rest of the
+      repository verification command from `AGENTS.md`, plus
+      `openspec validate --all --strict`.
+- [x] Open the pull request linking the originating issue.

--- a/openspec/changes/revision-round-method/tasks.md
+++ b/openspec/changes/revision-round-method/tasks.md
@@ -12,4 +12,6 @@
 - [x] Run `scripts/validate.py`, `tests.test_behavior` and the rest of the
       repository verification command from `AGENTS.md`, plus
       `openspec validate --all --strict`.
+- [x] Collapse the retirement enumeration to one page, with the other pages
+      naming the case and deferring, and pin that a page cannot re-grow its copy.
 - [x] Open the pull request linking the originating issue.

--- a/skills/drivers/ui-craft/reference/behavior-sweep.md
+++ b/skills/drivers/ui-craft/reference/behavior-sweep.md
@@ -340,6 +340,17 @@ Spec:
   ledger amendment that moves the entry back to STORY also deletes the absence
   assertion. On fallback, the `resettle` change set makes both changes. The
   assertion is never deleted on its own.
+- **A retired function asserts the premise the retirement reasoned from, not
+  only the absence.** Every ruling has a because — "the renderer is not visible
+  or focusable, so it cannot honestly claim a reader keyboard path" — and a
+  function that asserts the conclusion alone goes on passing after that because
+  stops being true. Record the premise on the ledger entry and assert it beside
+  the absence. When the premise fails while the behavior is still absent, the
+  story goes red as a **QUESTION-round trigger asking for a fresh ruling**; it is
+  not a `replayed-fail`, which stays reserved for the retired behavior being
+  present. A surface made visible again by a later change is exactly this case,
+  and it is silent without the premise: the absence assertion is still true, and
+  the reason it was allowed to be absent is gone.
 - **The script fails closed.** Missing browser dependencies (driver module,
   vendored assets, executable) exit nonzero — never `skip`. A skipped run exits 0,
   and a green step that executed zero stories is precisely the silent skip this
@@ -396,7 +407,8 @@ R3 · Dragging in the plot body drew a custom selection window; two handles
   verdict:  retired
   sanction: Connor · 2026-08-18 · "the presets cover every window I use; the
             drawn window goes."
-  replay:   fn R3 asserts absence and prints this sanction line
+  premise:  the preset window controls are present and cover the plot's range
+  replay:   fn R3 asserts absence and the premise, and prints this sanction line
   status:   retired (permanent)
 ```
 

--- a/skills/drivers/ui-craft/reference/behavior-sweep.md
+++ b/skills/drivers/ui-craft/reference/behavior-sweep.md
@@ -429,6 +429,22 @@ a waiver** — it is the record a waiver would have replaced. A §2 row still at
 `missed`, including one carrying `ruled-elsewhere`, is a QUESTION entry until
 the operator rules it.
 
+**What a retirement owes, in one place.** Every path that retires a behavior —
+`revise`'s ledger amendment, `resettle`'s post-lock ruling, a §2 `missed` row the
+operator rules — owes the same four things, and this page is the only one that
+enumerates them:
+
+1. the **sanction line** above, naming a person, dated, their reason quoted;
+2. a permanent **RETIRED entry** in this ledger;
+3. an **absence assertion** in the replay script that prints that sanction on
+   every run (§4); and
+4. the **premise** the ruling reasoned from, recorded on the entry and asserted
+   beside the absence (§4), so a dead premise asks for a fresh ruling.
+
+A page that routes a retirement here names the case and points at this list. It
+does not restate it: a list kept in three places is how a fourth obligation
+reaches only one of them.
+
 **Retired entries are permanent.** The ledger stops being a record of only what
 the surface does and becomes a record of what it does **and what it deliberately
 stopped doing**; the retired entries with their sanctions are the audit trail,

--- a/skills/drivers/ui-craft/reference/build.md
+++ b/skills/drivers/ui-craft/reference/build.md
@@ -160,7 +160,10 @@ mock opener exercises the mock and proves nothing about the port.
   the date that sanctioned the drop, so a retirement never becomes a silent green
   line. A RETIRED entry whose behavior is *present* in the build is a
   `replayed-fail`: the port restored something a human ruled gone, which is a
-  deviation in the same way dropping a locked term is.
+  deviation in the same way dropping a locked term is. A RETIRED entry whose
+  *premise* has failed while its behavior stays absent is `re-settle requested`,
+  never `replayed-fail` — the drop still holds but the reason for it does not, so
+  the operator rules again.
 - The script's fail-closed rule holds here: a green step that executed zero
   stories is a failure, so confirm the run **reported its applicable story
   count**, not merely that the step ran.

--- a/skills/drivers/ui-craft/reference/resettle.md
+++ b/skills/drivers/ui-craft/reference/resettle.md
@@ -36,12 +36,13 @@ The operator rules it, and the ruling lands as one of two change sets:
   block that it restores a predecessor behavior the lock omitted. The behavior
   ledger gains its STORY and the replay script its function, in the same set.
 - **retired** — no term moves. The sanction line is written into the behavior
-  ledger's RETIRED entry (§2's format), dated and quoted, and the entry's
-  absence assertion is added to the replay script. Where the merged lock already
-  spoke to the retirement, that citation rides along as the row's
-  `ruled-elsewhere` annotation and nothing more: it is what turns the ruling into
-  a one-sentence confirmation instead of a fresh decision, and it is never the
-  sanction itself.
+  ledger's RETIRED entry (§2's format), dated and quoted, with the premise the
+  ruling reasoned from recorded beside it, and the entry's absence assertion is
+  added to the replay script, asserting that premise as well as the absence.
+  Where the merged lock already spoke to the retirement, that citation rides
+  along as the row's `ruled-elsewhere` annotation and nothing more: it is what
+  turns the ruling into a one-sentence confirmation instead of a fresh decision,
+  and it is never the sanction itself.
 
 Either way it is dated and recorded, and the ledger keeps the trail.
 

--- a/skills/drivers/ui-craft/reference/resettle.md
+++ b/skills/drivers/ui-craft/reference/resettle.md
@@ -35,10 +35,9 @@ The operator rules it, and the ruling lands as one of two change sets:
   re-settle **adds** the term and says in the mock header's `RE-SETTLED TERM`
   block that it restores a predecessor behavior the lock omitted. The behavior
   ledger gains its STORY and the replay script its function, in the same set.
-- **retired** — no term moves. The sanction line is written into the behavior
-  ledger's RETIRED entry (§2's format), dated and quoted, with the premise the
-  ruling reasoned from recorded beside it, and the entry's absence assertion is
-  added to the replay script, asserting that premise as well as the absence.
+- **retired** — no term moves. The behavior ledger gains its RETIRED entry and
+  the replay script its absence assertion, to `behavior-sweep`'s enumeration of
+  what a retirement owes; this page adds nothing to that list.
   Where the merged lock already spoke to the retirement, that citation rides
   along as the row's `ruled-elsewhere` annotation and nothing more: it is what
   turns the ruling into a one-sentence confirmation instead of a fresh decision,

--- a/skills/drivers/ui-craft/reference/revise.md
+++ b/skills/drivers/ui-craft/reference/revise.md
@@ -147,8 +147,9 @@ settled:
   neither.
 - **Options differ in concept, not decoration** — five ways to site a control,
   not five colors of one control. Render every option live under the coverage
-  §1 already requires, and give each state its own specimen: a small tile at
-  rest is not evidence about a large one being held.
+  §1 already requires, plus the element sizes the option itself varies, and give
+  each state its own specimen: a small tile at rest is not evidence about a
+  large one being held.
 - **Every option carries a stated cost, the recommended one included.** An
   option offered as free is one whose cost has not been found yet, and it wins
   the round on an omission.
@@ -198,12 +199,16 @@ is failure, never skip.
   assertion that prints the sanction on every run. Record the premise the ruling
   reasoned from on the entry, so that assertion can assert it too
   (`behavior-sweep`).
-- **Moved:** a behavior that changed which surface owns it gets the same
-  ceremony as a removal. Name the fact, the surface it left, the surface it
-  landed on, and update every story that reads it in the same change. A move is
-  the case that looks like nothing happened: the app is right, the behavior is
-  intact, and the stories still reading the old surface were not wrong when they
-  were written and nobody was told they had become wrong.
+- **Moved:** a behavior that changed which surface owns it owes the same
+  ceremony as a removal, and lands as an amended STORY rather than a retirement
+  — the behavior still ships, so it keeps its entry and its replay, and no
+  sanction is owed. Name the fact, the surface it left, the surface it landed
+  on, and update every story that reads it in the same change, so the next
+  revision's inventory finds it where it now lives instead of reading its
+  absence from the old surface as an unsanctioned retirement. A move is the case
+  that looks like nothing happened: the app is right, the behavior is intact,
+  and the stories still reading the old surface were not wrong when they were
+  written and nobody was told they had become wrong.
 
 A dropped, changed or moved behavior without that record blocks the revision.
 There is no lock term to `resettle`; the ledger amendment is the decision

--- a/skills/drivers/ui-craft/reference/revise.md
+++ b/skills/drivers/ui-craft/reference/revise.md
@@ -194,11 +194,9 @@ is failure, never skip.
 - **Added:** add a STORY and replay function in the same change.
 - **Changed:** amend the STORY, record the dated decision under the frozen
   header, and prove the old replay fails before the new one passes.
-- **Retired:** require `sanction: <person> · <date> · "<their reason>"`, retain a
-  permanent RETIRED entry, and replace the positive replay with an absence
-  assertion that prints the sanction on every run. Record the premise the ruling
-  reasoned from on the entry, so that assertion can assert it too
-  (`behavior-sweep`).
+- **Retired:** the behavior owes what `behavior-sweep` requires of a retirement,
+  which that page enumerates in one place. Amend the ledger there, and carry the
+  entry back into this change with its replay function.
 - **Moved:** a behavior that changed which surface owns it owes the same
   ceremony as a removal, and lands as an amended STORY rather than a retirement
   — the behavior still ships, so it keeps its entry and its replay, and no
@@ -259,8 +257,7 @@ Before landing, confirm:
   cannot start a browser has no signal about the surface it just moved, and the
   suites that do run there staying green is not one;
 - every added, changed or moved behavior is represented in the ledger;
-- every retirement has a dated, named, quoted sanction, a recorded premise, and
-  a loud absence test asserting both;
+- every retirement carries everything `behavior-sweep` requires of one;
 - no wireframe or duplicated comparison route survives; and
 - the safe-start declaration and exact data source still match what produced the
   evidence.

--- a/skills/drivers/ui-craft/reference/revise.md
+++ b/skills/drivers/ui-craft/reference/revise.md
@@ -146,9 +146,9 @@ settled:
   nothing ruled reopens. A round that asks two questions gets an answer to
   neither.
 - **Options differ in concept, not decoration** — five ways to site a control,
-  not five colors of one control. Render each one live at the sizes, states and
-  themes that fail differently, as separate specimens: a small tile at rest is
-  not evidence about a large one being held.
+  not five colors of one control. Render every option live under the coverage
+  §1 already requires, and give each state its own specimen: a small tile at
+  rest is not evidence about a large one being held.
 - **Every option carries a stated cost, the recommended one included.** An
   option offered as free is one whose cost has not been found yet, and it wins
   the round on an omission.
@@ -195,7 +195,9 @@ is failure, never skip.
   header, and prove the old replay fails before the new one passes.
 - **Retired:** require `sanction: <person> · <date> · "<their reason>"`, retain a
   permanent RETIRED entry, and replace the positive replay with an absence
-  assertion that prints the sanction on every run.
+  assertion that prints the sanction on every run. Record the premise the ruling
+  reasoned from on the entry, so that assertion can assert it too
+  (`behavior-sweep`).
 - **Moved:** a behavior that changed which surface owns it gets the same
   ceremony as a removal. Name the fact, the surface it left, the surface it
   landed on, and update every story that reads it in the same change. A move is
@@ -203,8 +205,9 @@ is failure, never skip.
   intact, and the stories still reading the old surface were not wrong when they
   were written and nobody was told they had become wrong.
 
-A dropped or changed behavior without that record blocks the revision. There is
-no lock term to `resettle`; the ledger amendment is the decision record.
+A dropped, changed or moved behavior without that record blocks the revision.
+There is no lock term to `resettle`; the ledger amendment is the decision
+record.
 
 A move, a duplication or a rename also widens what the round owes outside the
 ledger, because each of them changes what an existing assertion means without
@@ -250,8 +253,9 @@ Before landing, confirm:
   actually run, launched by whoever can launch them. An agent whose sandbox
   cannot start a browser has no signal about the surface it just moved, and the
   suites that do run there staying green is not one;
-- every added or changed behavior is represented in the ledger;
-- every retirement has a dated, named, quoted sanction and a loud absence test;
+- every added, changed or moved behavior is represented in the ledger;
+- every retirement has a dated, named, quoted sanction, a recorded premise, and
+  a loud absence test asserting both;
 - no wireframe or duplicated comparison route survives; and
 - the safe-start declaration and exact data source still match what produced the
   evidence.

--- a/skills/drivers/ui-craft/reference/revise.md
+++ b/skills/drivers/ui-craft/reference/revise.md
@@ -132,6 +132,37 @@ the shipping shell, under all of these constraints:
 Do not run `lock` on the wireframe, produce a lock manifest for it, or cite it as
 fidelity evidence. A wireframe is a conversation aid, not a second surface.
 
+### Running the rounds
+
+Interactive divergent work only. The headless rule above stands: a headless
+session never opens this phase, and a direction it cannot settle is returned as
+a decision rather than invented.
+
+The constraints above say what a wireframe is. These say how the conversation
+converges, so that iterating in the running app is never how direction gets
+settled:
+
+- **One question per round.** Each round narrows what the next may ask, and
+  nothing ruled reopens. A round that asks two questions gets an answer to
+  neither.
+- **Options differ in concept, not decoration** — five ways to site a control,
+  not five colors of one control. Render each one live at the sizes, states and
+  themes that fail differently, as separate specimens: a small tile at rest is
+  not evidence about a large one being held.
+- **Every option carries a stated cost, the recommended one included.** An
+  option offered as free is one whose cost has not been found yet, and it wins
+  the round on an omission.
+- **Measure the claim instead of asserting it, and own a wrong measurement out
+  loud.** A retracted number costs one round; an unretracted one is believed for
+  the rest of the change.
+- **The operator's eye outranks the measurement when the metric measures the
+  wrong thing.** An area-blind contrast ratio is a correct number answering a
+  question nobody asked. Say which of those is happening rather than arguing the
+  number.
+- **Build only after the direction is ruled.** That is what moves review from
+  "is this right", which the rounds settle, to "is this broken", which the app
+  branch and the frozen stories settle.
+
 When the decisions settle, lift them into the app branch or worktree and continue
 there. Re-run the behavior sweep against the base app immediately before the
 lift, so the branch starts from a fresh frozen contract.
@@ -165,9 +196,35 @@ is failure, never skip.
 - **Retired:** require `sanction: <person> · <date> · "<their reason>"`, retain a
   permanent RETIRED entry, and replace the positive replay with an absence
   assertion that prints the sanction on every run.
+- **Moved:** a behavior that changed which surface owns it gets the same
+  ceremony as a removal. Name the fact, the surface it left, the surface it
+  landed on, and update every story that reads it in the same change. A move is
+  the case that looks like nothing happened: the app is right, the behavior is
+  intact, and the stories still reading the old surface were not wrong when they
+  were written and nobody was told they had become wrong.
 
 A dropped or changed behavior without that record blocks the revision. There is
 no lock term to `resettle`; the ledger amendment is the decision record.
+
+A move, a duplication or a rename also widens what the round owes outside the
+ledger, because each of them changes what an existing assertion means without
+changing its text:
+
+- **A second instance of an existing element under-specifies every selector that
+  names it.** Once a fact renders twice, a locator meaning "the element for this
+  item" matches both, and the locators do not all mean the same thing — some
+  meant the first instance, some the second, some "wherever this lives now",
+  readings that were indistinguishable while there was one copy. Re-read each
+  one's intent; find-and-replace picks a reading for you, silently, and breaks a
+  different set.
+- **A surface that can be conditionally absent invalidates every assertion using
+  it as a presence proxy.** Re-read them including the fallback paths that have
+  never executed: a dead branch in a replay driver is invisible until the day the
+  proxy starts failing, and it then runs against selectors the same change
+  deleted.
+- **A rename's blast radius is the repository, not the directory.** A name
+  outlives the fact it names, and a consumer outside the swept directory surfaces
+  as a type error inside a gate rather than anywhere near the edit.
 
 ## 5. Review and land
 
@@ -189,6 +246,10 @@ invent a lock manifest after the fact.
 Before landing, confirm:
 
 - every frozen story replayed against the built app;
+- for any round that moved a surface, the gates that replay those stories have
+  actually run, launched by whoever can launch them. An agent whose sandbox
+  cannot start a browser has no signal about the surface it just moved, and the
+  suites that do run there staying green is not one;
 - every added or changed behavior is represented in the ledger;
 - every retirement has a dated, named, quoted sanction and a loud absence test;
 - no wireframe or duplicated comparison route survives; and

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1312,7 +1312,7 @@ class UiCraftContractTests(unittest.TestCase):
         landing = " ".join(revise[revise.index("Before landing, confirm:") :].split())
         self.assertIn("launched by whoever can launch them", landing)
         self.assertIn("every added, changed or moved behavior", landing)
-        self.assertIn("a recorded premise", landing)
+        self.assertIn("everything `behavior-sweep` requires of one", landing)
 
         sweep_contract = " ".join(sweep.split())
         self.assertIn("asserts the premise the retirement reasoned from", sweep_contract)
@@ -1320,14 +1320,24 @@ class UiCraftContractTests(unittest.TestCase):
         self.assertIn("not a `replayed-fail`", sweep_contract)
         self.assertIn("premise:  the preset window controls are present", sweep)
 
-        # resettle is the other page that enumerates a retirement's change set;
-        # an enumeration lighter than the format it defers to reads as complete.
-        resettle = " ".join(
-            (ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "resettle.md")
-            .read_text(encoding="utf-8")
-            .split()
-        )
-        self.assertIn("with the premise the ruling reasoned from recorded beside it", resettle)
+        # What a retirement owes is enumerated on exactly one page. Three pages
+        # each carrying the list is how the premise obligation reached one of
+        # them and not the others; every other page names the case and points.
+        self.assertIn("What a retirement owes, in one place", sweep_contract)
+        resettle = (
+            ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "resettle.md"
+        ).read_text(encoding="utf-8")
+        pages = {
+            "revise.md": revise,
+            "resettle.md": resettle,
+            "build.md": build,
+        }
+        for name, text in pages.items():
+            with self.subTest(page=name):
+                self.assertIn("behavior-sweep", text)
+                # The sanction template is the tell that a page restated the list.
+                self.assertNotIn("sanction: <", text)
+        self.assertEqual(sweep.count("sanction: <"), 1)
 
         build_contract = " ".join(build.split())
         self.assertIn(

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1300,8 +1300,16 @@ class UiCraftContractTests(unittest.TestCase):
         ):
             self.assertIn(requirement, changes_contract)
 
+        # A case nothing blocks on is not a case: the blocking sentence and the
+        # landing checks reach a moved behavior and a retirement's premise too.
+        self.assertIn(
+            "A dropped, changed or moved behavior without that record blocks",
+            changes_contract,
+        )
         landing = " ".join(revise[revise.index("Before landing, confirm:") :].split())
         self.assertIn("launched by whoever can launch them", landing)
+        self.assertIn("every added, changed or moved behavior", landing)
+        self.assertIn("a recorded premise", landing)
 
         sweep_contract = " ".join(sweep.split())
         self.assertIn("asserts the premise the retirement reasoned from", sweep_contract)

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1263,6 +1263,58 @@ class UiCraftContractTests(unittest.TestCase):
         for name in ("modern-css", "modern-javascript"):
             self.assertFalse((ROOT / "skills" / "tools" / name).exists())
 
+    def test_revision_rounds_and_retired_premise_bind_through_ui_craft(self):
+        revise = (
+            ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "revise.md"
+        ).read_text(encoding="utf-8")
+        sweep = UI_CRAFT_SWEEP.read_text(encoding="utf-8")
+        build = (ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "build.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("### Running the rounds", revise)
+        rounds = revise[revise.index("### Running the rounds") :]
+        rounds = rounds[: rounds.index("When the decisions settle,")]
+        rounds_contract = " ".join(rounds.split())
+        for requirement in (
+            "Interactive divergent work only",
+            "One question per round",
+            "nothing ruled reopens",
+            "differ in concept, not decoration",
+            "carries a stated cost, the recommended one included",
+            "Measure the claim instead of asserting it",
+            "operator's eye outranks the measurement",
+            "Build only after the direction is ruled",
+        ):
+            self.assertIn(requirement, rounds_contract)
+
+        changes = revise[revise.index("### Behavior changes") :]
+        changes = changes[: changes.index("## 5.")]
+        changes_contract = " ".join(changes.split())
+        self.assertIn("**Moved:**", changes_contract)
+        self.assertIn("same ceremony as a removal", changes_contract)
+        for requirement in (
+            "under-specifies every selector that names it",
+            "presence proxy",
+            "blast radius is the repository, not the directory",
+        ):
+            self.assertIn(requirement, changes_contract)
+
+        landing = " ".join(revise[revise.index("Before landing, confirm:") :].split())
+        self.assertIn("launched by whoever can launch them", landing)
+
+        sweep_contract = " ".join(sweep.split())
+        self.assertIn("asserts the premise the retirement reasoned from", sweep_contract)
+        self.assertIn("QUESTION-round trigger asking for a fresh ruling", sweep_contract)
+        self.assertIn("not a `replayed-fail`", sweep_contract)
+        self.assertIn("premise:  the preset window controls are present", sweep)
+
+        build_contract = " ".join(build.split())
+        self.assertIn(
+            "*premise* has failed while its behavior stays absent is `re-settle requested`",
+            build_contract,
+        )
+
 
 class CodebaseDesignHexagonalContractTests(unittest.TestCase):
     def test_hexagonal_direction_preserves_seam_discipline(self):

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1320,6 +1320,15 @@ class UiCraftContractTests(unittest.TestCase):
         self.assertIn("not a `replayed-fail`", sweep_contract)
         self.assertIn("premise:  the preset window controls are present", sweep)
 
+        # resettle is the other page that enumerates a retirement's change set;
+        # an enumeration lighter than the format it defers to reads as complete.
+        resettle = " ".join(
+            (ROOT / "skills" / "drivers" / "ui-craft" / "reference" / "resettle.md")
+            .read_text(encoding="utf-8")
+            .split()
+        )
+        self.assertIn("with the premise the ruling reasoned from recorded beside it", resettle)
+
         build_contract = " ".join(build.split())
         self.assertIn(
             "*premise* has failed while its behavior stays absent is `re-settle requested`",

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1293,6 +1293,9 @@ class UiCraftContractTests(unittest.TestCase):
         changes_contract = " ".join(changes.split())
         self.assertIn("**Moved:**", changes_contract)
         self.assertIn("same ceremony as a removal", changes_contract)
+        # A move keeps its entry: the sweep admits exactly three entry types, so
+        # leaving this open reads a moved behavior's absence as a retirement.
+        self.assertIn("lands as an amended STORY rather than a retirement", changes_contract)
         for requirement in (
             "under-specifies every selector that names it",
             "presence proxy",


### PR DESCRIPTION
## What this is

Revise mode now says how a divergent round is run and what a round owes once a
surface actually moves. Previously it licensed throwaway wireframes for divergent
work but described no method for converging them, and its behavior ledger had no
case for a behavior that changes which surface owns it.

## What changed

* Divergent work gains a round method, binding the attended conversation only: one
  narrowing question per round with nothing ruled reopening, options that differ in
  concept and each carry a stated cost, claims measured rather than asserted, the
  operator's eye outranking a metric that measures the wrong thing, and building
  only once direction is ruled. The unattended path is unchanged and still goes
  straight to an app branch.
* A behavior that changes surfaces becomes a fifth ledger case beside preserved,
  added, changed and retired. It owes a removal's ceremony, lands as an amended
  story rather than a retirement, and is blocked at landing without that record.
  Three sweeps join it: a second copy of an element makes every locator naming it
  ambiguous, a surface that can be away invalidates anything using it as a presence
  proxy, and a rename reaches the whole repository.
* A round that moved a surface is not done until the checks replaying the frozen
  stories have run, launched by someone able to launch them. A sandbox that cannot
  start a browser yields no signal about the surface just moved.
* A retired story now records the premise its ruling reasoned from and asserts it
  beside the absence. A dead premise turns the story red as a request for a fresh
  ruling instead of reading as the behavior having returned.
* What a retirement owes is now enumerated on one page. Three pages each carried
  their own copy of that list, and two review rounds each found one more of them
  stale than the round before. The sweep page holds it; the revise and re-settle
  pages name the case and point at it.

The method binds through the pack, so every project revising a shipped surface
inherits it without an agent brief of its own. The ledger, the retirement sanction,
the lock contract and the unattended path are unchanged.

The decision and its risk contract remain with the active OpenSpec change.

Closes harmonichq/harmonic#219

## Verification

* Strict OpenSpec validation: 4 passed, 0 failed.
* Structural validation: 28 skills and 444 files.
* Complete repository suite: 513 passed, 23 skipped.
* The new guard fails without its subject: removing the round-method heading raises
  `AssertionError: '### Running the rounds' not found`.
* Refreshed-baseline applicability preflight passed.

Two full-depth review rounds, both axes. Round one raised three findings, round two
raised two, all five fixed in this branch.

Both rounds found the same defect in a different place: a page carrying its own
copy of the retirement list, correct when written and stale once a new obligation
arrived. Collapsing that list to one page removes the class rather than the two
instances. A test asserts the sanction template appears on exactly one page, and
it was proven to fail before it was relied on.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
