### PR TITLE
Route slicing calibration to per-repo reviewer memory

### DIFF
--- a/docs/epic-flow.md
+++ b/docs/epic-flow.md
@@ -95,7 +95,7 @@ Opening the pull request ends `start`. Human merge is the boundary.
 
 Run `/ticket revise <id>` for one round on an open pull request. It reloads the ticket, order, pull request reviews, and checks; reuses or respins the correct worktree; collects every unresolved comment and failure; fixes only grounded items within the order; re-verifies; re-audits; rebases once onto the current base; pushes the same branch; and responds to addressed pull request comments. It does not revise an already merged or closed pull request.
 
-After a human merge, run `/ticket finalize <id>`. It performs the applicable OpenSpec lifecycle above, then records actual session cost and tears down the worktree and branch. The cost verdict can identify a good slice, under-slicing, over-slicing, degraded chunks, degraded coordination, missing data, or unreadable transcripts. Under- or over-slicing produces an amendment proposal for the rubric; the skill does not silently edit the rubric.
+After a human merge, run `/ticket finalize <id>`. It performs the applicable OpenSpec lifecycle above, then records actual session cost and tears down the worktree and branch. The cost verdict can identify a good slice, under-slicing, over-slicing, degraded chunks, degraded coordination, missing data, or unreadable transcripts. A misprediction verdict is reported in the session; the slicing record already appended to that repository's reviewer memory is the calibration, so no rubric amendment is proposed and the operator is not asked anything.
 
 ## Human handoff and ticket-owned execution
 
@@ -158,6 +158,6 @@ that needs it.
 - A model or effort mismatch is a launch failure. Compare the session's actual model and confirmed effort to the stamped `Session fit` or `Open as` line.
 - A review dispute is resolved against the order's `Done when` clause, the stamped depth, and the cited repository rule. Reopen scope only when evidence changes a settled risk assumption.
 - A failed post-merge workflow blocks finalization. For ordinary OpenSpec changes, an archive, validation, commit, push, pull-request creation, or archive CI failure also blocks finalization before completion is posted or the ticket moves to done, and an archive pull request that is still open or was closed unmerged leaves the ticket incomplete for the operator.
-- A finalize verdict of under-sliced, over-sliced, or still-degraded calls for a proposed amendment to `references/slicing.md`; `finalize` does not edit that rubric itself.
+- A finalize verdict of under-sliced, over-sliced, or still-degraded is reported and nothing more. The per-repo slicing record is the calibration; `finalize` proposes no amendment to `references/slicing.md` and never edits it.
 
 For complete mechanics, start with [`ticket/SKILL.md`](../skills/drivers/ticket/SKILL.md), then the verb page for the current phase. For orchestration, read [`orchestrate/SKILL.md`](../skills/drivers/orchestrate/SKILL.md) and its routing references. For planning objections, read [`plan-review/SKILL.md`](../skills/tools/plan-review/SKILL.md).

