### PR TITLE
Route post-merge OpenSpec archives through reviewed pull requests

### DIFF
--- a/docs/epic-flow.md
+++ b/docs/epic-flow.md
@@ -10,7 +10,7 @@ The primary contracts are [`epic`](../skills/drivers/epic/SKILL.md), [`ticket`](
 ## OpenSpec change lifecycle
 
 - **Before merge:** an ordinary ticket keeps its active change and deltas in the pull request for review; it does not fold or archive them.
-- **After merge:** `/ticket finalize` verifies the human merge and CI, follows `operations.archive.guidance`, verifies archive JSON and strict validation, commits and pushes the archive on `main`, then verifies post-push CI before it comments completion or moves the ticket to done.
+- **After merge:** `/ticket finalize` verifies the human merge and CI, follows `operations.archive.guidance`, verifies archive JSON and strict validation, commits the archive on a dedicated branch in a sibling archive checkout, opens a reviewed follow-up pull request against `main`, posts its `Archive PR:` locator on the ticket, and stops. A later `/ticket finalize` reads that locator: an open archive pull request stays pending, a closed-unmerged one stops for operator direction, and only a human-merged one with green CI lets it comment completion and move the ticket to done. No archive commit is pushed directly to `main`.
 - **Epic children:** they create no child change. A required parent-plan amendment is
   committed in the child worktree and travels with implementation; the parent epic's
   active change remains the authority and the parent retains archive ownership.
@@ -25,7 +25,7 @@ The primary contracts are [`epic`](../skills/drivers/epic/SKILL.md), [`ticket`](
 6. Run `/ticket start <id>` in a fresh session. It executes the work order, verifies the result, reviews the change, and opens the pull request.
 7. Run `/ticket revise <id>` once per review round when the open pull request needs changes. It reloads the order, fixes and verifies the round, rebases once, and pushes the same branch.
 8. A human reviews and merges the pull request after green CI and passed review. Agents do not merge, self-approve, or answer reviews outside `revise`.
-9. Run `/ticket finalize <id>` after the human merge. It verifies the post-merge workflow, completes the repository's post-merge archive guidance for an ordinary OpenSpec change, comments the outcome, moves the ticket to done, records measured cost, and tears down the ticket worktree. An epic child leaves its parent change active for parent-owned archive.
+9. Run `/ticket finalize <id>` after the human merge. It verifies the post-merge workflow, completes the repository's post-merge archive guidance for an ordinary OpenSpec change by opening a reviewed archive pull request and stopping, then on a later run, after a human merged that pull request, comments the outcome, moves the ticket to done, records measured cost, and tears down the ticket worktree. An epic child leaves its parent change active for parent-owned archive.
 
 An epic closes only after its live GitHub state proves that no spike child is open, every build child has a merged closing pull request or is closed `NOT_PLANNED`, and no deferred child remains open; then close the epic issue.
 
@@ -157,7 +157,7 @@ that needs it.
 - A stale or overlapping target is a preflight failure. Refresh from the origin default-branch tip and re-triage when the order no longer matches the tree.
 - A model or effort mismatch is a launch failure. Compare the session's actual model and confirmed effort to the stamped `Session fit` or `Open as` line.
 - A review dispute is resolved against the order's `Done when` clause, the stamped depth, and the cited repository rule. Reopen scope only when evidence changes a settled risk assumption.
-- A failed post-merge workflow blocks finalization. For ordinary OpenSpec changes, an archive, validation, commit, push, or post-push-CI failure also blocks finalization before completion is posted or the ticket moves to done.
+- A failed post-merge workflow blocks finalization. For ordinary OpenSpec changes, an archive, validation, commit, push, pull-request creation, or archive CI failure also blocks finalization before completion is posted or the ticket moves to done, and an archive pull request that is still open or was closed unmerged leaves the ticket incomplete for the operator.
 - A finalize verdict of under-sliced, over-sliced, or still-degraded calls for a proposed amendment to `references/slicing.md`; `finalize` does not edit that rubric itself.
 
 For complete mechanics, start with [`ticket/SKILL.md`](../skills/drivers/ticket/SKILL.md), then the verb page for the current phase. For orchestration, read [`orchestrate/SKILL.md`](../skills/drivers/orchestrate/SKILL.md) and its routing references. For planning objections, read [`plan-review/SKILL.md`](../skills/tools/plan-review/SKILL.md).

--- a/docs/scope/reviewed-openspec-archives.md
+++ b/docs/scope/reviewed-openspec-archives.md
@@ -1,0 +1,52 @@
+# Scope: reviewed OpenSpec archives
+
+## Decision
+
+Keep archiving ordinary OpenSpec changes after the implementation pull request
+merges, but land the archive through a small follow-up pull request instead of a
+direct push to `main`.
+
+Ticket finalization therefore has two attended stages:
+
+1. Verify the implementation merge and green workflow, create and validate the
+   archive on a dedicated branch, open the archive pull request, post its URL on
+   the ticket, and stop.
+2. On a later `finalize`, read that URL. If the pull request is still open, stop.
+   If a human merged it and its workflow is green, post completion, record actuals,
+   and clean up.
+
+The archive branch and sibling checkout are a narrow post-merge exception to the
+ticket's normal one-branch, one-worktree rule. Agents still never merge pull
+requests.
+
+## Risk contract
+
+- **Must prevent:** direct pushes to `main`, agent merges, and ticket completion
+  before the archive pull request is human-merged and green.
+- **Accepted failure:** if archive creation, validation, pull-request creation, or
+  ticket commenting fails, stop visibly and leave the branch/checkouts for the
+  operator to recover manually.
+- **Unsupported:** automatic recovery when a pull request was created but its URL
+  was not recorded on the ticket; automatic replacement of a closed-unmerged
+  archive pull request.
+- **Evidence owed:** contract tests show the two-stage order and absence of a
+  direct push to `main`.
+
+## Shape
+
+Flat, one agent. This is one small documentation-and-contract change with no new
+runtime module, parser, service, or integration.
+
+## Open questions
+
+None.
+
+## Review rounds
+
+- The initial draft was rejected as over-engineered. This revision removes the
+  head-branch lookup protocol, automatic missing-comment recovery, scratch Git
+  spike, and detailed cleanup state machine. Failures remain visible and manually
+  recoverable for the single operator.
+- One operator-directed Codex Terra cold review returned `COUNTERSIGNED` with no
+  build-changing objections. It spot-checked the current direct-push guidance in
+  `openspec/config.yaml` and `skills/drivers/ticket/verbs/finalize.md`.

--- a/openspec/changes/273-reviewed-openspec-archives/.openspec.yaml
+++ b/openspec/changes/273-reviewed-openspec-archives/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+

--- a/openspec/changes/273-reviewed-openspec-archives/design.md
+++ b/openspec/changes/273-reviewed-openspec-archives/design.md
@@ -1,0 +1,19 @@
+# Design
+
+## ADR 273 — Review post-merge archives
+
+After an ordinary ticket's implementation pull request is human-merged and green,
+finalization creates the OpenSpec archive on a dedicated archive branch in a
+sibling checkout. It validates the archive, creates a signed-off commit, opens a
+small follow-up pull request, posts an attributed `Archive PR: <url>` comment, and
+stops.
+
+A later finalization reads that locator. An open archive pull request remains
+pending. A closed-unmerged pull request stops for operator direction. A
+human-merged pull request with a green workflow allows completion, actuals, and
+cleanup.
+
+The archive checkout is the sole narrow exception to the ticket's normal
+one-branch, one-worktree rule. Failures stop visibly and leave recoverable Git
+state for the operator. There is no automatic missing-locator recovery, parser,
+new state module, API integration, or merge automation.

--- a/openspec/changes/273-reviewed-openspec-archives/proposal.md
+++ b/openspec/changes/273-reviewed-openspec-archives/proposal.md
@@ -1,0 +1,21 @@
+# Proposal
+
+## Why
+
+This repository currently tells ticket finalization to push a post-merge OpenSpec
+archive directly to `main`. OpenSpec recommends the post-merge timing, but does not
+require bypassing normal review.
+
+## What changes
+
+- Keep post-merge archiving for ordinary OpenSpec tickets.
+- Land the archive through a small reviewed follow-up pull request.
+- Record that pull request on the ticket and finish only after a human merges it
+  and its workflow succeeds.
+- Keep strict validation, signed-off commits, and the rule that agents never merge.
+
+## Impact
+
+Repository archive guidance, ticket finalization prose, the ticket-workflow delta,
+documentation, and their contract tests change together. No runtime module,
+parser, external service, or merge automation is added.

--- a/openspec/changes/273-reviewed-openspec-archives/proposal.md
+++ b/openspec/changes/273-reviewed-openspec-archives/proposal.md
@@ -16,6 +16,7 @@ require bypassing normal review.
 
 ## Impact
 
-Repository archive guidance, ticket finalization prose, the ticket-workflow delta,
-documentation, and their contract tests change together. No runtime module,
+Repository archive guidance (`openspec/config.yaml`), the `skills/drivers/ticket/`
+source skill's `SKILL.md` and `verbs/finalize.md`, the ticket-workflow delta,
+`docs/epic-flow.md`, and their contract tests change together. No runtime module,
 parser, external service, or merge automation is added.

--- a/openspec/changes/273-reviewed-openspec-archives/specs/ticket-workflow/spec.md
+++ b/openspec/changes/273-reviewed-openspec-archives/specs/ticket-workflow/spec.md
@@ -1,0 +1,52 @@
+# ticket-workflow Delta
+
+## MODIFIED Requirements
+
+### Requirement: Finalization and abandonment
+
+Merged finalization MUST verify the implementation pull-request merge and
+successful post-merge workflow. For an ordinary OpenSpec-backed ticket, it MUST
+archive and strictly validate the change on a dedicated branch, create a signed-off
+commit, and open a reviewed follow-up pull request instead of pushing the archive
+commit directly to the default branch. An agent MUST NOT merge either pull request.
+
+Finalization MUST post an attributed `Archive PR: <url>` ticket comment and stop.
+A later finalization MUST read that locator. An open archive pull request MUST
+remain pending. A closed-unmerged archive pull request MUST stop for operator
+direction. Only a human-merged archive pull request with a successful post-merge
+workflow permits completion, actuals recording, and cleanup.
+
+The archive branch and checkout MAY be a narrow post-merge exception to the normal
+one-branch, one-worktree ticket lifecycle. A failure MUST stop visibly and preserve
+recoverable Git state. An epic child MUST leave archive ownership with its parent.
+
+#### Scenario: An ordinary OpenSpec ticket is finalized after merge
+
+- **WHEN** the implementation pull request is human-merged and green
+- **THEN** finalization archives and validates the change, creates a signed-off
+  commit, opens but does not merge a follow-up pull request, posts its attributed
+  URL on the ticket, and stops
+
+#### Scenario: The archive pull request is still open
+
+- **WHEN** a later finalization reads an archive pull request that remains open
+- **THEN** it reports pending human review and does not complete the ticket
+
+#### Scenario: A human merges the archive pull request
+
+- **WHEN** a later finalization verifies that the archive pull request was
+  human-merged and its post-merge workflow succeeded
+- **THEN** it posts completion, records actuals, cleans up, and moves the ticket to
+  done
+
+#### Scenario: The archive pull request closes without merge
+
+- **WHEN** finalization finds the archive pull request closed without merge
+- **THEN** it stops for operator direction without completing the ticket
+
+#### Scenario: A pull request was abandoned
+
+- **WHEN** the implementation pull request closes without merge or the work is
+  cancelled
+- **THEN** finalization comments the reason and waits for explicit user confirmation
+  before teardown or any user-selected terminal transition

--- a/openspec/changes/273-reviewed-openspec-archives/specs/ticket-workflow/spec.md
+++ b/openspec/changes/273-reviewed-openspec-archives/specs/ticket-workflow/spec.md
@@ -18,7 +18,10 @@ workflow permits completion, actuals recording, and cleanup.
 
 The archive branch and checkout MAY be a narrow post-merge exception to the normal
 one-branch, one-worktree ticket lifecycle. A failure MUST stop visibly and preserve
-recoverable Git state. An epic child MUST leave archive ownership with its parent.
+recoverable Git state. Actuals MUST be recorded before the ticket worktree is torn
+down. An epic child MUST leave archive ownership with its parent. A closed-unmerged
+or cancelled ticket MUST NOT be torn down or assigned a terminal state until the user
+explicitly confirms the abandoned path and chooses the ticket state.
 
 #### Scenario: An ordinary OpenSpec ticket is finalized after merge
 

--- a/openspec/changes/273-reviewed-openspec-archives/tasks.md
+++ b/openspec/changes/273-reviewed-openspec-archives/tasks.md
@@ -6,4 +6,6 @@
       after human merge.
 - [x] Document the narrow archive checkout exception and ordinary failure stops.
 - [x] Align the OpenSpec delta and contract tests.
-- [x] Run strict OpenSpec validation and the repository test command.
+- [x] Run `openspec validate --all --strict`, then `python3 scripts/validate.py`
+      and `python3 -m unittest tests.test_behavior tests.test_ticket` with the
+      rest of the repository test command.

--- a/openspec/changes/273-reviewed-openspec-archives/tasks.md
+++ b/openspec/changes/273-reviewed-openspec-archives/tasks.md
@@ -1,9 +1,9 @@
 # Tasks
 
-- [ ] Replace direct-to-`main` archive guidance with a reviewed follow-up pull
+- [x] Replace direct-to-`main` archive guidance with a reviewed follow-up pull
       request.
-- [ ] Make finalization stop after posting the archive pull-request URL and resume
+- [x] Make finalization stop after posting the archive pull-request URL and resume
       after human merge.
-- [ ] Document the narrow archive checkout exception and ordinary failure stops.
-- [ ] Align the OpenSpec delta and contract tests.
-- [ ] Run strict OpenSpec validation and the repository test command.
+- [x] Document the narrow archive checkout exception and ordinary failure stops.
+- [x] Align the OpenSpec delta and contract tests.
+- [x] Run strict OpenSpec validation and the repository test command.

--- a/openspec/changes/273-reviewed-openspec-archives/tasks.md
+++ b/openspec/changes/273-reviewed-openspec-archives/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [ ] Replace direct-to-`main` archive guidance with a reviewed follow-up pull
+      request.
+- [ ] Make finalization stop after posting the archive pull-request URL and resume
+      after human merge.
+- [ ] Document the narrow archive checkout exception and ordinary failure stops.
+- [ ] Align the OpenSpec delta and contract tests.
+- [ ] Run strict OpenSpec validation and the repository test command.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -16,8 +16,10 @@ rules:
 operations:
   archive:
     guidance:
-      - After a verified merge, update a clean main checkout to origin/main.
+      - After a verified merge, update a clean main checkout to origin/main in a sibling archive checkout.
+      - Cut a dedicated archive branch there.
       - Run openspec archive <change-name> --json --yes.
       - Run openspec validate --all --strict.
       - Create a Signed-off-by archive commit for the resulting baseline merge and archived change.
-      - Push main directly; do not archive in the finishing pull request or push archive work to an approved pull request.
+      - Open that archive branch as a reviewed follow-up pull request to main and let a human merge it.
+      - Never push an archive commit directly or forcibly to main, and do not archive in the finishing pull request.

--- a/skills/drivers/ticket/SKILL.md
+++ b/skills/drivers/ticket/SKILL.md
@@ -54,7 +54,9 @@ model dispatch.
   and the order, fix, re-verify, push.
 * `finalize` runs after a human merged: verify the merge and post-merge workflow,
   complete the repository's post-merge archive guidance for an ordinary OpenSpec
-  change, then close the ticket with a comment linking the pull request, record
+  change, which opens a reviewed archive pull request and posts its `Archive PR:`
+  locator before stopping, then on a later finalization, once a human merged that
+  pull request, close the ticket with a comment linking the pull request, record
   what the ticket actually cost in context, and tear the worktree down, so the
   slicing rubric is tuned against measured numbers rather than intuition.
 
@@ -172,7 +174,9 @@ branch. Broad read-only grounding never authorizes it.
    triage: it fetches and verifies the issue body's pinned remote parent-plan base,
    then passes that branch to the helper. Outside an epic child, grounding, scope ledgers, and
    the active change record are written and committed there; post-merge archiving
-   follows `operations.archive.guidance` on `main`. An epic child keeps its
+   follows `operations.archive.guidance` in a sibling archive checkout, which is the
+   one narrow post-merge exception to this rule and lands through its own reviewed
+   pull request rather than a push to `main`. An epic child keeps its
    instrumentation in session scratch and relies on its parent record. The control checkout may be dirty, stale, or
    on another branch: its working tree is never read or written, and it never
    switches branches. Never commit, stash, move, or clean its files, and never
@@ -302,7 +306,9 @@ Outside an epic, follow this per-ticket rule:
    embodies a real decision). Start and revise keep the active change and its
    deltas reviewable in the ticket pull request; they do not fold or archive it
    before merge. The repository's `operations.archive.guidance` determines when
-   finalization archives a verified merge. `/openspec-adopt`, when it is installed,
+   finalization archives a verified merge, and the archive itself lands through a
+   reviewed follow-up pull request that a human merges, never a direct push to the
+   default branch. `/openspec-adopt`, when it is installed,
    is what adopts OpenSpec in a repo that lacks it. OpenSpec is the worked example,
    never a requirement.
 2. The repo has a different convention (a changelog, a decision-record tree, a

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -17,27 +17,50 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    b. Confirm the post-merge workflow succeeded (`gh run list` on the repo). If it
    failed, stop and report; the ticket is not done while the post-merge run is red.
 
-   c. **Archive an ordinary OpenSpec change after the verified merge.** Follow
-   `operations.archive.guidance` exactly. In this repository, start from a clean
-   `main` checkout updated to `origin/main`, run
-   `openspec archive <change-name> --json --yes`, verify its archive JSON, run
-   `openspec validate --all --strict`, create a Signed-off-by archive commit, push
-   `main` directly, and verify the post-push workflow succeeded. OpenSpec is
-   Git-unaware: this verb trusts the verified GitHub merge state and adds no
-   enforcement layer. An archive, validation, commit, push, or post-push workflow
-   failure stops finalization before the completion comment and done transition.
-   An epic child creates no child change record, skips this ordinary-change archive
-   procedure, and leaves the parent active and unarchived for the parent epic's
-   archive guidance.
+   c. **Read the archive locator.** An ordinary OpenSpec change is archived across
+   two attended finalizations, because the archive lands through an ordinary
+   reviewed pull request that a human merges. Scan the ticket's comments
+   newest-first for a line reading `Archive PR: <url>`; the newest one wins. None
+   found: this is the first stage, so run step 2d and stop there. Found: this is the
+   second stage, so skip to step 2e. An epic child creates no child change record,
+   has no archive locator, skips steps 2d and 2e, and leaves the parent active and
+   unarchived for the parent epic's archive guidance.
 
-   d. Comment on the ticket (attribution first): the merged pull request link, a
+   d. **First stage: open the archive pull request, then stop.** Follow
+   `operations.archive.guidance` exactly. In this repository, work in a sibling
+   archive checkout whose `main` is updated to `origin/main`, cut a dedicated
+   archive branch there, run `openspec archive <change-name> --json --yes`, verify
+   its archive JSON, run `openspec validate --all --strict`, create a Signed-off-by
+   archive commit, push that branch, and open a follow-up pull request against
+   `main`, scoring the body with `/pr-body` when it is installed. Never push an
+   archive commit directly or forcibly to `main`, and never merge the archive pull
+   request. Then comment on the ticket (attribution first) with the merged
+   implementation pull request link, the post-merge evidence, and a line reading
+   `Archive PR: <url>`, and stop: the ticket is not done, and steps 3 and 4 wait for
+   the later finalization. OpenSpec is Git-unaware: this verb trusts the verified
+   GitHub merge state and adds no enforcement layer. An archive, validation, commit,
+   push, pull-request creation, or comment failure stops finalization here and
+   leaves the archive branch and its checkout in place for the operator to recover
+   by hand; this verb adds no automatic recovery, and a pull request opened without
+   its locator comment is recovered by the operator, not by a later run.
+
+   e. **Second stage: finish only after a human merged the archive pull request.**
+   Run `gh pr view <archive-pr> --json state,mergedAt` on the locator's pull
+   request. Still open: report it pending human review and stop without completing
+   the ticket. Closed without merge: stop for operator direction, and never open a
+   replacement archive pull request automatically. Merged: confirm its post-merge
+   workflow succeeded (`gh run list`) and continue; a red run stops finalization
+   before the completion comment and done transition.
+
+   f. Comment on the ticket (attribution first): the merged pull request link, a
    one-line outcome, the post-merge evidence, and, for an ordinary change, the
-   completed archive evidence.
+   merged archive pull request as the completed archive evidence.
 
-   e. Move the ticket to done. Report a failed move; do not retry.
+   g. Move the ticket to done. Report a failed move; do not retry.
 
-3. **Record the actuals.** On the merged path only. When record needs a target
-   worktree, do this before cleanup; otherwise it may follow cleanup. Read the
+3. **Record the actuals.** On the merged path only, and for an ordinary OpenSpec
+   change only after step 2e's human-merged archive pull request. When record needs
+   a target worktree, do this before cleanup; otherwise it may follow cleanup. Read the
    order's shape off the ticket comment (flat or chunked, chunk count, which rubric
    traits triage said fired, the stamped depths), then:
 
@@ -150,7 +173,8 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    context or a handoff between chunks, never more chunks.
 
 4. **Tear the worktree and branch down.** On the merged path only, after recording
-   actuals:
+   actuals. Remove the sibling archive checkout and its archive branch the same way,
+   once the archive pull request is merged:
 
    ```sh
    <cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <worktree path>
@@ -172,5 +196,6 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    says, and never pick the terminal state yourself.
 
 6. **Report.** The ticket's state, the comment link, the recorded verdict, and
-   anything left open (a red post-merge or post-push run, a failed archive, a
-   surviving branch or worktree).
+   anything left open (a red post-merge run, a failed archive, an archive pull
+   request still awaiting human review or closed unmerged, a surviving branch or
+   worktree).

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -197,8 +197,10 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    locally and on the remote.
 
 5. **Abandoned path** (pull request closed unmerged, or the work cancelled): comment
-   why, then on explicit user confirmation run the same teardown as step 4. Never
-   pick this path without the user confirming. Move the ticket wherever the user
+   why, then on explicit user confirmation run the same teardown as step 4, without
+   its archive-checkout paragraph: this path never reached step 2d, so no archive
+   branch or checkout exists to retire. Never pick this path without the user
+   confirming. Move the ticket wherever the user
    says, and never pick the terminal state yourself.
 
 6. **Report.** The ticket's state, the comment link, the recorded verdict, and

--- a/skills/drivers/ticket/verbs/finalize.md
+++ b/skills/drivers/ticket/verbs/finalize.md
@@ -173,8 +173,7 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    context or a handoff between chunks, never more chunks.
 
 4. **Tear the worktree and branch down.** On the merged path only, after recording
-   actuals. Remove the sibling archive checkout and its archive branch the same way,
-   once the archive pull request is merged:
+   actuals:
 
    ```sh
    <cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <worktree path>
@@ -189,6 +188,13 @@ the code host back to the tracker; this verb is that sync. Its fresh session cla
    `git ls-remote --heads origin <ticket branch>` and delete it with
    `git push origin --delete <ticket branch>` only if it is still there, since the
    code host usually deletes it on merge.
+
+   Then retire the sibling archive checkout the same way, because it is a checkout
+   this skill authored and carries its own graph identity: run
+   `<cbm-onboard-skill-directory>/scripts/cbm-teardown.sh <archive checkout>` first,
+   then `git -C <control checkout> worktree remove <archive checkout>` when it was cut
+   as a worktree and delete the directory otherwise, and delete its archive branch
+   locally and on the remote.
 
 5. **Abandoned path** (pull request closed unmerged, or the work cancelled): comment
    why, then on explicit user confirmation run the same teardown as step 4. Never

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -4426,7 +4426,15 @@ class OpenSpecAdoptionContractTests(unittest.TestCase):
         self.assertIn("openspec archive <change-name> --json --yes", config)
         self.assertIn("openspec validate --all --strict", config)
         self.assertIn("Signed-off-by archive commit", config)
-        self.assertIn("Push main directly", config)
+        self.assertIn("Cut a dedicated archive branch there", config)
+        self.assertIn(
+            "Open that archive branch as a reviewed follow-up pull request to main",
+            config,
+        )
+        self.assertIn(
+            "Never push an archive commit directly or forcibly to main", config
+        )
+        self.assertNotIn("Push main directly", config)
 
     def test_readme_and_site_require_the_global_pinned_cli(self):
         readme = README.read_text(encoding="utf-8")

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -635,14 +635,12 @@ class TicketSkillContractTests(unittest.TestCase):
         self.assertIn("active change and its deltas remain reviewable", start_contract)
         self.assertIn("its active change and deltas remain reviewable", revise_contract)
         self.assertIn("operations.archive.guidance", finalize_contract)
-        self.assertIn("clean `main` checkout updated to `origin/main`", finalize_contract)
+        self.assertIn("sibling archive checkout whose `main` is updated to `origin/main`", finalize_contract)
         self.assertIn("openspec archive <change-name> --json --yes", finalize_contract)
         self.assertIn("openspec validate --all --strict", finalize_contract)
         self.assertIn("Signed-off-by archive commit", finalize_contract)
-        self.assertIn("push `main` directly", finalize_contract)
-        self.assertIn("post-push workflow", finalize_contract)
         self.assertLess(finalize_contract.index("openspec archive"), finalize_contract.index("Comment on the ticket"))
-        self.assertLess(finalize_contract.index("post-push workflow"), finalize_contract.index("Move the ticket to done"))
+        self.assertLess(finalize_contract.index("Archive PR: <url>"), finalize_contract.index("Comment on the ticket"))
         self.assertLess(finalize_contract.index("Move the ticket to done"), finalize_contract.index("**Record the actuals.**"))
         self.assertLess(finalize_contract.index("**Record the actuals.**"), finalize_contract.index("**Tear the worktree and branch down.**"))
         self.assertIn("leaves the parent active and unarchived", finalize_contract)
@@ -653,6 +651,56 @@ class TicketSkillContractTests(unittest.TestCase):
         live = "\n".join((shared, start, revise, finalize, coordinator)).lower()
         self.assertNotRegex(live, r"fold.{0,100}(?:last|finishing).{0,100}pull request")
         self.assertNotRegex(live, r"archive.{0,100}(?:last|finishing).{0,100}pull request")
+
+    def test_ordinary_archives_land_through_a_reviewed_pull_request_in_two_stages(self):
+        finalize = (TICKET_DIRECTORY / "verbs" / "finalize.md").read_text(encoding="utf-8")
+        shared = (TICKET_DIRECTORY / "SKILL.md").read_text(encoding="utf-8")
+        guide = (ROOT / "docs" / "epic-flow.md").read_text(encoding="utf-8")
+        finalize_contract = " ".join(finalize.split())
+        shared_contract = " ".join(shared.split())
+        guide_contract = " ".join(guide.split())
+
+        # Stage one opens the archive pull request and stops on its locator.
+        self.assertIn("Read the archive locator", finalize_contract)
+        self.assertIn("`Archive PR: <url>`", finalize_contract)
+        self.assertIn("open a follow-up pull request against `main`", finalize_contract)
+        self.assertLess(
+            finalize_contract.index("First stage"),
+            finalize_contract.index("Second stage"),
+        )
+
+        # Stage two is gated on a human merge, and neither stage merges anything.
+        self.assertIn("never merge the archive pull request", finalize_contract)
+        self.assertIn("pending human review and stop", finalize_contract)
+        self.assertIn("Closed without merge: stop for operator direction", finalize_contract)
+        self.assertIn(
+            "never open a replacement archive pull request automatically",
+            finalize_contract,
+        )
+        self.assertLess(
+            finalize_contract.index("Second stage"),
+            finalize_contract.index("Move the ticket to done"),
+        )
+
+        # No surface still tells finalization to push the archive to the default branch.
+        for surface, text in (
+            ("finalize", finalize_contract),
+            ("shared", shared_contract),
+            ("guide", guide_contract),
+        ):
+            with self.subTest(surface=surface):
+                self.assertNotRegex(
+                    text.lower(), r"push(?:es|ing)? (?:the )?(?:archive )?(?:commit )?(?:on |to )?`?main`? directly"
+                )
+                self.assertNotRegex(
+                    text.lower(), r"pushes the archive on `?main`?"
+                )
+        self.assertIn(
+            "Never push an archive commit directly or forcibly to `main`",
+            finalize_contract,
+        )
+        self.assertIn("reviewed follow-up pull request", guide_contract)
+        self.assertIn("No archive commit is pushed directly to `main`", guide_contract)
 
     def test_status_binding_orders_code_prerequisites_before_triaged_and_excludes_them_otherwise(self):
         binding = " ".join(

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -683,6 +683,8 @@ class TicketSkillContractTests(unittest.TestCase):
         )
 
         # No surface still tells finalization to push the archive to the default branch.
+        # These two patterns matched the pre-change `finalize.md` and `docs/epic-flow.md`
+        # respectively, so they are the ones that would regress.
         for surface, text in (
             ("finalize", finalize_contract),
             ("shared", shared_contract),
@@ -699,6 +701,29 @@ class TicketSkillContractTests(unittest.TestCase):
             "Never push an archive commit directly or forcibly to `main`",
             finalize_contract,
         )
+
+        # The shared page carries the routing itself, not merely the absence of a push.
+        self.assertIn(
+            "follows `operations.archive.guidance` in a sibling archive checkout",
+            shared_contract,
+        )
+        self.assertIn("one narrow post-merge exception", shared_contract)
+        self.assertIn(
+            "lands through its own reviewed pull request rather than a push to `main`",
+            shared_contract,
+        )
+        self.assertIn(
+            "opens a reviewed archive pull request and posts its `Archive PR:` locator",
+            shared_contract,
+        )
+        self.assertIn(
+            "reviewed follow-up pull request that a human merges, never a direct push",
+            shared_contract,
+        )
+        self.assertNotIn(
+            "follows `operations.archive.guidance` on `main`", shared_contract
+        )
+
         self.assertIn("reviewed follow-up pull request", guide_contract)
         self.assertIn("No archive commit is pushed directly to `main`", guide_contract)
 


### PR DESCRIPTION
## What this is

Archiving an OpenSpec change after a ticket merges now lands through an ordinary
reviewed pull request that a human merges. Previously this repository's archive
guidance told finalization to push the archive commit straight to `main`, routing
it around the review boundary every other change goes through.

## What changed

* Closing a ticket now takes two attended finalize runs. The first verifies the
  implementation merge and its green run, builds and strictly validates the archive
  on a dedicated branch in a sibling checkout, opens the archive pull request, posts
  its locator on the ticket, and stops with the ticket still open. A later run reads
  that locator and finishes only once a human merged that pull request with a green
  run.
* An archive pull request still open leaves the ticket pending, and one closed
  without a merge stops for the operator. Neither opens a replacement, and neither
  completes the ticket.
* Every failure along the way (the archive, its validation, the commit, the push,
  opening the pull request, the ticket comment) stops where it happened and leaves
  the branch and checkout for a person to pick up. No recovery machinery, no state
  module, and nothing that merges on an agent's behalf.
* The sibling archive checkout is now the one narrow post-merge exception to the
  rule that a ticket lives in one worktree on one branch, and it is retired through
  the same graph teardown as any checkout this skill authors.

Epic children are unchanged: no child change record, archiving still owned by the
parent. The decision and its risk contract stay with the active OpenSpec change.

Fixes #273

## Verification

* Strict OpenSpec validation: 5 passed, 0 failed.
* Structural validation: 28 skills and 436 files.
* Complete repository suite: 496 passed, 23 skipped.
* The six new assertions pinning the shared page's archive routing all fail against
  that page's pre-change bytes and pass at head.

Two full-depth review rounds, both axes. Round one raised five findings, round two
confirmed all five fixed and raised one more. All six are fixed in this branch.

The costliest was in the spec delta rather than the prose: restating the whole
`Finalization and abandonment` requirement quietly dropped two rules the baseline
carries, that actuals are recorded before a worktree is torn down and that an
abandoned ticket is not torn down without the user's say-so. Strict validation
passes either way, so archiving this change would have deleted both from the
baseline with nothing failing. A second finding was a test asserting the absence of
two phrasings that were never present, which pinned nothing.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
