### PR TITLE
Measure archived Codex rollouts in ticket telemetry

### DIFF
--- a/docs/scope/290-generated-facts.md
+++ b/docs/scope/290-generated-facts.md
@@ -1,0 +1,68 @@
+# Generated facts — ticket 290
+
+## A. Current Codex rollout root
+
+Command:
+
+```text
+rg -n "CODEX_SESSIONS_DIR|return sorted\(CODEX_SESSIONS_DIR" skills/drivers/ticket/scripts/ticket.py
+```
+
+Output:
+
+```text
+38:CODEX_SESSIONS_DIR = Path(
+244:        return sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
+```
+
+## B. Archived discovery and threshold behavior
+
+Command:
+
+```text
+/opt/homebrew/bin/python3.14 docs/scope/290-probes/reproduce.py
+```
+
+Output:
+
+```json
+{
+  "archived_only": {
+    "session_count": 0,
+    "unreadable": [
+      "codex-archived-290"
+    ]
+  },
+  "active_threshold": {
+    "peak_context": 228055,
+    "verdict": "under-sliced",
+    "reason": "flat order execution peaked at 228,055 tokens, past the 180,000 degradation band"
+  }
+}
+```
+
+## C. Host interpreter versions
+
+Command:
+
+```text
+python3 --version
+```
+
+Output:
+
+```text
+Python 3.9.6
+```
+
+Command:
+
+```text
+/opt/homebrew/bin/python3.14 --version
+```
+
+Output:
+
+```text
+Python 3.14.7
+```