--- a/openspec/changes/276-per-repo-slicing-calibration/design.md
+++ b/openspec/changes/276-per-repo-slicing-calibration/design.md
@@ -1,0 +1,75 @@
+# Design
+
+## ADR 276 — Slicing calibration is per-repository
+
+### Context
+
+The slicing rubric decides whether a work order is flat or chunked, and how big
+each chunk is. It carries two different kinds of content. One is mechanism: the
+trait table, the 180k target, the 120k floor, chunk shape, orchestrator tier.
+The other is measurement: an anchor table of real tickets with their measured
+peaks, which grew a row at a time as tickets finished.
+
+Only the mechanism is portable. The anchors were measured on one operator's
+sessions, on one machine, and increasingly against named repositories —
+`259 (skills)`, `253 (harmonic)`. A Harmonic ticket's cost is evidence about
+Harmonic's grounding cost, not about what any installation's chunks should weigh.
+
+Ticket #197 already built the right home for those numbers: a per-repository
+reviewer-memory store that `finalize` appends a slicing record to and `triage`
+reads, with "cross-repo learning: unsupported; per-repo default" as its recorded
+risk contract. Both channels then ran at once. `finalize` appended the record
+*and*, on a misprediction verdict, drafted a rubric diff for the operator to land
+as a skills-repo pull request.
+
+### Decision
+
+Calibration accrues per repository. Three consequences:
+
+1. **The rubric is frozen to mechanism.** `references/slicing.md` keeps the trait
+   table, the sizing rules, chunk shape, and orchestrator tier. It carries no
+   measured anchors of its own, and stops growing a row per finished ticket.
+
+2. **Lessons accrue in reviewer memory.** The per-repo store is the anchor
+   source. `triage` reads it for the shapes and peaks its traits are calibrated
+   against here; `finalize` keeps appending to it exactly as it does today.
+
+3. **The misprediction path is report-only.** On `under-sliced`,
+   `still-degraded`, or `over-sliced`, `finalize` reports which call was wrong and
+   by how much, and stops. It drafts nothing, offers no pull request, and asks the
+   operator nothing.
+
+### The threshold escape hatch
+
+A per-repo record cannot move a constant. The 180k target and the 120k floor are
+paired with constants in `skills/drivers/ticket/scripts/ticket.py`, so a genuine
+move has to change the rubric prose and those constants together. That stays
+operator-initiated skills-repo work. The rubric says so; `finalize` never
+proposes it.
+
+### Consequences
+
+* A fresh repository starts with the bare thresholds and no anchors, and gains
+  them over a handful of finished tickets. That is the intended trade: no anchors
+  beats another repository's anchors.
+* Anchor rows with a resolvable repository move to that repository's store. Rows
+  with no resolvable identity (the lettered rows, `53`, `10`, unlabeled `90`, and
+  `62 (external)`) are dropped rather than assigned to a guess; the thresholds
+  they informed already carry their lesson.
+* Coordinator-cost anchors keep their caveat when migrated: a coordinator peak
+  tunes no threshold in either direction.
+* The operator loses the automatic rubric-diff offer. That is the point of the
+  change, not a cost of it.
+
+### Alternatives considered
+
+* **Keep both channels.** Rejected: it is what produced repository-specific rows
+  in a shared rubric, and it puts a prompt and a pull request on every
+  misprediction.
+* **Have `finalize` edit the rubric itself.** Rejected for the reason the original
+  rule gave, which still holds: a skill that amends its own rubric from one
+  repository's measurement is exactly the coupling this decision removes.
+* **Implement reviewer-memory's `distill` and have triage read raw records
+  directly.** Out of scope. `distill` is documented in the reviewer-memory skill
+  but absent from `memory.py`; triage reads the curated digest that already
+  exists. Worth its own issue.

