### PR TITLE
Codex image-dispatch argv fix; triage stamps a Design record line

### DIFF
--- a/skills/drivers/orchestrate/scripts/codex-worker.py
+++ b/skills/drivers/orchestrate/scripts/codex-worker.py
@@ -123,7 +123,7 @@ def start(args: argparse.Namespace) -> int:
         return fail(error)
     assert state is not None
     effort = effort_of(state)
-    command = [args.codex, "exec", "-m", args.model, "-c", f"model_reasoning_effort={effort}", *network_arguments(state.get("network", False)), "--sandbox", args.sandbox, "--skip-git-repo-check", "-C", str(args.cwd), "--json", *image_arguments(getattr(args, "image", [])), args.prompt]
+    command = [args.codex, "exec", "-m", args.model, "-c", f"model_reasoning_effort={effort}", *network_arguments(state.get("network", False)), "--sandbox", args.sandbox, "--skip-git-repo-check", "-C", str(args.cwd), "--json", args.prompt, *image_arguments(getattr(args, "image", []))]
     return lifecycle.run_lifecycle(
         args, command, state, parse=parse, emit=emit, fail=fail,
         stdin_text=None, effort_levels=EFFORT_LEVELS,
@@ -138,7 +138,7 @@ def resume(args: argparse.Namespace) -> int:
         return fail(error)
     assert fresh is not None and expected is not None
     effort = effort_of(fresh)
-    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", *network_arguments(fresh.get("network", False)), "--skip-git-repo-check", "--json", *image_arguments(getattr(args, "image", [])), args.prompt]
+    command = [args.codex, "exec", "resume", fresh["session_id"], "-m", fresh["model"], "-c", f'sandbox_mode="{fresh["sandbox"]}"', "-c", f"model_reasoning_effort={effort}", *network_arguments(fresh.get("network", False)), "--skip-git-repo-check", "--json", args.prompt, *image_arguments(getattr(args, "image", []))]
     return lifecycle.run_lifecycle(
         args, command, fresh, expected=expected, parse=parse, emit=emit, fail=fail,
         stdin_text=None, effort_levels=EFFORT_LEVELS,

--- a/skills/drivers/ticket/verbs/triage.md
+++ b/skills/drivers/ticket/verbs/triage.md
@@ -184,6 +184,12 @@ disclosed target and exact mutation.
      frozen behavior ledger and replay that execution will use. Triage records the
      route but does not start the app or implement the revision.
 
+   Every non-`none` lifecycle also stamps one `Design record:` line naming the
+   design-doc and behavior-ledger updates the change carries, or the explicit
+   deferral it inherits (a parent-plan pointer, a ticket). An order that changes
+   a rendered surface with neither is incomplete: the update travels with the
+   implementation pull request, and a deferral is written down, never assumed.
+
    A UI Craft refusal or ambiguous route blocks the order. In a chunked order the
    header carries the one non-`none` lifecycle active across the whole diff and
    every sub-order carries its own; an affected sub-order must repeat the contract


### PR DESCRIPTION
The Codex worker adapter now emits the positional prompt before `--image` in the exec argv: the CLI's image flag swallowed the following argument as a second image path, so every image-carrying dispatch lost its prompt and codex fell back to an empty stdin read. Found and fixed live during harmonic #205's chart review; the review-routing contract's image dispatch works again.

Ticket triage's surface-lifecycle step now also stamps a `Design record:` line on every order that changes a rendered surface: the design-doc and behavior-ledger updates the change carries, or the explicit deferral it inherits. The update-or-deferral decision had been living in chat.

* The argv fix touches both `start` and `resume` command builders; no other adapter behavior changes.
* The triage line is additive to the existing `Surface lifecycle:` value; `none` orders are untouched.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.