--- a/docs/scope/290-generated-facts.md
+++ b/docs/scope/290-generated-facts.md
@@ -41,7 +41,25 @@ Output:
 }
 ```
 
-## C. Host interpreter versions
+## C. Redacted real archive inventory
+
+Command:
+
+```text
+/opt/homebrew/bin/python3.14 docs/scope/290-probes/inspect-real-archive.py
+```
+
+Output:
+
+```json
+{
+  "root": "archived_sessions",
+  "filename_shape": "rollout-<timestamp>-<session-id>.jsonl",
+  "matching_rollout_exists": true
+}
+```
+
+## D. Host interpreter versions
 
 Command:
 

--- a/docs/scope/290-generated-facts.md
+++ b/docs/scope/290-generated-facts.md
@@ -12,7 +12,8 @@ Output:
 
 ```text
 38:CODEX_SESSIONS_DIR = Path(
-244:        return sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
+41:CODEX_ARCHIVED_SESSIONS_DIR = CODEX_SESSIONS_DIR.parent / "archived_sessions"
+248:                *CODEX_SESSIONS_DIR.glob(pattern),
 ```
 
 ## B. Archived discovery and threshold behavior
@@ -28,10 +29,8 @@ Output:
 ```json
 {
   "archived_only": {
-    "session_count": 0,
-    "unreadable": [
-      "codex-archived-290"
-    ]
+    "session_count": 1,
+    "unreadable": []
   },
   "active_threshold": {
     "peak_context": 228055,

--- a/docs/scope/290-generated-facts.md
+++ b/docs/scope/290-generated-facts.md
@@ -54,8 +54,8 @@ Output:
 ```json
 {
   "root": "archived_sessions",
-  "filename_shape": "rollout-<timestamp>-<session-id>.jsonl",
-  "matching_rollout_exists": true
+  "checked_at_least_one_rollout": true,
+  "all_checked_filenames_end_with_metadata_id": true
 }
 ```
 

--- a/docs/scope/290-measure-archived-codex-rollouts.md
+++ b/docs/scope/290-measure-archived-codex-rollouts.md
@@ -49,3 +49,19 @@ Disposition: inline
 ## Spawned tasks
 
 - None.
+
+## Plan review
+
+- Round 1 blocker, `authoring`: the 228,055-token `under-sliced`
+  acceptance lacked a generated command-to-output derivation. Resolved with a
+  portable public-command probe and complete deterministic evidence.
+- Round 2 blocker, `authoring`: the real Codex archive premise was supported
+  only by a synthetic fixture. Resolved with a privacy-preserving live
+  inventory.
+- Round 2 blocker, `injected`: the first live-inventory correction printed a
+  hard-coded filename shape without verifying it. Resolved by checking real
+  archived filenames against their own session metadata while emitting only
+  booleans.
+- Round 3: no blocking objections; the fresh cold pass countersigned the plan.
+
+Injected blockers did not climb across rounds. All review findings are resolved.

--- a/docs/scope/290-measure-archived-codex-rollouts.md
+++ b/docs/scope/290-measure-archived-codex-rollouts.md
@@ -1,0 +1,51 @@
+# Scope ledger — ticket 290: measure archived Codex rollouts
+
+## Decisions
+
+- Codex transcript discovery treats active and archived rollout roots as one
+  exact-session-id source, while preserving distinct resumed rollouts and the
+  maximum context peak across them.
+  Why: the public-command reproduction proves archived top-level sessions are
+  currently misclassified as unreadable, while ADR 70 requires exact-id
+  attribution rather than content inference.
+  Disposition: inline
+
+- The shipping change is a flat, non-UI code order through the existing ticket
+  command interface; it adds no new module or external dependency.
+  Why: `transcripts_for()` is already the single transcript-discovery interface
+  used by both `scan` and `record`, and the repository is standard-library only.
+  Disposition: inline
+
+- Do not reconstruct or append a corrective slicing record for
+  `harmonichq/harmonic#194`; issue 290 fixes future measurement only.
+  Why: the operator explicitly does not value recovering the lost historical
+  calibration, and cross-repository history is unrelated to correcting rollout
+  discovery.
+  Disposition: inline
+
+### Risk contract
+
+- **Must prevent:** secret exposure, irreversible loss of authoritative data,
+  and silent incorrect success; specifically, a claimed Codex session must not
+  be reported unreadable when an exact matching rollout exists in either
+  supported root.
+- **Must recover:** none; transcript discovery is read-only.
+- **Accepted failure:** when no exact matching rollout exists in either root,
+  preserve the visible `unmeasurable` result and manual inspection path.
+- **Unsupported:** reconstructing historical slicing records, changing rollout
+  parsing, or inferring session identity from transcript contents.
+- **Evidence owed:** public `scan` and `record` behavior for active-only,
+  archived-only, active-plus-archived, and missing-rollout sessions; the mixed
+  case must use every distinct rollout and report the maximum peak.
+
+Why: the command reads local telemetry and its harmful failure mode is a silent
+false measurement, not loss of source data.
+Disposition: inline
+
+## Open questions
+
+- None.
+
+## Spawned tasks
+
+- None.

--- a/docs/scope/290-probes/inspect-real-archive.py
+++ b/docs/scope/290-probes/inspect-real-archive.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Confirm Codex's real archive root and filename shape without exposing metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser()
+archive = codex_home / "archived_sessions"
+has_rollout = next(archive.rglob("rollout-*.jsonl"), None) is not None
+print(
+    json.dumps(
+        {
+            "root": "archived_sessions",
+            "filename_shape": "rollout-<timestamp>-<session-id>.jsonl",
+            "matching_rollout_exists": has_rollout,
+        },
+        indent=2,
+    )
+)

--- a/docs/scope/290-probes/inspect-real-archive.py
+++ b/docs/scope/290-probes/inspect-real-archive.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Confirm Codex's real archive root and filename shape without exposing metadata."""
+"""Confirm Codex's archive naming contract without exposing session metadata."""
 
 from __future__ import annotations
 
@@ -10,13 +10,30 @@ from pathlib import Path
 
 codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser()
 archive = codex_home / "archived_sessions"
-has_rollout = next(archive.rglob("rollout-*.jsonl"), None) is not None
+rollouts = list(archive.rglob("rollout-*.jsonl"))
+
+
+def filename_ends_with_metadata_id(path: Path) -> bool:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("type") != "session_meta":
+                continue
+            session_id = entry.get("payload", {}).get("id")
+            return bool(session_id) and path.name.endswith(f"-{session_id}.jsonl")
+    return False
+
+
 print(
     json.dumps(
         {
             "root": "archived_sessions",
-            "filename_shape": "rollout-<timestamp>-<session-id>.jsonl",
-            "matching_rollout_exists": has_rollout,
+            "checked_at_least_one_rollout": bool(rollouts),
+            "all_checked_filenames_end_with_metadata_id": bool(rollouts)
+            and all(filename_ends_with_metadata_id(path) for path in rollouts),
         },
         indent=2,
     )

--- a/docs/scope/290-probes/reproduce.py
+++ b/docs/scope/290-probes/reproduce.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Reproduce ticket 290 with public ticket commands and isolated local data."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+TICKET = ROOT / "skills" / "drivers" / "ticket" / "scripts" / "ticket.py"
+
+
+def run(environment: dict[str, str], *arguments: str) -> dict:
+    result = subprocess.run(
+        ["python3", str(TICKET), *arguments],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def rollout(path: Path, session_id: str, peak: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entries = [
+        {
+            "timestamp": "2026-08-30T00:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": session_id},
+        },
+        {
+            "timestamp": "2026-08-30T00:00:01Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {"last_token_usage": {"input_tokens": peak}},
+            },
+        },
+    ]
+    path.write_text("\n".join(json.dumps(entry) for entry in entries) + "\n")
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    scratch = Path(temporary)
+    codex_home = scratch / "codex-home"
+    environment = os.environ.copy()
+    environment.pop("CLAUDE_CODE_SESSION_ID", None)
+    environment.pop("CODEX_SESSION_ID", None)
+    environment["CODEX_HOME"] = str(codex_home)
+    environment["TICKET_CLAIMS"] = str(scratch / "claims.jsonl")
+    environment["CLAUDE_PROJECTS_DIR"] = str(scratch / "projects")
+
+    archived_id = "codex-archived-290"
+    rollout(
+        codex_home / "archived_sessions" / f"rollout-2026-08-30-{archived_id}.jsonl",
+        archived_id,
+        228_055,
+    )
+    run(
+        environment,
+        "claim",
+        "REPRO-290-ARCHIVED",
+        "--session",
+        archived_id,
+        "--agent",
+        "codex",
+        "--verb",
+        "start",
+        "--role",
+        "coordinator",
+    )
+    archived = run(environment, "scan", "REPRO-290-ARCHIVED")
+
+    active_id = "codex-active-290"
+    rollout(
+        codex_home
+        / "sessions"
+        / "2026"
+        / "08"
+        / "30"
+        / f"rollout-2026-08-30-{active_id}.jsonl",
+        active_id,
+        228_055,
+    )
+    run(
+        environment,
+        "claim",
+        "REPRO-290-ACTIVE",
+        "--session",
+        active_id,
+        "--agent",
+        "codex",
+        "--verb",
+        "start",
+        "--role",
+        "coordinator",
+    )
+    active = run(
+        environment,
+        "record",
+        "REPRO-290-ACTIVE",
+        "--verb",
+        "start",
+        "--trait",
+        "narrow-scope",
+        "--depth",
+        "full",
+    )
+
+    print(
+        json.dumps(
+            {
+                "archived_only": {
+                    "session_count": archived["session_count"],
+                    "unreadable": archived["unreadable"],
+                },
+                "active_threshold": {
+                    "peak_context": active["peak_context"],
+                    "verdict": active["verdict"],
+                    "reason": active["reason"],
+                },
+            },
+            indent=2,
+        )
+    )

--- a/openspec/changes/290-measure-archived-codex-rollouts/proposal.md
+++ b/openspec/changes/290-measure-archived-codex-rollouts/proposal.md
@@ -6,8 +6,10 @@ Ticket telemetry resolves a claimed Codex session only under the active
 `sessions` root. Codex can move completed top-level rollouts to
 `archived_sessions` before a later finalization measures them, so an exact valid
 claim is reported unreadable and a measurable flat order becomes
-`unmeasurable`. The archived-only public-command reproduction is recorded in
-`docs/scope/290-generated-facts.md`.
+`unmeasurable`. The redacted real-archive inventory and archived-only
+public-command reproduction are recorded in
+`docs/scope/290-generated-facts.md`; they expose no transcript content or session
+identifier.
 
 ## What changes
 

--- a/openspec/changes/290-measure-archived-codex-rollouts/proposal.md
+++ b/openspec/changes/290-measure-archived-codex-rollouts/proposal.md
@@ -1,0 +1,44 @@
+# Measure archived Codex rollouts
+
+## Why
+
+Ticket telemetry resolves a claimed Codex session only under the active
+`sessions` root. Codex can move completed top-level rollouts to
+`archived_sessions` before a later finalization measures them, so an exact valid
+claim is reported unreadable and a measurable flat order becomes
+`unmeasurable`. The archived-only public-command reproduction is recorded in
+`docs/scope/290-generated-facts.md`.
+
+## What changes
+
+- Treat active and archived Codex rollout directories as one discovery source
+  for an exact claimed session id.
+- Preserve every distinct matching rollout across both roots so resumed sessions
+  still report the maximum context peak.
+- Cover active-only, archived-only, mixed-root, and genuinely missing rollouts
+  through the public `scan` and `record` commands.
+- Leave claim attribution, rollout parsing, verdict thresholds, Claude
+  transcript discovery, and historical slicing records unchanged.
+
+## Risk contract
+
+- **Must prevent:** secret exposure, irreversible loss of authoritative data,
+  and silent incorrect success; specifically, a claimed Codex session must not
+  be reported unreadable when an exact matching rollout exists in either
+  supported root.
+- **Must recover:** none; transcript discovery is read-only.
+- **Accepted failure:** when no exact matching rollout exists in either root,
+  preserve the visible `unmeasurable` result and manual inspection path.
+- **Unsupported:** reconstructing historical slicing records, changing rollout
+  parsing, or inferring session identity from transcript contents.
+- **Evidence owed:** public `scan` and `record` behavior for active-only,
+  archived-only, active-plus-archived, and missing-rollout sessions; the mixed
+  case must use every distinct rollout and report the maximum peak.
+
+## Impact
+
+The existing ticket command interface and `transcripts_for()` seam remain in
+place. The implementation changes only Codex transcript discovery, its
+public-command regression tests, and this ticket-workflow specification delta.
+No rendered surface, new module, dependency, migration, or historical repair is
+included.

--- a/openspec/changes/290-measure-archived-codex-rollouts/proposal.md
+++ b/openspec/changes/290-measure-archived-codex-rollouts/proposal.md
@@ -8,8 +8,9 @@ Ticket telemetry resolves a claimed Codex session only under the active
 claim is reported unreadable and a measurable flat order becomes
 `unmeasurable`. The redacted real-archive inventory and archived-only
 public-command reproduction are recorded in
-`docs/scope/290-generated-facts.md`; they expose no transcript content or session
-identifier.
+`docs/scope/290-generated-facts.md`; the inventory verifies archived filenames
+against their own session metadata while exposing no filename, transcript
+content, or session identifier.
 
 ## What changes
 

--- a/openspec/changes/290-measure-archived-codex-rollouts/specs/ticket-workflow/spec.md
+++ b/openspec/changes/290-measure-archived-codex-rollouts/specs/ticket-workflow/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Codex rollout discovery includes active and archived sessions
+
+Ticket telemetry MUST resolve an exact claimed Codex session from every distinct
+matching rollout under both the active `sessions` root and the completed-task
+`archived_sessions` root. `scan` and `record` MUST use the maximum context peak
+across all of those matches. A claimed Codex session MUST be unreadable only when
+neither root contains an exact matching rollout. This discovery change MUST NOT
+alter Claude transcript discovery, session attribution, rollout parsing, or
+verdict thresholds.
+
+#### Scenario: A Codex rollout remains active
+
+- **WHEN** a claimed Codex session has an exact matching rollout only under the
+  active root
+- **THEN** `scan` and `record` measure that rollout as before
+
+#### Scenario: A Codex rollout was archived
+
+- **WHEN** a claimed Codex session has an exact matching rollout only under the
+  archived root
+- **THEN** `scan` and `record` measure the session instead of reporting it
+  unreadable
+
+#### Scenario: A resumed session spans both roots
+
+- **WHEN** distinct exact matching rollouts for one claimed Codex session exist
+  under the active and archived roots
+- **THEN** discovery returns every distinct rollout and `scan` and `record`
+  report the maximum context peak across them
+
+#### Scenario: No matching rollout exists
+
+- **WHEN** neither root contains an exact matching rollout for a claimed Codex
+  session
+- **THEN** the existing visible unreadable and `unmeasurable` behavior is
+  preserved

--- a/openspec/changes/290-measure-archived-codex-rollouts/tasks.md
+++ b/openspec/changes/290-measure-archived-codex-rollouts/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+- [ ] Expand exact-id Codex rollout discovery across the active and archived
+      roots without collapsing distinct resumed rollouts.
+- [ ] Add public-command tests for active-only, archived-only,
+      active-plus-archived, and genuinely missing rollout discovery through
+      `scan` and `record`, including the 228,055-token flat-order verdict
+      reproduced in `docs/scope/290-generated-facts.md`.
+- [ ] Preserve claim attribution, Claude discovery, rollout parsing, verdict
+      thresholds, and existing missing-rollout behavior.
+- [ ] Run `openspec validate 290-measure-archived-codex-rollouts --strict` and
+      the full repository verification command from `AGENTS.md`.

--- a/openspec/changes/290-measure-archived-codex-rollouts/tasks.md
+++ b/openspec/changes/290-measure-archived-codex-rollouts/tasks.md
@@ -1,12 +1,12 @@
 # Tasks
 
-- [ ] Expand exact-id Codex rollout discovery across the active and archived
+- [x] Expand exact-id Codex rollout discovery across the active and archived
       roots without collapsing distinct resumed rollouts.
-- [ ] Add public-command tests for active-only, archived-only,
+- [x] Add public-command tests for active-only, archived-only,
       active-plus-archived, and genuinely missing rollout discovery through
       `scan` and `record`, including the 228,055-token flat-order verdict
       reproduced in `docs/scope/290-generated-facts.md`.
-- [ ] Preserve claim attribution, Claude discovery, rollout parsing, verdict
+- [x] Preserve claim attribution, Claude discovery, rollout parsing, verdict
       thresholds, and existing missing-rollout behavior.
-- [ ] Run `openspec validate 290-measure-archived-codex-rollouts --strict` and
+- [x] Run `openspec validate 290-measure-archived-codex-rollouts --strict` and
       the full repository verification command from `AGENTS.md`.

--- a/skills/drivers/ticket/scripts/ticket.py
+++ b/skills/drivers/ticket/scripts/ticket.py
@@ -38,6 +38,7 @@ CLAIMS_PATH = Path(
 CODEX_SESSIONS_DIR = Path(
     os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
 ).expanduser() / "sessions"
+CODEX_ARCHIVED_SESSIONS_DIR = CODEX_SESSIONS_DIR.parent / "archived_sessions"
 
 # Which environment variable carries the running session id, per agent. A verb
 # that cannot read one passes --session instead.
@@ -241,7 +242,13 @@ def transcripts_for(claim: dict, projects_dir: Path) -> list[Path]:
     """
     session_id = claim["session_id"]
     if claim.get("agent") == "codex":
-        return sorted(CODEX_SESSIONS_DIR.glob(f"**/rollout-*-{session_id}.jsonl"))
+        pattern = f"**/rollout-*-{session_id}.jsonl"
+        return sorted(
+            {
+                *CODEX_SESSIONS_DIR.glob(pattern),
+                *CODEX_ARCHIVED_SESSIONS_DIR.glob(pattern),
+            }
+        )
     parent_sessions = projects_dir.glob(f"*/{session_id}.jsonl")
     native_workers = projects_dir.glob(f"*/*/subagents/agent-{session_id}.jsonl")
     return sorted([*parent_sessions, *native_workers])

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -999,8 +999,10 @@ class TicketTelemetryTests(unittest.TestCase):
         path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         return path
 
-    def write_codex_session(self, session_id: str, lines: list[str]) -> Path:
-        directory = self.codex_home / "sessions" / "2026" / "01" / "01"
+    def write_codex_session(
+        self, session_id: str, lines: list[str], root: str = "sessions"
+    ) -> Path:
+        directory = self.codex_home / root / "2026" / "01" / "01"
         directory.mkdir(parents=True, exist_ok=True)
         path = directory / f"rollout-2026-01-01T00-00-00-{session_id}.jsonl"
         path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -1278,6 +1280,61 @@ class TicketTelemetryTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(len(payload["sessions"][0]["transcripts"]), 2)
         self.assertEqual(payload["peak_context"], 200_000)
+
+    def test_archived_codex_rollout_is_measured_by_scan_and_record(self):
+        archived = self.write_codex_session(
+            "codex-archived", [codex_meta_line("codex-archived"), codex_token_line(228_055)],
+            root="archived_sessions",
+        )
+        self.claim("TICKET-290", "codex-archived", agent="codex")
+
+        scanned = self.ticket("scan", "TICKET-290")
+
+        self.assertEqual(scanned.returncode, 0, scanned.stderr)
+        scan_payload = json.loads(scanned.stdout)
+        self.assertEqual(scan_payload["session_count"], 1)
+        self.assertEqual(scan_payload["peak_context"], 228_055)
+        self.assertEqual(scan_payload["sessions"][0]["transcripts"], [str(archived)])
+
+        recorded = self.ticket(
+            "record", "TICKET-290", "--verb", "start", "--trait", "shared-contract",
+            "--depth", "full",
+        )
+
+        self.assertEqual(recorded.returncode, 0, recorded.stderr)
+        record_payload = json.loads(recorded.stdout)
+        self.assertEqual(record_payload["peak_context"], 228_055)
+        self.assertEqual(record_payload["verdict"], "under-sliced")
+
+    def test_codex_session_spanning_active_and_archived_roots_uses_every_rollout(self):
+        active = self.write_codex_session(
+            "codex-mixed", [codex_meta_line("codex-mixed"), codex_token_line(5_000)]
+        )
+        archived = self.write_codex_session(
+            "codex-mixed", [codex_meta_line("codex-mixed"), codex_token_line(228_055)],
+            root="archived_sessions",
+        )
+        self.claim("TICKET-290-MIXED", "codex-mixed", agent="codex")
+
+        scanned = self.ticket("scan", "TICKET-290-MIXED")
+
+        self.assertEqual(scanned.returncode, 0, scanned.stderr)
+        scan_payload = json.loads(scanned.stdout)
+        self.assertEqual(
+            scan_payload["sessions"][0]["transcripts"],
+            [str(path) for path in sorted((active, archived))],
+        )
+        self.assertEqual(scan_payload["peak_context"], 228_055)
+
+        recorded = self.ticket(
+            "record", "TICKET-290-MIXED", "--verb", "start",
+            "--trait", "shared-contract", "--depth", "full",
+        )
+
+        self.assertEqual(recorded.returncode, 0, recorded.stderr)
+        record_payload = json.loads(recorded.stdout)
+        self.assertEqual(record_payload["peak_context"], 228_055)
+        self.assertEqual(record_payload["verdict"], "under-sliced")
 
     def test_record_flat_order_above_degradation_band_is_under_sliced(self):
         self.worked("TICKET-7", "proj-a", "session-1", [assistant_line(200_000)])


### PR DESCRIPTION
## Motivation and Context

Ticket telemetry now measures claimed Codex sessions from both active and archived rollout locations. Previously a completed top-level session could move before finalization, so a real 228,055-token start peak appeared unmeasurable.

* Exact session-id discovery remains the sole attribution rule, and every distinct active or archived rollout feeds the existing maximum calculation.
* Active-only and genuinely missing sessions keep their existing behavior. Claude discovery, rollout parsing, claim attribution, and verdict thresholds are unchanged.
* The decisions, risk contract, and generated evidence remain in the active change under `openspec/changes/290-measure-archived-codex-rollouts/`.
* Historical slicing records are unchanged.

Fixes #290

## How Has This Been Tested?

```text
Fail-first archived-only case:
scan session_count expected 1, got 0

Fail-first mixed-root case:
transcript count expected 2, got 1

Final verification:
OpenSpec change is valid
validated 28 skills and 473 files
Ran 533 tests in 74.313s
OK (skipped=23)
py_compile exit 0

Full two-axis review:
Standards 16/16, 0 violated
Spec 11/11, all met
Converged in round 1
```

## Checklist before requesting a review

* [x] I have performed a self-review of my code.
* [ ] I have stepped through the README as though I was a new user to ensure clarity.
* [ ] I have added new or changed keys, tokens, other secrets to the DevOps 1Pass.
* [ ] I have labeled all "TO DO" items with associated Jira ticket number.
* [x] I have removed commented code from PRs to `main`.
* [x] I have followed conventional-commits standards when making this PR.

> Written by an AI agent operating for Connor Griffin. Verify before relying on it.