--- a/openspec/changes/276-per-repo-slicing-calibration/proposal.md
+++ b/openspec/changes/276-per-repo-slicing-calibration/proposal.md
@@ -1,0 +1,47 @@
+# Slicing calibration accrues per repository
+
+## Why
+
+Slicing lessons had two homes. Every finished ticket already appended a measured
+slicing record to the target repository's reviewer-memory store, which triage
+reads; but on an `under-sliced`, `still-degraded`, or `over-sliced` verdict,
+`finalize` also drafted a diff against `ticket/references/slicing.md`, showed it
+to the operator, and waited for them to land it as a skills-repo pull request.
+
+That second channel does not fit what slicing calibration is. The rubric's anchor
+table held rows measured on one operator's machine against particular
+repositories (`259 (skills)`, `253 (harmonic)`), so a lesson from one repository
+was growing into the rubric every installation inherits. It also put an operator
+prompt and a pull request on the finalize path, which the operator does not want.
+
+## What changes
+
+* `finalize`'s misprediction path becomes report-only: it says which rubric call
+  was wrong and by how much, and stops. The slicing record it already appended to
+  this repository's reviewer-memory store is the durable calibration. It drafts no
+  rubric diff, offers no pull request, and asks the operator nothing here. The
+  abandoned-ticket confirmation, which guards a destructive teardown, is untouched.
+* `references/slicing.md` loses its anchor table and keeps only repo-agnostic
+  instruction: the trait rubric, the sizing thresholds, chunk shape, and
+  orchestrator tier. Its provenance section points calibration at each
+  repository's reviewer-memory store.
+* `triage` reads that store for the anchors the traits are calibrated against,
+  and records which anchor the ticket matched or that none was nearby.
+* Repo-attributed anchor rows migrate to the matching reviewer-memory store's
+  slicing digest; rows with no resolvable repository identity are dropped, their
+  lessons already being in the thresholds.
+
+## Risk contract
+
+- **Must prevent:** `finalize` prompting the operator or proposing a rubric
+  change on a misprediction verdict; a measured anchor for one repository living
+  in the shared rubric.
+- **Must recover:** n/a; no runtime state changes. The `append-slicing` pipeline
+  and its record bytes are untouched.
+- **Accepted failure:** a repository with no accumulated slicing records gets the
+  bare thresholds and no anchors until it finishes a few tickets.
+- **Unsupported:** cross-repo learning (per the #197 risk contract), moving the
+  180k/120k constants, and implementing reviewer-memory's documented-but-absent
+  `distill` command.
+- **Evidence owed:** the repository gate (`scripts/validate.py` plus the named
+  unittest modules and `py_compile`) and `openspec validate --all --strict`.

--- a/openspec/changes/276-per-repo-slicing-calibration/specs/ticket-workflow/spec.md
+++ b/openspec/changes/276-per-repo-slicing-calibration/specs/ticket-workflow/spec.md
@@ -1,0 +1,91 @@
+# Ticket workflow — deltas
+
+## MODIFIED Requirements
+
+### Requirement: Slicing amendment verdicts
+
+Finalization MUST report the misprediction for `under-sliced`, `still-degraded`,
+or `over-sliced` verdicts, naming which rubric call was wrong and by how much. It
+MUST NOT draft a slicing-rubric amendment, MUST NOT prompt the operator on that
+path, and MUST NOT edit the rubric. The slicing record already appended to the
+target repository's reviewer-memory store is the calibration sink for those
+lessons. Finalization MUST NOT report a misprediction for `no-data`,
+`unmeasurable`, `coordinator-only`, or `coordination-degraded`. A change to the
+slicing thresholds themselves MUST be operator-initiated and MUST update the
+rubric prose and the helper constant together.
+
+#### Scenario: Measured chunks were too large
+
+- **WHEN** role-aware measurement returns `still-degraded`
+- **THEN** finalization reports the misprediction against the stamped shape, names
+  the per-repo slicing record as the calibration, and neither drafts a rubric diff
+  nor asks the operator anything
+
+#### Scenario: A verdict is not a misprediction
+
+- **WHEN** role-aware measurement returns `no-data`, `unmeasurable`,
+  `coordinator-only`, or `coordination-degraded`
+- **THEN** finalization reports that verdict's own meaning and reports no slicing
+  misprediction
+
+### Requirement: Role-aware measurement and review depth
+
+Each participating session MUST be claimable with both its responsibility
+(`coordinator`, `worker`, or `reviewer`) and the ticket lifecycle verb that
+produced the claim. Finalization MUST compute responsibility-tagged and
+verb-tagged costs separately, print the resulting record as JSON, and append that
+same record to the target repository's reviewer-memory store. It MUST NOT create
+or append a second ticket-wide telemetry store. Worker peaks alone MUST calibrate
+chunk sizing; measurable non-reviewer `start` claims alone MUST calibrate a flat
+order; triage, revise, finalize, and reviewer peaks MUST remain independent
+overhead. Claims without a lifecycle verb MUST remain readable as legacy data and
+MUST NOT be guessed into a verb. A session MUST NOT be reused under a different
+lifecycle verb; same-verb resumes remain valid, while a later verb requires a
+fresh session. Review depth MUST be stamped from change scope and sensitivity
+rather than inferred from recorded slicing outcomes.
+
+#### Scenario: A measurable ticket is finalized
+
+- **WHEN** finalization computes a slicing record from attributable claims
+- **THEN** `record` prints the complete JSON record and finalization appends those
+  bytes to reviewer memory without creating a parallel ticket telemetry file
+
+#### Scenario: A flat ticket has expensive lifecycle overhead
+
+- **WHEN** triage, revise, or finalize peaks above the slicing band while the
+  measurable non-reviewer `start` claim remains below it
+- **THEN** the flat verdict is based on the `start` peak and reports lifecycle
+  overhead separately
+
+#### Scenario: A claimed flat ticket has no attributable execution
+
+- **WHEN** at least one attributable claim exists but no measurable non-reviewer
+  `start` claim exists, including when every readable claim predates
+  lifecycle-verb attribution
+- **THEN** finalization returns `unmeasurable` and makes no slicing judgment
+
+#### Scenario: A flat ticket has no attributable claims
+
+- **WHEN** no attributable in-repository claim exists
+- **THEN** finalization preserves the existing `no-data` outcome
+
+#### Scenario: A later lifecycle verb follows execution
+
+- **WHEN** revise or finalize follows the session that executed `start`
+- **THEN** the later verb runs in a fresh session so its context cannot inflate the
+  start-attributed execution peak
+
+#### Scenario: A session is re-claimed under another verb
+
+- **WHEN** `claim` receives a ticket/session pair already persisted under a
+  different lifecycle verb
+- **THEN** it preserves and prints the persisted claim, reports one visible
+  non-blocking conflict naming both verbs, and does not claim that the submitted
+  verb was stored
+
+#### Scenario: A chunked ticket has an expensive review
+
+- **WHEN** finalization records a reviewer peak above the slicing band while the
+  implementation workers remain within it
+- **THEN** the reviewer cost is reported separately and does not make the chunks
+  appear under-sliced or change their stamped review depth

--- a/openspec/changes/276-per-repo-slicing-calibration/tasks.md
+++ b/openspec/changes/276-per-repo-slicing-calibration/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Make `finalize`'s misprediction path report-only, with no rubric diff, no pull request, and no operator prompt.
+- [x] Restate the report-only contract in `ticket/SKILL.md` and `docs/epic-flow.md`.
+- [x] Delete the anchor table from `references/slicing.md` and point its provenance at the per-repo store.
+- [x] Make `triage` read the reviewer-memory store as the anchor source and record which anchor matched.
+- [x] Update the work-order template's "Why sliced" placeholder.
+- [x] Pin the new contract in tests and repoint the section splits that keyed on the anchor table.
+- [x] Record the decision as an ADR and modify the two affected spec requirements.
+- [x] Migrate repo-attributed anchor rows into their reviewer-memory slicing digests.
+- [x] Run the repository gate and record its result in the pull request.

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -39,8 +39,9 @@ four.
   change, which opens a reviewed archive pull request and posts its `Archive PR:`
   locator before stopping, then on a later finalization, once a human merged that
   pull request, close the ticket with a comment linking the pull request, record
-  what the ticket actually cost in context, and tear the worktree down, so the
-  slicing rubric is tuned against measured numbers rather than intuition.
+  what the ticket actually cost in context, and tear the worktree down, so this
+  repo's slicing calibration is tuned against measured numbers rather than
+  intuition.
 
 ## The tracker contract
 

--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -35,8 +35,7 @@ them together.
 ## Sizing
 
 Every execution session carries roughly 90k of fixed overhead (skill load,
-grounding, review) before it touches the work, which is what leaves a sub-120k
-chunk mostly paying for itself.
+grounding, review) before it touches the work.
 
 These numbers describe what one agent building one piece of work costs, so only a
 session claimed `--role worker` measures them. A coordinator's peak and a

--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -37,8 +37,8 @@ them together.
 Every execution session carries roughly 90k of fixed overhead (skill load,
 grounding, review) before it touches the work.
 
-These numbers describe what one agent building one piece of work costs, so only a
-session claimed `--role worker` measures them. A coordinator's peak and a
+That overhead and the two thresholds below describe what one agent building one
+piece of work costs, so only a session claimed `--role worker` measures them. A coordinator's peak and a
 reviewer's are recorded separately and tune nothing here. A coordinator over the
 band on an otherwise-held slice is `coordination-degraded`; carry less in that
 session, never cut more chunks.

--- a/skills/drivers/ticket/references/slicing.md
+++ b/skills/drivers/ticket/references/slicing.md
@@ -32,49 +32,11 @@ fact costs its own pass, whether they are chained from a single source of truth
 or restated independently of one another, and they drift because nothing checks
 them together.
 
-## Anchor table
-
-Calibration from real tickets. Peaks are the measured session maximum, read with
-the helper's `scan` command, not estimates.
-
-| Ticket | Work | Traits | Right shape | Actual |
-|---|---|---|---|---|
-| A | One configuration grant in one deployment target | none | flat, one agent | peaked 128k, one session |
-| B | Bootstrap script, its tests, a CI job and a runbook, run live against the target host | multiple artifacts, live run | slice: build the artifact, then run and correct | flat; peaked 313k over 2 sessions |
-| C | Routes across two environments and two accounts | multiple targets, cross-boundary writes | slice by target | 4 sessions, 275k to 408k |
-| D | Port live networking into the repo's own tooling, with imports | multiple targets, import | slice; was not | 574k in one session |
-| E | CI previewing every deployment target | multiple targets, multiple artifacts | slice | 359k plus a 313k resume |
-| F | One new member of a closed behavioural taxonomy, wired through its server projection, a JS mirror, three fixture generators and a browser gate | multiple artifacts, live run, lockstep copies | slice: detector and its tests, then the surface and its fixtures | flat; peaked 503k over 4 sessions |
-| 53 | Replace a rejected application route already on the ticket branch, then build a narrower shared route adapter and update its consumers | multiple artifacts, in-flight scope replacement | slice into two serial chunks: remove and reconcile the rejected implementation, then build and verify the replacement | flat revised order; peaked 245k across 5 sessions |
-| 10 | Proof-bounded I:C history across an analyzer, server projections, generated fixtures, and a lifecycle-gated Diagnose revision | multiple artifacts, live run, lockstep copies, lifecycle-gated surface revision | slice into four serial chunks: analyzer, server contract, generated projections/evidence, then surface lock and browser evidence | 3 chunks; peaked 244k |
-| 90 | One shared behavioural judgment across model view, two server projections, generated fixtures and mirrors, and browser replay | multiple artifacts, live run, lockstep copies | slice into three serial chunks: source judgment, projection contracts, then generated artifacts and live replay | 2 chunks; peaked 231k |
-| 62 (external) | Four pull-request-sized chunks delegated from one coordinator | multiple artifacts, lockstep copies | slice into four chunks | 4 chunks; coordinator peaked 387k, chunk workers unmeasured |
-| 109 (harmonic) | Two admission bars for candidate I:C estimators (a synthetic truth/placebo generator with its entry bar, a stable-era replay harness) plus a live read-only calibration run against a real snapshot | multiple artifacts, live run | three serial chunks | 3 chunks; chunk workers peaked 162k and 138k, coordination peaked 299k |
-| 90 (skills) | A shared graph-identity interface, its ticket-workflow consumers, and the separately installed discovery policy, with argv and response shapes discovered by probing a live external CLI | multiple artifacts, lockstep copies | slice into two serial chunks: the ensure interface with its spiked contract tests, then the workflow pages and discovery policy that consume it | flat; peaked 243k in one session |
-| 79 (harmonic) | A server projection with identity and association semantics, a bounded registry/concurrency/cache-lifetime/HTTP contract, a shipped browser consumer, generated mirrors, and a closed recovery matrix run against an offline server | multiple artifacts, live run, lockstep copies | slice into four: projection core; registry/HTTP lifecycle; browser consumer; generated evidence and live replay | 2 chunks; server and surface chunks peaked 237k/242k, lifecycle peak 244k |
-| 259 (skills) | Remove one command side effect while preserving its JSON interface across public tests, the finalization procedure, and the OpenSpec contract | multiple artifacts, lockstep copies | slice into two serial chunks: command and public tests, then workflow/specification contract and verification | flat; start peaked 187k |
-| 253 (harmonic) | Revise one shipped Diagnose chart across interaction containment, theme/composited-pixel auditing, synthetic evidence capture, and full offline browser replay | live run, lifecycle-gated surface revision | three serial chunks: behavior containment; theme and composited audit; evidence capture, full replay, and reconciliation | 2 chunks; largest worker peaked 245k |
-| 239 (skills) | Reconcile a rejected prose-contract implementation with current main, then replace it across the shared ticket contract, triage consumer, and aggregate tests | in-flight scope replacement, lockstep copies | flat, one agent; reconciliation was a mechanical prelude below the chunk floor | 2 serial chunks; implementation workers peaked 55,447 to 116,486, all below the 120k floor |
-
-When a ticket's traits match an anchor row, take that row's shape. When it sits
-between rows, say which two and pick the more conservative one.
-
-Row `62 (external)` is a shape anchor only. Its four chunks each landed as a
-correct pull-request-sized piece, so the slice is worth copying, but no chunk
-worker's peak was measured: the 387k belongs to the coordinator, whose context
-grows with dispatches, returned results, review rounds and merges. Coordinator
-cost never tunes the thresholds below, in either direction, and this row is
-unusable for that.
-
-Row `109 (harmonic)` is also a shape anchor: its 299k is coordinator cost, not
-chunk cost. It was attributed by joining pre-role claims to their chunk worktrees,
-rather than read from role-tagged records. It tunes no threshold.
-
 ## Sizing
 
-Ground truth from mining 134 past sessions: 31 peaked above 180k, and every
-execution session carries roughly 90k of fixed overhead (skill load, grounding,
-review) before it touches the work.
+Every execution session carries roughly 90k of fixed overhead (skill load,
+grounding, review) before it touches the work, which is what leaves a sub-120k
+chunk mostly paying for itself.
 
 These numbers describe what one agent building one piece of work costs, so only a
 session claimed `--role worker` measures them. A coordinator's peak and a
@@ -92,16 +54,23 @@ session, never cut more chunks.
 
 ## Where these numbers came from
 
-Every figure on this page was measured on one operator's own sessions, on one
-machine, against that operator's repositories. The mechanism generalizes and the
-constants may not: fixed overhead moves with how much a project's grounding costs,
-and the degradation band moves with the model in use.
+These thresholds were measured on one operator's own sessions, on one machine,
+against that operator's repositories. The mechanism generalizes and the constants
+may not: fixed overhead moves with how much a project's grounding costs, and the
+degradation band moves with the model in use.
 
-So another installation re-tunes rather than trusting them. Run the helper's
-`record` command at the end of each finished ticket, as `finalize` does. After a
-handful of tickets, its verdicts show whether the 180k target and the 120k floor
-are right on your work, and each misprediction arrives with a drafted amendment
-against this page.
+So another installation re-tunes rather than trusting them, and it re-tunes per
+repository. This page carries no measured anchors of its own. Calibration accrues
+in each repository's reviewer-memory store, which `finalize` appends a slicing
+record to at the end of every finished ticket and `triage` reads before choosing a
+shape. After a handful of tickets, that store holds this repository's own anchors
+and shows whether the 180k target and the 120k floor are right on its work.
+
+Moving the thresholds themselves is a change to this page, not to a store: the
+180k target and the 120k floor are paired with constants in the ticket helper
+(`scripts/ticket.py`), so a genuine move changes the prose and the constants
+together. That is operator-initiated skills-repo work; `finalize` reports a
+misprediction and proposes nothing.
 
 ## Chunk shape
 

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -136,8 +136,9 @@ Review depth (whole diff): <targeted | full> (<one-line reason>)
 Profile: <none | hardening>
 
 Why sliced
-<the rubric traits that fired, one line each, and the nearest reviewer-memory
- anchor this matches, or "no nearby anchor">
+<the rubric traits that fired, one line each, and whether a nearby
+ reviewer-memory anchor agreed, disagreed, or was absent — the fact of the match
+ only, never the anchor's content>
 
 Context
 <2-5 bullets shared by every chunk: what exists today, what constrains the change,

--- a/skills/drivers/ticket/templates/work-order.md
+++ b/skills/drivers/ticket/templates/work-order.md
@@ -136,7 +136,8 @@ Review depth (whole diff): <targeted | full> (<one-line reason>)
 Profile: <none | hardening>
 
 Why sliced
-<the rubric traits that fired, one line each, and the anchor row this matches>
+<the rubric traits that fired, one line each, and the nearest reviewer-memory
+ anchor this matches, or "no nearby anchor">
 
 Context
 <2-5 bullets shared by every chunk: what exists today, what constrains the change,

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -146,18 +146,20 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    context per claimed session without recording anything, which is the way to look
    before committing a record.
 
-   **On `under-sliced`, `still-degraded`, or `over-sliced`, report the misprediction
-   and draft the amendment.** Say which rubric call was wrong and by how much, then
-   write a concrete diff against
-   [references/slicing.md](../references/slicing.md): a trait added or reworded, a
-   threshold moved, a new anchor row with this ticket's measured peak. An amendment
-   that moves a threshold moves it in both places, the prose and the helper's
-   constants, or the two drift apart. Show it to the user; landing it is an ordinary
-   pull request they approve. The skill never amends its own rubric, and never edits
-   `references/slicing.md` itself.
+   **On `under-sliced`, `still-degraded`, or `over-sliced`, report the
+   misprediction.** Say which rubric call was wrong and by how much: the traits
+   triage read, the shape it chose, and the peak that contradicted it. That is the
+   whole path. The slicing record appended in the previous step already landed the
+   lesson in this repository's reviewer-memory store, which is where triage reads
+   its anchors, so the calibration is durable without anything further. Finalize
+   drafts no rubric diff, offers no pull request, never edits
+   [references/slicing.md](../references/slicing.md), and asks the operator nothing
+   here. Moving the 180k target or the 120k floor themselves is
+   operator-initiated skills-repo work, because it changes the rubric prose and the
+   helper's constants together; finalize never proposes it.
 
    `no-data`, `unmeasurable`, `coordinator-only`, and `coordination-degraded` are not
-   mispredictions, and none drafts an amendment. `no-data` has two readings the
+   mispredictions, and none of them reports one. `no-data` has two readings the
    report keeps apart: no session claimed the ticket, so it ran outside this
    machine's transcripts, or claims for another repository were excluded.
    `unmeasurable` means this repository had claims but no measurable eligible start

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -192,16 +192,19 @@ disclosed target and exact mutation.
 
 8. **Decide the shape: flat or chunked.** Read
    [references/slicing.md](../references/slicing.md) and run its trait rubric
-   against what grounding found. Consult this repo's reviewer-memory slicing records
-   alongside the rubric's anchor table, and say when they disagree. The rubric
-   decides flat or chunked and, when chunked,
+   against what grounding found. The rubric carries the traits and the thresholds;
+   this repo's own anchors live in its reviewer-memory slicing records, so read
+   those for the shapes and measured peaks the traits are calibrated against here,
+   and say when a nearby record contradicts the call the rubric points at. The
+   rubric decides flat or chunked and, when chunked,
    sizes the chunks and names each one's mode, coherent capability ownership, file
    or target ownership, shared-contract ownership, agent tier, and the orchestrator
    tier. Every capability and shared contract has exactly one owning chunk. A
    parallel chunk must not implement, revise, or depend on another chunk's private
    capability; make that work serial when the dependency is real. Record which
-   traits fired and which anchor row the ticket matches; the order carries that
-   reasoning, so a wrong call is visible later.
+   traits fired and which reviewer-memory anchor or record the ticket matches, or
+   that the store held no nearby anchor; the order carries that reasoning, so a
+   wrong call is visible later.
 
 9. **Stamp the review depth.** Read
    [references/review-depth.md](../references/review-depth.md) and stamp one depth

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -202,9 +202,11 @@ disclosed target and exact mutation.
    tier. Every capability and shared contract has exactly one owning chunk. A
    parallel chunk must not implement, revise, or depend on another chunk's private
    capability; make that work serial when the dependency is real. Record which
-   traits fired and which reviewer-memory anchor or record the ticket matches, or
-   that the store held no nearby anchor; the order carries that reasoning, so a
-   wrong call is visible later.
+   traits fired, and whether a nearby reviewer-memory anchor agreed with the call,
+   disagreed with it, or was absent from the store. Record the fact of that match,
+   never the record: store content stays out of the order under step 4's rule, so
+   an anchor is never quoted, named, or given its measured peaks here. The order
+   carries that reasoning, so a wrong call is visible later.
 
 9. **Stamp the review depth.** Read
    [references/review-depth.md](../references/review-depth.md) and stamp one depth

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -3402,7 +3402,10 @@ class ReviewerMemoryConsumerContractTests(unittest.TestCase):
         )
         self.assertIn("including its not-installed carve-out", text)
         self.assertIn("slicing records", text)
-        self.assertIn("say when they disagree", text)
+        self.assertIn(
+            "say when a nearby record contradicts the call the rubric points at",
+            text,
+        )
 
     def test_code_review_injects_the_pointer_and_appends_rounds_under_the_authoritative_failure_rule(self):
         text = " ".join(self.CODE_REVIEW.read_text(encoding="utf-8").split())

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -113,7 +113,7 @@ class TicketSkillContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         trait_rubric = slicing.split("## The trait rubric", 1)[1].split(
-            "## Anchor table", 1
+            "## Sizing", 1
         )[0]
         chunk_shape = slicing.split("## Chunk shape", 1)[1].split(
             "## Orchestrator tier", 1
@@ -177,7 +177,7 @@ class TicketSkillContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         trait_rubric = slicing.split("## The trait rubric", 1)[1].split(
-            "## Anchor table", 1
+            "## Sizing", 1
         )[0]
         rows = [
             line.split("|")[1].strip()
@@ -211,6 +211,33 @@ class TicketSkillContractTests(unittest.TestCase):
                     f"the {word} trait row is no longer {expected[position]!r};"
                     " the explanation's ordinal now describes the wrong trait",
                 )
+
+    def test_a_slicing_misprediction_is_reported_and_never_offered_as_a_rubric_change(self):
+        # Slicing calibration is per repository: the record finalize already
+        # appended to this repo's reviewer-memory store is the lesson. If
+        # finalize went back to drafting a rubric diff for the operator to land,
+        # one repository's measurements would grow into every installation's
+        # rubric again, which is exactly what the per-repo store replaced.
+        finalize = " ".join(
+            (TICKET_DIRECTORY / "verbs" / "finalize.md")
+            .read_text(encoding="utf-8")
+            .split()
+        )
+        self.assertIn("report the misprediction", finalize)
+        self.assertIn("reviewer-memory store", finalize)
+        self.assertNotIn("Show it to the user", finalize)
+        self.assertNotIn("pull request they approve", finalize)
+
+    def test_the_slicing_rubric_keeps_no_measured_anchors_of_its_own(self):
+        # Measured anchors are one operator's numbers on one machine. They live
+        # in each repo's reviewer-memory store, which triage consults; the page
+        # keeps only the repo-agnostic mechanism.
+        slicing = (TICKET_DIRECTORY / "references" / "slicing.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("## Anchor table", slicing)
+        collapsed = " ".join(slicing.split())
+        self.assertIn("reviewer-memory store", collapsed)
 
     def test_surface_lifecycle_is_produced_and_consumed_across_ticket_paths(self):
         triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -239,6 +239,41 @@ class TicketSkillContractTests(unittest.TestCase):
         collapsed = " ".join(slicing.split())
         self.assertIn("reviewer-memory store", collapsed)
 
+    def test_the_order_records_the_anchor_match_without_carrying_store_content(self):
+        # Triage step 4 confines reviewer-memory content to worker prompts:
+        # "never copy them into the work order, a tracker comment...". Once the
+        # anchors moved out of the shipped rubric and into the private per-repo
+        # store, an order asked to name "the anchor row this matches" would post
+        # store content into a public tracker comment. The order records that a
+        # nearby anchor agreed, disagreed, or was absent — never the anchor.
+        triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(
+            encoding="utf-8"
+        )
+        template = (TICKET_DIRECTORY / "templates" / "work-order.md").read_text(
+            encoding="utf-8"
+        )
+        confinement = " ".join(triage.split("4. **", 1)[1].split("5. **", 1)[0].split())
+        self.assertIn(
+            "never copy them into the work order, a tracker comment",
+            confinement,
+        )
+        shape_step = " ".join(
+            triage.split("8. **Decide the shape", 1)[1]
+            .split("9. **Stamp the review depth", 1)[0]
+            .split()
+        )
+        why_sliced = " ".join(
+            template.split("Why sliced", 1)[1].split("Context", 1)[0].split()
+        )
+        for section, label in ((shape_step, "triage step 8"), (why_sliced, "the template")):
+            self.assertIn(
+                "never",
+                section,
+                f"{label} no longer bounds what the order may carry from the store",
+            )
+        self.assertIn("store content stays out of the order", shape_step)
+        self.assertIn("never the anchor's content", why_sliced)
+
     def test_surface_lifecycle_is_produced_and_consumed_across_ticket_paths(self):
         triage = (TICKET_DIRECTORY / "verbs" / "triage.md").read_text(encoding="utf-8")
         start = (TICKET_DIRECTORY / "verbs" / "start.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What this is

Slicing calibration is now per repository. Finalize reports a wrong slicing call
and stops, because the measured record it already appended to that repository's
reviewer memory is the lesson. Previously it also drafted a diff against the
shared slicing rubric and waited for the operator to land it as a pull request
here, which is how one repository's measured costs became every installation's
rubric.

## What changed

* The rubric keeps only what travels between installations: the trait table, the
  size thresholds, chunk shape, and the coordinator tier. Its anchor table is
  gone.
* Triage reads each repository's reviewer memory for the anchors its traits are
  calibrated against, and records whether a nearby anchor agreed, disagreed, or
  was absent. The fact of the match only: reviewer-memory content is confined to
  worker prompts and the work order is posted as a public tracker comment.
* Moving the 180k target or the 120k floor themselves still changes the rubric
  prose and the ticket helper's constants together, so it stays operator work.
  Finalize never proposes it.
* Four of the six repo-attributed anchor rows moved into the reviewer memory of
  the repository they were measured against. Rows with no resolvable repository
  (the lettered rows, and tickets 53, 10, unlabeled 90, and 62 external) were
  dropped rather than filed under a guess; the thresholds they set already carry
  their lesson.

The abandoned-ticket confirmation, the append-slicing pipeline, the eight verdict
definitions, and the 180k/120k values themselves are unchanged.

The decision and its risk contract are in the active OpenSpec change, recorded as
ADR 276.

Closes #276

## Verification

* Complete repository suite: 504 passed, 23 skipped. Structural validation: 28
  skills and 459 files. Byte compilation: exit 0.
* Strict OpenSpec validation: 6 passed, 0 failed.
* Anchor phrases: 0 in the skills tree, the published specs, and the epic guide.
  One in the tests, which is the assertion that they are gone.
* Both new guards were run against the pre-change tree and observed to fail
  there first.
* Reviewer memory pages: the skills store went 29 lines to 48 and gained tickets
  259 and 239; the harmonic store went 34 to 55 and gained 79 and 253. Tickets 90
  and 109 were not re-added because both pages already carried those lessons,
  including 109's coordinator-cost caveat. Those stores are operator-local, so
  this names the tickets rather than their text, and it is the one piece of
  evidence a reader cannot check from this branch.

Rebased onto the current default branch after the archive-pull-request and
worker-egress changes landed. Both conflicts were the same shape, a line whose
archive half moved on the default branch and whose calibration half moved here,
and both halves are kept. The suite is 11 tests smaller than before the rebase
because the egress change removed its own.

Two full-depth review rounds, both axes. Round one raised two findings, both
fixed here; round two raised none.

Round one caught a leak this change would have introduced. Triage confines
reviewer-memory content to worker prompts, and step 8 still told it to record
which anchor the ticket matched into the order that gets posted publicly. Safe
while the anchors lived in the shipped rubric, and not once they live only in the
private store. A guard now pins the confinement, and it detects the wording being
removed rather than a leak added elsewhere.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
